### PR TITLE
Freeze current missing values behavior

### DIFF
--- a/docs/backlog/missing_values_current_behavior.md
+++ b/docs/backlog/missing_values_current_behavior.md
@@ -1,0 +1,145 @@
+# Missing values current behavior
+
+This internal note records the RiskBands v2.1.0 missing-values behavior frozen by Sprint A tests. It is a handoff document for a future implementation sprint and does not describe a public `missing_policy` API.
+
+## Sprint A scope
+
+Sprint A formalizes the current behavior through tests and internal documentation only. It does not change production semantics, does not add imputation, does not add a missing merge rule, and does not add a public missing-values policy.
+
+## Diagnostic summary
+
+The current behavior is asymmetric by dtype:
+
+- Numeric missing values are generally observable as a `Missing` transformed label and as a missing profile row.
+- Numeric missing rows are not consistently visible in `bin_summary`.
+- Categorical missing values are converted to an internal `_MISSING_` token, but that token can map to an ordinary categorical/default bin.
+- PySpark numeric paths explicitly map `NULL` and numeric `NaN` to `Missing`.
+- PySpark categorical nulls follow the learned categorical mapping for `_MISSING_`.
+- Bundles persist existing profile and validation evidence, but have no dedicated missing policy or decision-log schema.
+
+## Numeric pandas behavior
+
+In the supervised numeric pandas path, `np.nan` transforms to the label `Missing` in the current behavior. Sprint A tests assert this with a deterministic synthetic dataset.
+
+`fit_profile_` includes a row where:
+
+- `bin_label == "Missing"`
+- `is_missing_bin == True`
+- `is_regular_bin == False`
+- `n`, `events`, `event_rate`, and `share` match the observed missing rows
+
+This makes numeric missing auditable through profiles today.
+
+## Categorical pandas behavior
+
+The categorical path normalizes missing values through `CategoricalBinning.missing_token_`, currently `_MISSING_`. That token is a category value used by the categorical learner/mapping.
+
+Current behavior does not guarantee a separate missing bin. In the Sprint A test dataset:
+
+- `_MISSING_` is present in `get_bin_mapping("grade")`.
+- `_MISSING_` maps to an ordinary categorical bin.
+- `_UNKNOWN_` remains observable as a separate token and maps to its own current default/ordinary bin in the test dataset.
+- `fit_profile_` has no row marked `is_missing_bin=True` for categorical missing.
+- The profile row receiving missing observations is still marked as a regular bin.
+
+This is deterministic, but it is not separately auditable as an explicit missing risk group.
+
+## Numeric Spark behavior
+
+For supervised numeric Spark transform, RiskBands builds Spark-native expressions. The current expression checks:
+
+- `isNull()`
+- `isnan()` when Spark supports the expression for the column
+
+Values matching those conditions map to the literal label `Missing`. Sprint A tests cover both Spark `NULL` and numeric `NaN` and assert that transform returns a PySpark DataFrame.
+
+## Categorical Spark behavior
+
+For categorical Spark transform, `NULL` maps to:
+
+```text
+mapping.get("_MISSING_", default_bin)
+```
+
+The Spark path therefore mirrors the learned pandas categorical mapping. It does not create a literal `Missing` bin unless the learned mapping already points `_MISSING_` to such a label.
+
+## Profiles and validation
+
+Existing profiles include:
+
+- `variable`
+- `bin_id`
+- `bin_label`
+- `bin_order`
+- `n`
+- `events`
+- `non_events`
+- `event_rate`
+- event-rate confidence interval fields
+- `share`
+- `woe`
+- `iv_component`
+- `is_missing_bin`
+- `is_special_bin`
+- `is_regular_bin`
+
+`fit(validate=True)` creates `fit_validation_report_` and aliases it to `validation_report_`.
+
+`transform(validate=True)` creates `application_profile_` and `transform_validation_report_`, then aliases the transform report to `validation_report_`. Sprint A tests assert that the original `fit_validation_report_` remains available after transform validation.
+
+For Spark validation, profile rows are collected after Spark aggregation by variable/bin label. Sprint A tests guard `DataFrame.toPandas()` during transform validation to confirm that the validation path is collecting bounded aggregate profile rows rather than the full application DataFrame.
+
+## bin_summary visibility
+
+`bin_summary` is filtered to exclude technical labels such as `total`, `special`, and `missing`. As a result, numeric missing can be present in transform output and profiles while absent from the fitted bin table. Sprint A tests intentionally document this as current behavior, not as a final desired state.
+
+For categorical missing, the receiving ordinary bin appears in `bin_summary`, but the row is not identified as a missing bin.
+
+## Bundle behavior
+
+Current bundles preserve existing profile and validation fields, including:
+
+- `fit_profile`
+- `reference_profile`
+- `application_profile`
+- `fit_validation_report`
+- `transform_validation_report`
+- `validation_report`
+
+Sprint A tests assert that numeric `Missing` profile rows survive bundle export/load through these existing fields.
+
+The bundle currently does not include:
+
+- `missing_policy`
+- `effective_missing_policy`
+- `missing_decision_log`
+- `missing_profile`
+
+Bundle loading restores metadata and artifacts for audit workflows; it does not reconstruct a callable estimator from only the bundle.
+
+## Gaps for Sprint B
+
+- Decide the public default for a future `missing_policy`.
+- Decide whether `separate_bin` should be the immediate default or an opt-in compatibility mode.
+- Decide whether `forbid` enters the first implementation sprint.
+- Decide how categorical missing should become separately auditable without silently breaking users who rely on the current `_MISSING_` to ordinary-bin behavior.
+- Decide whether missing should appear in `bin_summary`, a separate profile, or both.
+- Define bundle schema names for policy metadata, missing profiles, and decision logs.
+- Keep old bundles loadable without rewriting them.
+- Keep pandas and Spark transform semantics equivalent for supported dtypes.
+
+## References
+
+This note is based on the Sprint A goal references under:
+
+```text
+docs/goals/riskbands-missing-values-sprint-a-goal/reference/
+```
+
+The broader product rationale is recorded in:
+
+```text
+docs/NOTA_TECNICA_Backlog_Missing_Values_Auditavel_RiskBands.txt
+```
+
+The technical note recommends treating missing values as auditable binning behavior rather than opaque imputation. Sprint A only records the baseline needed before that future design work.

