### PR TITLE
Implement temporal separability metric and Optuna integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@
 
 Desenvolvido para facilitar a decisão de agrupamento de variáveis numéricas e categóricas.
 
+## Visão geral
+
+O NASABinning prioriza **estabilidade temporal** das taxas de evento. A biblioteca
+utiliza o `OptimalBinning` como base única para a geração dos cortes e o
+`Optuna` apenas para otimizar seus hiperparâmetros. O objetivo principal é
+encontrar binagens que mantenham curvas de `event rate` bem separadas e
+consistentes mês a mês. Métricas clássicas como IV e KS continuam sendo
+calculadas, porém com peso secundário na seleção final dos bins.
+O score utilizado na otimização segue a fórmula:
+
+```
+score = 0.7 * separabilidade + 0.2 * IV + 0.1 * KS
+```
+
 ## Principais recursos
 
 | Recurso | Descrição |
@@ -13,8 +27,8 @@ Desenvolvido para facilitar a decisão de agrupamento de variáveis numéricas e
 | **Binning supervisionado e não supervisionado** | Estratégias plug-and-play (Optimal Binning, quantílico, largura fixa, k-means). |
 | **Monotonicidade opcional** | Respeita tendências crescentes ou decrescentes para facilitar interpretação regulatória. |
 | **Diferença mínima de **event rate**** | Evita sobreposição de grupos ao unir automaticamente bins muito semelhantes. |
-| **Estabilidade temporal** | Calcula PSI, KS e desvio-padrão por safra; aplica penalizações ou mesclagens conforme limiares. |
-| **Otimização com Optuna (opcional)** | Busca corte ótimo maximizando IV e estabilidade, com múltiplas penalizações configuráveis. |
+| **Estabilidade temporal** | Calcula PSI, KS e o `temporal_separability_score` para priorizar curvas consistentes ao longo dos meses. |
+| **Otimização com Optuna (opcional)** | Explora hiperparâmetros do `OptimalBinning` visando maior separabilidade temporal; IV e KS servem como apoio na decisão. |
 | **Integração scikit-learn** | `NASABinner` implementa ``fit`/`transform``, permitindo uso em `Pipeline`. |
 | **Relatórios auditáveis** | Geração de tabelas e gráficos em `.xlsx`, `.json` e Matplotlib para `WoE`, event-rate e estabilidade. |
 

--- a/nasabinning/__init__.py
+++ b/nasabinning/__init__.py
@@ -1,6 +1,6 @@
 # Init file
 """
-NASABinning: Robust credit-risk binning with auditability and temporal stability.
+NASABinning: binning auditável com foco em estabilidade e separação temporal das curvas.
 
 A biblioteca expõe a classe principal `NASABinner`.
 """

--- a/nasabinning/binning_engine.py
+++ b/nasabinning/binning_engine.py
@@ -3,6 +3,7 @@
 binning_engine.py
 Orquestra a escolha de estratégia (supervised / unsupervised),
 aplica refinamentos e expõe interface scikit-learn-compatível.
+O foco está em manter a separação temporal das curvas de event rate.
 """
 from __future__ import annotations
 from typing import List, Optional, Dict
@@ -97,9 +98,11 @@ class NASABinner(BaseEstimator, TransformerMixin):
             self.best_params_ = {}
 
             for col in num_cols + cat_cols:
+                time_vals = X[time_col] if time_col else None
                 best, b_col = optimize_bins(
                     X[[col]], y,
                     time_col=time_col,
+                    time_values=time_vals,
                     n_trials=n_trials,
                     **base_kwargs
                 )

--- a/nasabinning/optuna_optimizer.py
+++ b/nasabinning/optuna_optimizer.py
@@ -4,17 +4,31 @@ Busca hiperparâmetros ótimos para NASABinner via Optuna.
 
 Função principal
 ----------------
-optimize_bins(X, y, time_col=None, n_trials=20, **base_kwargs)
+optimize_bins(
+    X, y, *, time_col=None, time_values=None, n_trials=20,
+    alpha=0.7, beta=0.2, gamma=0.1, **base_kwargs)
 → (best_params: dict, fitted_binner: NASABinner)
+
+O Optuna apenas ajusta os hiperparâmetros do OptimalBinning. O score retornado
+pelo ``_objective`` prioriza a separabilidade temporal das curvas por safra,
+utilizando IV e KS como métricas auxiliares.
 """
 from __future__ import annotations
 
-from typing import Any, Tuple
+from typing import Any, Tuple, Optional
 
 import optuna
 import pandas as pd
+import logging
 
 from .binning_engine import NASABinner
+from .temporal_stability import (
+    temporal_separability_score,
+    event_rate_by_time,
+    ks_over_time,
+)
+
+logger = logging.getLogger(__name__)
 
 
 # --------------------------------------------------------------------------- #
