### PR TITLE
Atualiza docs e exemplo de estabilidade temporal

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,14 @@ Desenvolvido para facilitar a decisão de agrupamento de variáveis numéricas e
 
 O NASABinning prioriza **estabilidade temporal** das taxas de evento. A biblioteca
 utiliza o `OptimalBinning` como base única para a geração dos cortes e o
-`Optuna` apenas para otimizar seus hiperparâmetros. O objetivo principal é
-encontrar binagens que mantenham curvas de `event rate` bem separadas e
-consistentes mês a mês. Métricas clássicas como IV e KS continuam sendo
-calculadas, porém com peso secundário na seleção final dos bins.
+`Optuna` apenas para buscar seus hiperparâmetros (``max_bins``, ``min_bin_size`` etc.).
+O objetivo é encontrar binagens que mantenham curvas de `event rate` bem separadas e
+consistentes mês a mês.
+
+Para medir essa qualidade é empregada a função
+`temporal_separability_score`, que calcula a distância média entre as curvas de
+cada bin ao longo das safras. Métricas clássicas como IV e KS continuam sendo
+computadas, porém com peso secundário na seleção final dos bins.
 O score utilizado na otimização segue a fórmula:
 
 ```

--- a/examples/binning_with_plot.py
+++ b/examples/binning_with_plot.py
@@ -1,1 +1,0 @@
-# binning_with_plot.py

--- a/examples/temporal_stability_example.py
+++ b/examples/temporal_stability_example.py
@@ -1,0 +1,54 @@
+"""Example demonstrating temporal stability with NASABinning."""
+
+import numpy as np
+import pandas as pd
+
+from nasabinning import NASABinner
+from nasabinning.temporal_stability import (
+    temporal_separability_score,
+    event_rate_by_time,
+    ks_over_time,
+)
+
+# synthetic dataset -------------------------------------------------------
+rng = np.random.default_rng(0)
+n = 800
+
+# feature with slight drift across months
+X = pd.DataFrame({"x": rng.normal(size=n)})
+X["month"] = rng.choice([202301, 202302, 202303, 202304], size=n)
+
+proba = 0.2 + 0.15 * X["x"] + 0.02 * (X["month"] - 202301)
+y = (rng.random(n) < proba).astype(int)
+
+# fit NASABinner using Optuna to maximise temporal separability
+binner = NASABinner(
+    strategy="supervised",
+    check_stability=True,
+    use_optuna=True,
+    time_col="month",
+    strategy_kwargs={"n_trials": 10},
+)
+
+binner.fit(X, y, time_col="month")
+
+# stability metrics ------------------------------------------------------
+pivot = binner.stability_over_time(X, y, time_col="month")
+ks = ks_over_time(pivot)
+
+bins = binner.transform(X)["x"]
+sep = temporal_separability_score(
+    pd.DataFrame({"bin": bins, "target": y, "time": X["month"]}),
+    "x",
+    "bin",
+    "target",
+    "time",
+)
+
+print(f"Temporal separability: {sep:.3f}")
+print(f"IV: {binner.iv_:.3f}")
+print(f"KS over time: {ks:.3f}")
+
+# plot curves ------------------------------------------------------------
+# Exibe gráfico de event rate por safra para cada bin
+binner.plot_event_rate_stability(pivot)

--- a/nasabinning/optuna_optimizer.py
+++ b/nasabinning/optuna_optimizer.py
@@ -11,7 +11,11 @@ optimize_bins(
 
 O Optuna apenas ajusta os hiperparâmetros do OptimalBinning. O score retornado
 pelo ``_objective`` prioriza a separabilidade temporal das curvas por safra,
-utilizando IV e KS como métricas auxiliares.
+computada por ``temporal_separability_score`` e ponderada com IV e KS segundo:
+
+``score = α * separabilidade + β * IV + γ * KS``
+
+onde ``α`` > ``β`` e ``γ`` (valores padrão: 0.7, 0.2 e 0.1).
 """
 from __future__ import annotations
 

--- a/nasabinning/temporal_stability.py
+++ b/nasabinning/temporal_stability.py
@@ -1,6 +1,7 @@
 """
-temporal_stability.py
-Avalia a robustez de cada bin ao longo do tempo e a separação entre suas curvas.
+Ferramentas para avaliação da **estabilidade temporal** dos bins.
+
+O principal indicador é ``temporal_separability_score``. Ele calcula a distância média entre as curvas de event rate de cada bin ao longo das safras (mês) e permite penalizações para inversões de tendência ou baixa frequência.
 
 Funções principais
 ------------------
@@ -9,7 +10,7 @@ stability_table(df_pivot)            -> métricas por bin
 psi_over_time(df_pivot)              -> PSI entre 1ª e última safra
 ks_over_time(df_pivot)               -> KS entre 1ª e última safra
 temporal_separability_score(df, variable, bin_col, target_col, time_col)
-    -> escore médio de distância entre curvas de cada bin
+    -> escore médio de separação temporal
 """
 
 import pandas as pd
@@ -73,7 +74,13 @@ def temporal_separability_score(
     penalize_inversions: bool = False,
     penalize_low_freq: bool = False,
 ) -> float:
-    """Escore médio de distância absoluta entre curvas dos bins."""
+    """Calcula a separação temporal entre os bins.
+
+    Para cada bin é obtida a curva de event rate por safra (mês). O score é a
+    média das distâncias absolutas entre todas as combinações de curvas.
+    Opcionalmente penaliza inversões de tendência ou bins com baixa
+    contagem.
+    """
     tbl = (
         df.groupby([bin_col, time_col])[target_col]
         .agg(["sum", "count"])


### PR DESCRIPTION
## Summary
- refresh README about temporal separability
- document stability module and Optuna optimizer
- improve docstring for `temporal_separability_score`
- add example demonstrating monthly curves

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6842ff01d8e48321a599f51e278b7644