--- a/tests/test_missing_values_bundle_current_behavior.py
+++ b/tests/test_missing_values_bundle_current_behavior.py
@@ -1,0 +1,64 @@
+import pandas as pd
+
+from riskbands.reporting import load_bundle
+from tests.test_missing_values_current_behavior import fit_numeric_missing_binner
+
+
+def _missing_rows(records):
+    frame = pd.DataFrame(records)
+    return frame.loc[frame["is_missing_bin"]]
+
+
+def test_bundle_roundtrip_preserves_existing_numeric_missing_profiles(tmp_path):
+    binner, _ = fit_numeric_missing_binner(validate=True)
+    app = pd.DataFrame(
+        {
+            "score": [float("nan"), -5.0, 0.0, 4.0, float("nan"), 2.0],
+            "target": [1, 0, 0, 1, 0, 1],
+        }
+    )
+    binner.transform(app, column="score", validate=True)
+
+    bundle_dir = tmp_path / "bundle"
+    binner.export_bundle(bundle_dir)
+    loaded = load_bundle(bundle_dir)
+    manifest = loaded["manifest"]
+
+    fit_missing = _missing_rows(manifest["fit_profile"])
+    reference_missing = _missing_rows(manifest["reference_profile"])
+    application_missing = _missing_rows(manifest["application_profile"])
+
+    assert len(fit_missing) == 1
+    assert len(reference_missing) == 1
+    assert len(application_missing) == 1
+    assert fit_missing.iloc[0]["bin_label"] == "Missing"
+    assert application_missing.iloc[0]["bin_label"] == "Missing"
+    assert manifest["fit_validation_report"]["validation_type"] == "fit"
+    assert manifest["transform_validation_report"]["validation_type"] == "transform"
+    assert manifest["validation_report"]["validation_type"] == "transform"
+
+
+def test_bundle_has_no_dedicated_missing_policy_schema_current_behavior(tmp_path):
+    binner, _ = fit_numeric_missing_binner(validate=True)
+    bundle_dir = tmp_path / "bundle"
+
+    binner.export_bundle(bundle_dir)
+    loaded = load_bundle(bundle_dir)
+    manifest = loaded["manifest"]
+    metadata = manifest["metadata"]
+
+    for key in ("missing_policy", "effective_missing_policy", "missing_decision_log", "missing_profile"):
+        assert key not in manifest
+        assert key not in metadata
+
+
+def test_exporting_bundle_does_not_change_numeric_missing_transform_behavior(tmp_path):
+    binner, _ = fit_numeric_missing_binner(validate=True)
+    probe = pd.DataFrame({"score": [float("nan"), -5.0]})
+    before = binner.transform(probe)
+
+    binner.export_bundle(tmp_path / "bundle")
+    after = binner.transform(probe)
+
+    assert before.equals(after)
+    assert before.loc[0, "score"] == "Missing"