@@ -23,7 +37,11 @@ def _objective(
     X: pd.DataFrame,
     y: pd.Series,
     base_kwargs: dict[str, Any],
-    time_col: str | None,
+    time_col: Optional[str],
+    time_values: Optional[pd.Series],
+    alpha: float,
+    beta: float,
+    gamma: float,
 ) -> float:
     """Função objetivo usada pelo Optuna."""
     params = {
@@ -48,25 +66,51 @@ def _objective(
         strategy_kwargs=dict(min_bin_size=params["min_bin_size"]),
         use_optuna=False,  # evita recursão
     )
-    binner.fit(X, y, time_col=time_col)
+    df_fit = X.copy()
+    if time_col and time_values is not None:
+        df_fit[time_col] = time_values
 
-    # métrica composta que queremos MINIMIZAR
+    binner.fit(df_fit, y, time_col=time_col)
+
+    # métricas para avaliação
     iv = binner.iv_
-    psi = binner.bin_summary.attrs.get("psi_over_time", 0.0) or 0.0
     n_bins = len(binner.bin_summary)
 
-    if n_bins < 2:
-        # penalização forte / descarta trial
-        return 1e6
+    if time_col and time_values is not None:
+        bins = binner.transform(df_fit)[X.columns[0]]
+        df_tmp = pd.DataFrame({
+            'bin': bins,
+            'target': y,
+            'time': time_values,
+        })
+        sep = temporal_separability_score(
+            df_tmp, X.columns[0], 'bin', 'target', 'time'
+        )
+        tbl = (
+            df_tmp.groupby(['bin', 'time'])['target']
+            .agg(['sum','count']).reset_index()
+            .rename(columns={'sum':'event','count':'count'})
+        )
+        tbl['variable'] = X.columns[0]
+        pivot = event_rate_by_time(tbl, 'time')
+        ks = ks_over_time(pivot)
+    else:
+        sep = 0.0
+        ks = 0.0
 
-    cost = -(iv) + 0.5 * psi + 0.01 * n_bins
+    score = alpha * sep + beta * iv + gamma * ks
 
-    # salva valores para análise posterior
-    trial.set_user_attr("iv", iv)
-    trial.set_user_attr("psi", psi)
-    trial.set_user_attr("n_bins", n_bins)
+    trial.set_user_attr('separability', sep)
+    trial.set_user_attr('iv', iv)
+    trial.set_user_attr('ks', ks)
+    trial.set_user_attr('n_bins', n_bins)
+    trial.set_user_attr('score', score)
 
-    return cost
+    logger.info(
+        f"Trial {trial.number}: score={score:.4f}, sep={sep:.4f}, iv={iv:.4f}, ks={ks:.4f}"
+    )
+
+    return score
 
 
 # --------------------------------------------------------------------------- #
@@ -75,7 +119,11 @@ def optimize_bins(
     y: pd.Series,
     *,
     time_col: str | None = None,
+    time_values: Optional[pd.Series] = None,
     n_trials: int = 20,
+    alpha: float = 0.7,
+    beta: float = 0.2,
+    gamma: float = 0.1,
     **base_kwargs,
 ) -> Tuple[dict[str, Any], NASABinner]:
     """
@@ -88,13 +136,15 @@ def optimize_bins(
     fitted_binner : NASABinner
         Binner treinado com os melhores hiperparâmetros.
     """
-    study = optuna.create_study(direction="minimize")
+    study = optuna.create_study(direction="maximize")
 
     # ajustando verbose do optuna
     optuna.logging.set_verbosity(optuna.logging.WARNING)
 
     study.optimize(
-        lambda tr: _objective(tr, X, y, base_kwargs, time_col),
+        lambda tr: _objective(
+            tr, X, y, base_kwargs, time_col, time_values, alpha, beta, gamma
+        ),
         n_trials=n_trials,
         show_progress_bar=False,
     )
@@ -112,13 +162,17 @@ def optimize_bins(
     cfg.pop("min_event_rate_diff", None)
     cfg.pop("strategy_kwargs", None)
 
+    df_final = X.copy()
+    if time_col and time_values is not None:
+        df_final[time_col] = time_values
+
     final_binner = NASABinner(
         **cfg,
         max_bins=best_params["max_bins"],
         min_event_rate_diff=best_params["min_event_rate_diff"],
         strategy_kwargs=dict(min_bin_size=best_params["min_bin_size"]),
         use_optuna=False,
-    ).fit(X, y, time_col=time_col)
+    ).fit(df_final, y, time_col=time_col)
 
     # expõe best_params ao objeto para debug externo se desejado
     final_binner.best_params_ = best_params

--- a/nasabinning/temporal_stability.py
+++ b/nasabinning/temporal_stability.py
@@ -1,6 +1,6 @@
 """
 temporal_stability.py
-Avalia a robustez de cada bin ao longo do tempo.
+Avalia a robustez de cada bin ao longo do tempo e a separação entre suas curvas.
 
 Funções principais
 ------------------
@@ -8,6 +8,8 @@ event_rate_by_time(df, time_col)     -> DataFrame pivotado
 stability_table(df_pivot)            -> métricas por bin
 psi_over_time(df_pivot)              -> PSI entre 1ª e última safra
 ks_over_time(df_pivot)               -> KS entre 1ª e última safra
+temporal_separability_score(df, variable, bin_col, target_col, time_col)
+    -> escore médio de distância entre curvas de cada bin
 """
 
 import pandas as pd
@@ -59,3 +61,50 @@ def ks_over_time(pivot: pd.DataFrame) -> float:
     """KS global entre primeira e última safra (distribuição de event-rate)."""
     first, last = pivot.columns[0], pivot.columns[-1]
     return ks_2samp(pivot[first], pivot[last]).statistic
+
+# ------------------------------------------------------------------ #
+def temporal_separability_score(
+    df: pd.DataFrame,
+    variable: str,
+    bin_col: str,
+    target_col: str,
+    time_col: str,
+    *,
+    penalize_inversions: bool = False,
+    penalize_low_freq: bool = False,
+) -> float:
+    """Escore médio de distância absoluta entre curvas dos bins."""
+    tbl = (
+        df.groupby([bin_col, time_col])[target_col]
+        .agg(["sum", "count"])
+        .reset_index()
+        .rename(columns={"sum": "event", "count": "count"})
+    )
+    tbl["variable"] = variable
+    pivot = event_rate_by_time(tbl, time_col)
+
+    n_bins = pivot.shape[0]
+    if n_bins < 2:
+        return 0.0
+
+    curves = pivot.to_numpy()
+    dists = []
+    for i in range(n_bins):
+        for j in range(i + 1, n_bins):
+            dists.append(np.abs(curves[i] - curves[j]).mean())
+
+    score = float(np.mean(dists))
+
+    if penalize_low_freq:
+        freq = tbl.groupby(bin_col)["count"].min()
+        low = (freq < 30).sum()
+        score -= 0.1 * low
+
+    if penalize_inversions:
+        for idx in pivot.index:
+            values = pivot.loc[idx].values
+            trend = np.sign(np.diff(values))
+            if np.unique(trend[trend != 0]).size > 1:
+                score -= 0.1
+
+    return score

--- a/notebooks/05_temporal_separability_comparison.ipynb
+++ b/notebooks/05_temporal_separability_comparison.ipynb
@@ -1,0 +1,80 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Compara\u00e7\u00e3o de Binning\n",
+    "Este notebook compara o resultado do `NASABinner` tradicional com a \"vers\u00e3o\" que utiliza a \"temporal_separability_score\" via Optuna."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "source": [
+    "import os, sys\n",
+    "sys.path.append(os.path.abspath('..'))\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from nasabinning import NASABinner\n",
+    "from nasabinning.optuna_optimizer import optimize_bins"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "source": [
+    "# dados simples com coluna de tempo\n",
+    "rng = np.random.default_rng(0)\n",
+    "X = pd.DataFrame({'score': rng.normal(size=500)})\n",
+    "y = (X['score'] > 0).astype(int)\n",
+    "X['safra'] = np.repeat([202301, 202302, 202303, 202304, 202305], 100)\n"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "source": [
+    "# binning tradicional\n",
+    "binner = NASABinner(strategy='supervised', use_optuna=False)\n",
+    "binner.fit(X[['score']], y, time_col='safra')\n",
+    "binner.plot_event_rate_stability()"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "source": [
+    "# binning otimizado com separabilidade temporal\n",
+    "best, opt_binner = optimize_bins(\n",
+    "    X[['score']], y,\n",
+    "    time_col='safra', time_values=X['safra'],\n",
+    "    strategy='supervised', n_trials=20\n",
+    ")\n",
+    "opt_binner.plot_event_rate_stability()"
+   ],
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_temporal_stability.py
+++ b/tests/test_temporal_stability.py
@@ -1,6 +1,10 @@
 import pandas as pd
 import numpy as np
-from nasabinning.temporal_stability import event_rate_by_time, psi_over_time
+from nasabinning.temporal_stability import (
+    event_rate_by_time,
+    psi_over_time,
+    temporal_separability_score,
+)
 
 def test_event_rate_pivot_and_psi():
     # cria tabela fake
@@ -16,3 +20,15 @@ def test_event_rate_pivot_and_psi():
     assert pivot.shape == (3, 2)
     psi = psi_over_time(pivot)
     assert psi >= 0
+
+
+def test_temporal_separability_score():
+    df = pd.DataFrame({
+        'bin': [0, 0, 1, 1] * 3,
+        'target': [0, 1, 0, 1] * 3,
+        'time': [202301] * 4 + [202302] * 4 + [202303] * 4,
+    })
+    score = temporal_separability_score(
+        df, 'x', 'bin', 'target', 'time'
+    )
+    assert score > 0


### PR DESCRIPTION
## Summary
- document updated vision with temporal stability focus
- add temporal_separability_score in temporal_stability module
- integrate new metric into Optuna objective with weighted score
- allow passing time values to optimize_bins
- minor docstring updates and new unit test
- add notebook comparing baseline vs separability-optimized binning

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68426b88e27c83218b32d8b5c1f22824