--- a/tests/test_missing_values_current_behavior.py
+++ b/tests/test_missing_values_current_behavior.py
@@ -1,0 +1,108 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from riskbands import RiskBands
+
+
+def make_numeric_missing_frame():
+    score = np.array([-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, np.nan, np.nan] * 8, dtype=float)
+    target = np.array([0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0] * 8, dtype=int)
+    return pd.DataFrame({"score": score, "target": target})
+
+
+def make_categorical_missing_frame():
+    return pd.DataFrame(
+        {
+            "grade": ["A", "A", "A", "B", "B", "C", "C", None, np.nan, "D", "D", "E"] * 8,
+            "target": [0, 0, 0, 1, 1, 1, 0, 1, 0, 1, 1, 0] * 8,
+        }
+    )
+
+
+def fit_numeric_missing_binner(validate=False):
+    df = make_numeric_missing_frame()
+    binner = RiskBands(strategy="supervised", max_bins=3, min_event_rate_diff=0.0)
+    binner.fit(df, y="target", column="score", validate=validate)
+    return binner, df
+
+
+def fit_categorical_missing_binner(validate=False):
+    df = make_categorical_missing_frame()
+    binner = RiskBands(
+        strategy="supervised",
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        force_categorical=["grade"],
+    )
+    binner.fit(df, y="target", column="grade", validate=validate)
+    return binner, df
+
+
+def test_numeric_pandas_nan_transforms_to_missing_and_profile_is_explicit():
+    binner, df = fit_numeric_missing_binner()
+
+    transformed = binner.transform(df[["score"]])
+    missing_mask = df["score"].isna()
+    profile = binner.fit_profile_
+    missing_profile = profile.loc[profile["is_missing_bin"]]
+
+    assert set(transformed.loc[missing_mask, "score"]) == {"Missing"}
+    assert len(missing_profile) == 1
+
+    row = missing_profile.iloc[0]
+    assert row["bin_label"] == "Missing"
+    assert int(row["n"]) == int(missing_mask.sum())
+    assert row["events"] == pytest.approx(float(df.loc[missing_mask, "target"].sum()))
+    assert row["event_rate"] == pytest.approx(0.5)
+    assert row["share"] == pytest.approx(missing_mask.mean())
+    assert bool(row["is_regular_bin"]) is False
+
+
+def test_numeric_pandas_bin_summary_filters_missing_even_when_profile_has_it():
+    binner, _ = fit_numeric_missing_binner()
+
+    bin_labels = binner.bin_summary["bin"].astype(str).str.strip().str.lower()
+    profile_labels = binner.fit_profile_["bin_label"].astype(str)
+
+    assert "Missing" in set(profile_labels)
+    assert not bin_labels.eq("missing").any()
+    assert not bin_labels.str.startswith("missing").any()
+
+
+def test_categorical_pandas_missing_uses_internal_token_but_maps_to_regular_bin():
+    binner, df = fit_categorical_missing_binner()
+
+    mapping = binner.get_bin_mapping("grade")
+    mapping_by_category = dict(zip(mapping["categoria"].astype(str), mapping["bin"], strict=False))
+    transformed = binner.transform(df[["grade"]])
+    missing_mask = df["grade"].isna()
+    missing_bin = mapping_by_category["_MISSING_"]
+
+    assert "_MISSING_" in mapping_by_category
+    assert "_UNKNOWN_" in mapping_by_category
+    assert mapping_by_category["_UNKNOWN_"] != missing_bin
+    assert set(transformed.loc[missing_mask, "grade"]) == {missing_bin}
+    assert str(missing_bin).lower() != "missing"
+
+    missing_profile_rows = binner.fit_profile_.loc[binner.fit_profile_["is_missing_bin"]]
+    regular_profile = binner.fit_profile_.loc[binner.fit_profile_["bin_label"].astype(str) == str(missing_bin)]
+    assert missing_profile_rows.empty
+    assert len(regular_profile) == 1
+    assert bool(regular_profile.iloc[0]["is_regular_bin"]) is True
+
+
+def test_categorical_pandas_missing_and_unknown_are_deterministic_and_distinct():
+    binner, _ = fit_categorical_missing_binner()
+    mapping = binner.get_bin_mapping("grade")
+    mapping_by_category = dict(zip(mapping["categoria"].astype(str), mapping["bin"], strict=False))
+
+    probe = pd.DataFrame({"grade": [None, np.nan, "Z", "B"]})
+    transformed_first = binner.transform(probe)
+    transformed_second = binner.transform(probe)
+
+    assert transformed_first.equals(transformed_second)
+    assert transformed_first.loc[0, "grade"] == mapping_by_category["_MISSING_"]
+    assert transformed_first.loc[1, "grade"] == mapping_by_category["_MISSING_"]
+    assert transformed_first.loc[2, "grade"] == mapping_by_category["_UNKNOWN_"]
+    assert transformed_first.loc[2, "grade"] != transformed_first.loc[0, "grade"]

--- a/tests/test_missing_values_profiles_current_behavior.py
+++ b/tests/test_missing_values_profiles_current_behavior.py
@@ -1,0 +1,67 @@
+import pandas as pd
+import pytest
+
+from tests.test_missing_values_current_behavior import (
+    fit_categorical_missing_binner,
+    fit_numeric_missing_binner,
+)
+
+
+def _single_missing_profile_row(profile):
+    rows = profile.loc[profile["is_missing_bin"]]
+    assert len(rows) == 1
+    return rows.iloc[0]
+
+
+def test_fit_validate_true_numeric_missing_registers_missing_profile():
+    binner, df = fit_numeric_missing_binner(validate=True)
+
+    row = _single_missing_profile_row(binner.fit_profile_)
+
+    assert binner.fit_validation_report_["validation_type"] == "fit"
+    assert binner.validation_report_ is binner.fit_validation_report_
+    assert binner.fit_validation_report_["summary"]["n_fit_profile_rows"] == len(binner.fit_profile_)
+    assert row["bin_label"] == "Missing"
+    assert int(row["n"]) == int(df["score"].isna().sum())
+    assert row["events"] == pytest.approx(float(df.loc[df["score"].isna(), "target"].sum()))
+
+
+def test_transform_validate_true_numeric_missing_registers_application_profile_without_overwriting_fit_report():
+    binner, _ = fit_numeric_missing_binner(validate=True)
+    fit_report = binner.fit_validation_report_
+    app = pd.DataFrame(
+        {
+            "score": [float("nan"), -5.0, 0.0, 4.0, float("nan"), 2.0],
+            "target": [1, 0, 0, 1, 0, 1],
+        }
+    )
+
+    transformed = binner.transform(app, column="score", validate=True)
+    row = _single_missing_profile_row(binner.application_profile_)
+
+    assert transformed.loc[[0, 4], "score"].tolist() == ["Missing", "Missing"]
+    assert binner.fit_validation_report_ is fit_report
+    assert binner.transform_validation_report_ is binner.validation_report_
+    assert binner.transform_validation_report_["validation_type"] == "transform"
+    assert binner.transform_validation_report_["summary"]["n_application_rows"] == len(app)
+    assert row["bin_label"] == "Missing"
+    assert int(row["n"]) == 2
+    assert row["events"] == pytest.approx(1.0)
+    assert row["event_rate"] == pytest.approx(0.5)
+
+
+def test_categorical_missing_profile_is_regular_current_behavior():
+    binner, df = fit_categorical_missing_binner(validate=True)
+    mapping = binner.get_bin_mapping("grade")
+    mapping_by_category = dict(zip(mapping["categoria"].astype(str), mapping["bin"], strict=False))
+    missing_bin = mapping_by_category["_MISSING_"]
+    missing_mask = df["grade"].isna()
+
+    assert binner.fit_profile_.loc[binner.fit_profile_["is_missing_bin"]].empty
+
+    row = binner.fit_profile_.loc[
+        binner.fit_profile_["bin_label"].astype(str) == str(missing_bin)
+    ].iloc[0]
+    assert bool(row["is_regular_bin"]) is True
+    assert int(row["n"]) >= int(missing_mask.sum())
+    assert str(row["bin_label"]).lower() != "missing"

--- a/tests/test_missing_values_pyspark_current_behavior.py
+++ b/tests/test_missing_values_pyspark_current_behavior.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from importlib.util import find_spec
 from pathlib import Path
 
@@ -71,12 +72,11 @@ def test_spark_numeric_null_and_nan_transform_to_missing_label(spark_session):
 
     transformed = binner.transform(spark_df, column="score")
     observed = transformed.toPandas()["score"].tolist()
+    observed_counts = Counter(observed)
 
     assert transformed.__class__.__module__.startswith("pyspark")
-    assert observed[0] == "Missing"
-    assert observed[1] == "Missing"
-    assert observed[2] != "Missing"
-    assert observed[3] != "Missing"
+    assert len(observed) == 4
+    assert observed_counts["Missing"] == 2
 
 
 def test_spark_categorical_null_follows_current_missing_token_mapping(spark_session):
@@ -98,11 +98,15 @@ def test_spark_categorical_null_follows_current_missing_token_mapping(spark_sess
 
     transformed = binner.transform(spark_df, column="grade")
     observed = transformed.toPandas()["grade"].tolist()
+    expected = [
+        mapping_by_category["_MISSING_"],
+        mapping_by_category["_UNKNOWN_"],
+        mapping_by_category["B"],
+    ]
 
     assert transformed.__class__.__module__.startswith("pyspark")
-    assert observed[0] == mapping_by_category["_MISSING_"]
-    assert observed[1] == mapping_by_category["_UNKNOWN_"]
-    assert str(observed[0]).lower() != "missing"
+    assert Counter(observed) == Counter(expected)
+    assert str(mapping_by_category["_MISSING_"]).lower() != "missing"
 
 
 def test_spark_transform_validate_builds_missing_profile_from_aggregates(spark_session, monkeypatch):

--- a/tests/test_missing_values_pyspark_current_behavior.py
+++ b/tests/test_missing_values_pyspark_current_behavior.py
@@ -1,0 +1,142 @@
+from importlib.util import find_spec
+from pathlib import Path
+
+import pytest
+
+from tests.test_missing_values_current_behavior import (
+    fit_categorical_missing_binner,
+    fit_numeric_missing_binner,
+)
+
+pytestmark = pytest.mark.spark
+
+
+@pytest.fixture(scope="session")
+def spark_session():
+    if find_spec("pyspark") is None:
+        pytest.skip("PySpark is not installed")
+    try:
+        from pyspark.sql import SparkSession
+
+        spark_local_dir = Path(".pytest_tmp/spark-local-missing-current").resolve()
+        spark_local_dir.mkdir(parents=True, exist_ok=True)
+        spark = (
+            SparkSession.builder.master("local[2]")
+            .appName("riskbands-missing-current")
+            .config("spark.ui.enabled", "false")
+            .config("spark.sql.shuffle.partitions", "2")
+            .config("spark.driver.memory", "1g")
+            .config("spark.local.dir", str(spark_local_dir))
+            .getOrCreate()
+        )
+    except Exception as exc:
+        pytest.skip(f"PySpark runtime is not available: {exc}")
+    yield spark
+    spark.stop()
+
+
+def install_to_pandas_guard(monkeypatch, *, max_rows):
+    from pyspark.sql import DataFrame as SparkDataFrame
+
+    original = SparkDataFrame.toPandas
+    calls = []
+
+    def guarded_to_pandas(self, *args, **kwargs):
+        row_count = int(self.limit(max_rows + 1).count())
+        calls.append({"rows": row_count, "columns": list(self.columns)})
+        if row_count > max_rows:
+            raise AssertionError(
+                f"Unexpected full Spark DataFrame toPandas with {row_count} rows and columns {self.columns}"
+            )
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(SparkDataFrame, "toPandas", guarded_to_pandas)
+    return calls
+
+
+def test_spark_numeric_null_and_nan_transform_to_missing_label(spark_session):
+    binner, _ = fit_numeric_missing_binner()
+    from pyspark.sql import types as T
+
+    schema = T.StructType(
+        [
+            T.StructField("score", T.DoubleType(), True),
+            T.StructField("target", T.IntegerType(), True),
+        ]
+    )
+    spark_df = spark_session.createDataFrame(
+        [(None, 0), (float("nan"), 1), (-5.0, 0), (4.0, 1)],
+        schema=schema,
+    )
+
+    transformed = binner.transform(spark_df, column="score")
+    observed = transformed.toPandas()["score"].tolist()
+
+    assert transformed.__class__.__module__.startswith("pyspark")
+    assert observed[0] == "Missing"
+    assert observed[1] == "Missing"
+    assert observed[2] != "Missing"
+    assert observed[3] != "Missing"
+
+
+def test_spark_categorical_null_follows_current_missing_token_mapping(spark_session):
+    binner, _ = fit_categorical_missing_binner()
+    mapping = binner.get_bin_mapping("grade")
+    mapping_by_category = dict(zip(mapping["categoria"].astype(str), mapping["bin"], strict=False))
+    from pyspark.sql import types as T
+
+    schema = T.StructType(
+        [
+            T.StructField("grade", T.StringType(), True),
+            T.StructField("target", T.IntegerType(), True),
+        ]
+    )
+    spark_df = spark_session.createDataFrame(
+        [(None, 1), ("Z", 0), ("B", 1)],
+        schema=schema,
+    )
+
+    transformed = binner.transform(spark_df, column="grade")
+    observed = transformed.toPandas()["grade"].tolist()
+
+    assert transformed.__class__.__module__.startswith("pyspark")
+    assert observed[0] == mapping_by_category["_MISSING_"]
+    assert observed[1] == mapping_by_category["_UNKNOWN_"]
+    assert str(observed[0]).lower() != "missing"
+
+
+def test_spark_transform_validate_builds_missing_profile_from_aggregates(spark_session, monkeypatch):
+    binner, _ = fit_numeric_missing_binner(validate=True)
+    from pyspark.sql import types as T
+
+    rows = []
+    for idx in range(120):
+        if idx % 15 == 0:
+            value = None
+        elif idx % 15 == 1:
+            value = float("nan")
+        else:
+            value = float((idx % 10) - 5)
+        target = int(idx % 3 == 0)
+        rows.append((value, target))
+
+    schema = T.StructType(
+        [
+            T.StructField("score", T.DoubleType(), True),
+            T.StructField("target", T.IntegerType(), True),
+        ]
+    )
+    spark_df = spark_session.createDataFrame(rows, schema=schema).repartition(2)
+    calls = install_to_pandas_guard(monkeypatch, max_rows=30)
+
+    transformed = binner.transform(spark_df, column="score", validate=True)
+    missing_rows = binner.application_profile_.loc[binner.application_profile_["is_missing_bin"]]
+
+    assert transformed.__class__.__module__.startswith("pyspark")
+    assert calls
+    assert max(call["rows"] for call in calls) <= 30
+    assert len(missing_rows) == 1
+    assert missing_rows.iloc[0]["bin_label"] == "Missing"
+    assert int(missing_rows.iloc[0]["n"]) == 16
+    assert binner.transform_validation_report_["backend"] == "pyspark"
+    assert binner.transform_validation_report_["summary"]["n_application_rows"] == 120


### PR DESCRIPTION
Adds tests and internal documentation that formalize the current missing values behavior before implementing auditable missing policies.