### PR TITLE
Add auditable missing value policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ Em outras palavras:
 
 O repositório agora expõe dois caminhos explícitos de score:
 
-- `legacy`
+- `standard`
   Mantém o objetivo histórico baseado em componentes positivos menos penalidades.
+  `legacy` segue aceito apenas como alias compatível.
 - `stable`
   Introduz a estratégia pública recomendada para robustez temporal, orientada a
   minimização, com componentes normalizados e foco em equilíbrio entre
@@ -173,6 +174,22 @@ binner = RiskBands(
 )
 ```
 
+## Missing values auditaveis
+
+`missing_policy` controla como valores ausentes nas features selecionadas entram
+no binning:
+
+- `standard` e o default e preserva o comportamento historico congelado na
+  Sprint A.
+- `separate_bin` e opt-in e cria bin explicito `Missing`, incluindo missing
+  categorico.
+- `forbid` falha em `fit` ou `transform` quando houver missing nas features
+  selecionadas.
+
+Bundles novos persistem `missing_policy`, `effective_missing_policy`,
+`missing_profile` e `missing_decision_log`. Bundles antigos sem esses campos
+carregam como `standard`.
+
 ## Export auditavel e supply chain
 
 `export_bundle(...)` gera artefatos tabulares e JSON para auditoria. Nomes de
@@ -263,7 +280,7 @@ binner = RiskBands(
 
 Leitura rápida:
 
-- no `legacy`, maiores scores continuam melhores
+- no `standard`, maiores scores continuam melhores
 - no `stable`, menores scores são melhores
 - relatórios auditáveis expõem score final, componentes raw, componentes normalizados, pesos, estratégia e parâmetros de shrink
 

--- a/docs-site/src/content/docs/index.md
+++ b/docs-site/src/content/docs/index.md
@@ -21,7 +21,7 @@ features:
     description: Instalação, primeiro exemplo mínimo e fluxo recomendado com `Binner` no estilo sklearn/pandas.
     link: ./technical/quickstart/
   - title: Score strategy
-    description: Entenda `legacy` vs `stable`, quando usar cada um e como pensar separação versus robustez temporal.
+    description: Entenda `standard` vs `stable`, quando usar cada um e como pensar separação versus robustez temporal.
     link: ./technical/score-strategy/
   - title: Outputs fáceis de ler
     description: Veja como interpretar `summary()`, `report()`, `score_details()`, `diagnostics()` e `binning_table()`.

--- a/docs-site/src/content/docs/technical/api-overview.md
+++ b/docs-site/src/content/docs/technical/api-overview.md
@@ -91,10 +91,18 @@ binner.export_bundle("artifacts/run_2026_04_14")
 
 Hoje a API expõe duas estratégias explícitas:
 
-- `legacy`
-  Mantém o score histórico orientado a maximização.
+- `standard`
+  Mantém o score histórico orientado a maximização. `legacy` segue aceito apenas como alias compatível.
 - `stable`
   Introduz o objective orientado a robustez temporal e minimização.
+
+## Missing values
+
+`missing_policy` aceita:
+
+- `standard`: default compatível com o comportamento atual
+- `separate_bin`: opt-in para bin explícito `Missing`
+- `forbid`: erro em `fit` ou `transform` se houver missing nas features selecionadas
 
 Exemplo:
 

--- a/docs-site/src/content/docs/technical/examples.md
+++ b/docs-site/src/content/docs/technical/examples.md
@@ -19,7 +19,7 @@ Esse material mostra:
 - `binning_table()`
 - `score_details()`
 - `diagnostics()`
-- comparação entre `legacy` e `stable`
+- comparação entre `standard` e `stable`
 
 ### Quickstart de estabilidade temporal
 

--- a/docs-site/src/content/docs/technical/outputs.md
+++ b/docs-site/src/content/docs/technical/outputs.md
@@ -130,10 +130,14 @@ Gera um pacote de auditoria com:
 
 Uma regra simples:
 
-- `legacy`: score bruto maior é melhor
+- `standard`: score bruto maior é melhor
 - `stable`: score bruto menor é melhor
 
 Se quiser uma régua consolidada para comparação entre estratégias, olhe também `objective_preference_score`.
+
+Bundles também persistem a trilha de missing values quando disponível:
+`missing_policy`, `effective_missing_policy`, `missing_profile` e
+`missing_decision_log`.
 
 ## Exemplo
 

--- a/docs-site/src/content/docs/technical/quickstart.md
+++ b/docs-site/src/content/docs/technical/quickstart.md
@@ -113,7 +113,7 @@ Para um novo usuário, `stable` costuma ser a melhor estratégia pública para c
 - estabilidade importa de verdade
 - você quer equilibrar separação e robustez
 
-Se você precisa reproduzir um comportamento mais histórico ou comparar com a abordagem anterior, use `legacy`.
+Se você precisa reproduzir um comportamento mais histórico ou comparar com a abordagem anterior, use `standard`.
 
 ## Próximos passos
 

--- a/docs-site/src/content/docs/technical/score-strategy.md
+++ b/docs-site/src/content/docs/technical/score-strategy.md
@@ -28,10 +28,10 @@ Em geral:
 
 Os valores públicos válidos agora são:
 
-- `legacy`
+- `standard`
 - `stable`
 
-`stable` substitui a nomenclatura pública usada anteriormente e passa a ser o nome recomendado daqui para frente.
+`standard` é o nome canônico do score histórico orientado a maximização. `legacy` segue aceito apenas como alias compatível.
 
 ## Quando usar `stable`
 
@@ -52,9 +52,9 @@ Em termos práticos, `stable` é orientado a minimização:
 - menor `objective_score` é melhor
 - maior `objective_preference_score` continua ajudando em comparações consolidadas
 
-## Quando usar `legacy`
+## Quando usar `standard`
 
-`legacy` continua útil quando você quer:
+`standard` continua útil quando você quer:
 
 - reproduzir a leitura histórica do projeto
 - comparar com o comportamento anterior

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -34,7 +34,8 @@ Common parameters:
 - `check_stability`: enables temporal checks in the flow
 - `use_optuna`: enables hyperparameter search for `strategy="supervised"`
 - `time_col`: period column used by temporal diagnostics
-- `score_strategy`: `"legacy"` or `"stable"`
+- `missing_policy`: `"standard"` (default), `"separate_bin"`, or `"forbid"`
+- `score_strategy`: `"standard"` or `"stable"`; `"legacy"` remains a compatibility alias for `"standard"`
 - `score_weights`: optional weights for `stable`
 - `normalization_strategy`: currently `absolute` for standalone-safe normalization
 - `woe_shrinkage_strength`: shrink intensity applied before temporal scoring
@@ -103,6 +104,7 @@ Main attributes after `fit`:
 - `transform_validation_report_` when `transform(validate=True)` was requested
 - `validation_report_` as the latest validation report compatibility alias
 - `fit_profile_`, `source_profile_`, and `reference_profile_` when available
+- `missing_policy_`, `missing_profile_`, and `missing_decision_log_`
 - `iv_`
 - `iv_by_variable_`
 - `objective_config_`
@@ -153,6 +155,7 @@ Main attributes after `fit`:
 
 - fit metadata and RiskBands version
 - strategy, score strategy, normalization mode, shrinkage configuration
+- missing policy and effective missing policy
 - target, time column, fitted features and generation timestamp
 - auditable score weights and effective score-weight profile
 - per-feature binning tables, score details and audit-friendly summaries
@@ -162,6 +165,7 @@ Main attributes after `fit`:
 - `metadata.json`
 - `binnings.json`
 - friendly CSV outputs such as `summary.csv`, `score_table.csv`, `audit_table.csv`, and `report.csv`
+- missing audit outputs such as `missing_profile.csv` and `missing_decision_log.csv` when available
 - per-feature tables under `feature_tables/`
 - parquet artifacts when the environment has parquet support available
 
@@ -169,9 +173,10 @@ Main attributes after `fit`:
 
 `optimize_bins(...)` now supports two explicit scoring strategies:
 
-- `legacy`
+- `standard`
   - maximize-oriented
   - keeps the historical score based on positive components and penalties
+  - `legacy` is accepted only as a compatibility alias
 - `stable`
   - minimize-oriented
   - explicit stable objective with normalized components
@@ -195,7 +200,7 @@ Default weights:
 - `entropy_weight=0.08`
 - `psi_weight=0.12`
 
-Legacy optimization remains composed of:
+Standard optimization remains composed of:
 
 - base components:
   - `separability`
@@ -215,7 +220,7 @@ The final winner summary is stored in `objective_summary_`.
 
 Interpretation:
 
-- in `legacy`, higher `objective_score` is better
+- in `standard`, higher `objective_score` is better
 - in `stable`, lower `objective_score` is better
 - `objective_preference_score` keeps comparisons consistent across strategies
 

--- a/docs/v2.2.0_missing_policy_design.md
+++ b/docs/v2.2.0_missing_policy_design.md
@@ -1,0 +1,48 @@
+# v2.2.0 Missing Policy Design
+
+This internal design note records the implemented Sprint B contract. It does not
+claim that a v2.2.0 release has been published.
+
+## Public Contract
+
+```python
+RiskBands(missing_policy="standard")
+RiskBands(missing_policy="separate_bin")
+RiskBands(missing_policy="forbid")
+```
+
+- `standard` is the default and preserves the Sprint A baseline behavior.
+- `separate_bin` is opt-in and makes missing values explicit as `Missing`,
+  including categorical missing values.
+- `forbid` raises during `fit` or `transform` when selected features contain
+  missing values.
+
+## Score Strategy Naming
+
+`standard` is the canonical name for the historical maximize-oriented objective.
+`legacy` is accepted as a compatibility alias and normalizes to `standard`.
+New metadata and bundles should use `standard`.
+
+## Audit Fields
+
+Fitted objects expose:
+
+- `missing_policy_`
+- `effective_missing_policy_`
+- `missing_profile_`
+- `missing_decision_log_`
+
+Bundles persist:
+
+- `missing_policy`
+- `effective_missing_policy`
+- `missing_profile`
+- `missing_decision_log`
+
+Old bundles without these fields load as `standard`.
+
+## Out Of Scope
+
+No merge policy is implemented in this sprint. Policies such as
+`merge_nearest_woe`, `merge_nearest_event_rate`, and
+`merge_monotonic_neighbor` remain future work.

--- a/examples/riskbands_synthetic_plotly_comparative_demo.ipynb
+++ b/examples/riskbands_synthetic_plotly_comparative_demo.ipynb
@@ -13,7 +13,7 @@
     "\n",
     "- começar com um fluxo curto e memorável\n",
     "- usar `DataFrame` com `y=\"target\"`\n",
-    "- comparar `legacy` e `stable`\n",
+    "- comparar `standard` e `stable` (`legacy` segue apenas como alias compatível)\n",
     "- inspecionar `summary()`, `binning_table()`, `score_details()` e `diagnostics()`\n",
     "- gerar visuais comparativos com Plotly a partir de dados sintéticos\n"
    ]

--- a/riskbands/binning_engine.py
+++ b/riskbands/binning_engine.py
@@ -21,6 +21,15 @@ from .utils.dataframe_backend import detect_dataframe_backend
 from .utils.dtypes import search_dtypes
 
 _MAX_PROFILE_ROWS_TO_COLLECT = 100_000
+_STANDARD_MISSING_POLICY = "standard"
+_SEPARATE_BIN_MISSING_POLICY = "separate_bin"
+_FORBID_MISSING_POLICY = "forbid"
+_LEGACY_POLICY_ALIAS = "legacy"
+_VALID_MISSING_POLICIES = {
+    _STANDARD_MISSING_POLICY,
+    _SEPARATE_BIN_MISSING_POLICY,
+    _FORBID_MISSING_POLICY,
+}
 
 
 class Binner(BaseEstimator, TransformerMixin):
@@ -41,7 +50,8 @@ class Binner(BaseEstimator, TransformerMixin):
         time_col: str | None = None,
         force_categorical: list[str] | None = None,
         force_numeric: list[str] | None = None,
-        score_strategy: str = "legacy",
+        missing_policy: str = "standard",
+        score_strategy: str = "standard",
         score_weights: dict | None = None,
         normalization_strategy: str = "absolute",
         woe_shrinkage_strength: float = 25.0,
@@ -72,8 +82,11 @@ class Binner(BaseEstimator, TransformerMixin):
         self.time_col = time_col
         self.force_categorical = force_categorical or []
         self.force_numeric = force_numeric or []
+        self.missing_policy = self._normalize_missing_policy(missing_policy)
+        self.missing_policy_ = self.missing_policy
+        self.effective_missing_policy_ = self.missing_policy
         self.objective_kwargs = objective_kwargs or {}
-        resolve_score_strategy(score_strategy=score_strategy)
+        score_strategy = resolve_score_strategy(score_strategy=score_strategy)
         if "score_strategy" in self.objective_kwargs:
             resolve_score_strategy(
                 {"score_strategy": self.objective_kwargs["score_strategy"]},
@@ -113,12 +126,14 @@ class Binner(BaseEstimator, TransformerMixin):
                 "`monotonic` and `monotonic_trend` must match when both are provided."
             )
         if "score_strategy" in params:
-            resolve_score_strategy(score_strategy=params["score_strategy"])
+            params["score_strategy"] = resolve_score_strategy(score_strategy=params["score_strategy"])
         if "objective_kwargs" in params and "score_strategy" in (params["objective_kwargs"] or {}):
             resolve_score_strategy(
                 {"score_strategy": params["objective_kwargs"]["score_strategy"]},
                 score_strategy=None,
             )
+        if "missing_policy" in params:
+            params["missing_policy"] = self._normalize_missing_policy(params["missing_policy"])
         if "min_n_bins" in params:
             params["min_n_bins"] = self._validate_min_n_bins(params["min_n_bins"])
         if "sample_size" in params:
@@ -136,7 +151,22 @@ class Binner(BaseEstimator, TransformerMixin):
         result = super().set_params(**params)
         self.max_n_bins = self.max_bins
         self.monotonic_trend = self.monotonic
+        self.missing_policy_ = self.missing_policy
+        self.effective_missing_policy_ = self.missing_policy
         return result
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _normalize_missing_policy(value: str | None) -> str:
+        policy = _STANDARD_MISSING_POLICY if value is None else str(value)
+        if policy == _LEGACY_POLICY_ALIAS:
+            return _STANDARD_MISSING_POLICY
+        if policy not in _VALID_MISSING_POLICIES:
+            allowed = ", ".join(f"'{item}'" for item in sorted(_VALID_MISSING_POLICIES))
+            raise ValueError(
+                f"Unsupported missing_policy '{policy}'. Use one of: {allowed}."
+            )
+        return policy
 
     # ------------------------------------------------------------------
     @staticmethod
@@ -245,6 +275,102 @@ class Binner(BaseEstimator, TransformerMixin):
         return F
 
     # ------------------------------------------------------------------
+    @staticmethod
+    def _pandas_missing_counts(X: pd.DataFrame, columns: Sequence[str]) -> dict[str, int]:
+        if not columns:
+            return {}
+        counts = X.loc[:, list(columns)].isna().sum()
+        return {str(column): int(count) for column, count in counts.items()}
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _format_missing_counts(counts: dict[str, int]) -> str:
+        return ", ".join(f"{column}={count}" for column, count in counts.items() if count > 0)
+
+    # ------------------------------------------------------------------
+    def _raise_forbidden_missing(
+        self,
+        counts: dict[str, int],
+        *,
+        context: str,
+        backend: str,
+    ) -> None:
+        present = {column: count for column, count in counts.items() if count > 0}
+        if not present:
+            return
+        detail = self._format_missing_counts(present)
+        raise ValueError(
+            f"missing_policy='forbid' detected missing values during {context} "
+            f"on backend '{backend}': {detail}. "
+            "Clean missing values upstream or use missing_policy='standard' or "
+            "missing_policy='separate_bin' when missing values are expected."
+        )
+
+    # ------------------------------------------------------------------
+    def _check_missing_policy_pandas(
+        self,
+        X: pd.DataFrame,
+        columns: Sequence[str],
+        *,
+        context: str,
+    ) -> None:
+        if self.missing_policy != _FORBID_MISSING_POLICY:
+            return
+        self._raise_forbidden_missing(
+            self._pandas_missing_counts(X, columns),
+            context=context,
+            backend="pandas",
+        )
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _spark_column_supports_nan(data_type: Any) -> bool:
+        try:
+            from pyspark.sql import types as T
+        except Exception:  # pragma: no cover - import availability checked by caller
+            return False
+        return isinstance(data_type, (T.DoubleType, T.FloatType))
+
+    # ------------------------------------------------------------------
+    def _spark_missing_count_expressions(self, X, columns: Sequence[str], F):
+        fields = {field.name: field.dataType for field in X.schema.fields}
+        expressions = []
+        for column in columns:
+            col_expr = F.col(column)
+            missing_condition = col_expr.isNull()
+            if self._spark_column_supports_nan(fields.get(column)):
+                missing_condition = missing_condition | F.isnan(col_expr)
+            expressions.append(
+                F.sum(F.when(missing_condition, F.lit(1)).otherwise(F.lit(0))).alias(str(column))
+            )
+        return expressions
+
+    # ------------------------------------------------------------------
+    def _pyspark_missing_counts(self, X, columns: Sequence[str]) -> dict[str, int]:
+        if not columns:
+            return {}
+        F = self._spark_functions()
+        expressions = self._spark_missing_count_expressions(X, columns, F)
+        row = X.agg(*expressions).collect()[0]
+        return {str(column): int(row[str(column)] or 0) for column in columns}
+
+    # ------------------------------------------------------------------
+    def _check_missing_policy_pyspark(
+        self,
+        X,
+        columns: Sequence[str],
+        *,
+        context: str,
+    ) -> None:
+        if self.missing_policy != _FORBID_MISSING_POLICY:
+            return
+        self._raise_forbidden_missing(
+            self._pyspark_missing_counts(X, columns),
+            context=context,
+            backend="pyspark",
+        )
+
+    # ------------------------------------------------------------------
     def _normalize_pyspark_fit_inputs(
         self,
         X,
@@ -349,6 +475,7 @@ class Binner(BaseEstimator, TransformerMixin):
             features=features,
             time_col=time_col,
         )
+        self._check_missing_policy_pyspark(X, feature_columns, context="fit")
         source_rows = int(X.count())
         selected_spark = X.select(*collect_columns)
         sampled_spark, sampling_plan = self._sample_pyspark_dataframe(
@@ -525,7 +652,10 @@ class Binner(BaseEstimator, TransformerMixin):
         default_bin = getattr(strategy, "default_bin_", mapping.get(unknown_token))
         col_expr = F.col(column)
         str_col = col_expr.cast("string")
-        expr = F.when(col_expr.isNull(), F.lit(mapping.get(missing_token, default_bin)))
+        if self.missing_policy == _SEPARATE_BIN_MISSING_POLICY:
+            expr = F.when(col_expr.isNull(), F.lit("Missing"))
+        else:
+            expr = F.when(col_expr.isNull(), F.lit(mapping.get(missing_token, default_bin)))
         for category, label in sorted(mapping.items(), key=lambda item: str(item[0])):
             if category in {missing_token, unknown_token}:
                 continue
@@ -567,6 +697,7 @@ class Binner(BaseEstimator, TransformerMixin):
             feature=feature,
             features=features,
         )
+        self._check_missing_policy_pyspark(X, selected_columns, context="transform")
         F = self._spark_functions()
         transformed = X
         for selected_column in selected_columns:
@@ -1032,6 +1163,88 @@ class Binner(BaseEstimator, TransformerMixin):
         return mask
 
     # ------------------------------------------------------------------
+    def _fitted_summary_mask(self, summary: pd.DataFrame) -> pd.Series:
+        if summary.empty:
+            return pd.Series(dtype=bool, index=summary.index)
+
+        mask = pd.Series(True, index=summary.index)
+        if "count" in summary.columns:
+            counts = pd.to_numeric(summary["count"], errors="coerce").fillna(0)
+            mask &= counts > 0
+        if "bin" in summary.columns:
+            labels_raw = summary["bin"].astype(str)
+            labels = labels_raw.str.strip().str.lower()
+            technical = labels.isin({"total", "totals", "special", "special codes", ""})
+            technical |= labels.str.startswith("special")
+            if self.missing_policy != _SEPARATE_BIN_MISSING_POLICY:
+                technical |= labels.isin({"missing"})
+                technical |= labels.str.startswith("missing")
+            mask &= ~technical
+            if "variable" in summary.columns:
+                mask &= labels_raw != summary["variable"].astype(str)
+        return mask
+
+    # ------------------------------------------------------------------
+    def _filter_fitted_summary(self, summary: pd.DataFrame) -> pd.DataFrame:
+        return summary.loc[self._fitted_summary_mask(summary)].reset_index(drop=True)
+
+    # ------------------------------------------------------------------
+    def _refine_bins_for_policy(
+        self,
+        bin_summary: pd.DataFrame,
+        *,
+        min_er_delta: float,
+        trend: str | None = None,
+        time_col: str | None = None,
+        check_stability: bool = False,
+    ) -> pd.DataFrame:
+        if self.missing_policy != _SEPARATE_BIN_MISSING_POLICY:
+            return refine_bins(
+                bin_summary,
+                min_er_delta=min_er_delta,
+                trend=trend,
+                time_col=time_col,
+                check_stability=check_stability,
+            )
+
+        label_column = "Bin" if "Bin" in bin_summary.columns else "bin"
+        labels = bin_summary[label_column].astype(str).str.strip().str.lower()
+        missing_mask = labels.str.startswith("missing")
+        if not missing_mask.any():
+            return refine_bins(
+                bin_summary,
+                min_er_delta=min_er_delta,
+                trend=trend,
+                time_col=time_col,
+                check_stability=check_stability,
+            )
+
+        parts = []
+        regular = bin_summary.loc[~missing_mask].copy()
+        if not regular.empty:
+            parts.append(
+                refine_bins(
+                    regular,
+                    min_er_delta=min_er_delta,
+                    trend=trend,
+                    time_col=time_col,
+                    check_stability=check_stability,
+                )
+            )
+        missing = bin_summary.loc[missing_mask].copy()
+        if not missing.empty:
+            parts.append(
+                refine_bins(
+                    missing,
+                    min_er_delta=min_er_delta,
+                    trend=None,
+                    time_col=None,
+                    check_stability=False,
+                )
+            )
+        return pd.concat(parts, ignore_index=True) if parts else pd.DataFrame()
+
+    # ------------------------------------------------------------------
     @classmethod
     def _count_regular_bins(cls, summary: pd.DataFrame) -> int:
         return int(cls._regular_bin_mask(summary).sum())
@@ -1125,6 +1338,112 @@ class Binner(BaseEstimator, TransformerMixin):
     def _build_fit_profile(self, X: pd.DataFrame, y: pd.Series) -> pd.DataFrame:
         transformed = self.transform(X, return_type="dataframe")
         return self._build_profile_from_transformed(transformed, y)
+
+    # ------------------------------------------------------------------
+    def _build_missing_audit_from_fit(
+        self,
+        X: pd.DataFrame,
+        y: pd.Series,
+        *,
+        backend: str,
+    ) -> None:
+        feature_columns = list(getattr(self, "feature_names_in_", X.columns))
+        counts = self._pandas_missing_counts(X, feature_columns)
+        transformed = self.transform(X.loc[:, feature_columns], return_type="dataframe")
+        target = pd.to_numeric(pd.Series(y, index=X.index), errors="coerce")
+        profile_records = []
+        decision_records = []
+
+        for variable in feature_columns:
+            n_missing = int(counts.get(str(variable), 0))
+            missing_detected = n_missing > 0
+            missing_mask = X[variable].isna() if variable in X.columns else pd.Series(False, index=X.index)
+            bin_label = None
+            is_missing_bin = False
+            events_missing = None
+            event_rate_missing = None
+            if missing_detected:
+                missing_bins = transformed.loc[missing_mask, variable]
+                unique_labels = list(dict.fromkeys(missing_bins.map(self._bin_label_key).tolist()))
+                if unique_labels:
+                    bin_label = None if unique_labels[0] == "<NA>" else missing_bins.iloc[0]
+                    is_missing_bin = any(self._bin_flag(label, "missing") for label in missing_bins)
+                events_missing = float(target.loc[missing_mask].sum(skipna=True))
+                event_rate_missing = events_missing / n_missing if n_missing else None
+                profile_records.append(
+                    {
+                        "variable": variable,
+                        "policy": self.missing_policy,
+                        "effective_policy": self.missing_policy,
+                        "n_missing_fit": n_missing,
+                        "share_missing_fit": n_missing / len(X) if len(X) else np.nan,
+                        "events_missing_fit": events_missing,
+                        "event_rate_missing_fit": event_rate_missing,
+                        "is_missing_bin": bool(is_missing_bin),
+                        "bin_label": bin_label,
+                        "backend": backend,
+                        "context": "fit",
+                    }
+                )
+
+            if not missing_detected:
+                action = "no_missing_detected"
+            elif self.missing_policy == _SEPARATE_BIN_MISSING_POLICY:
+                action = "separate_bin_created" if is_missing_bin else "separate_bin_requested"
+            elif self.missing_policy == _FORBID_MISSING_POLICY:
+                action = "forbidden_missing_detected"
+            else:
+                action = "standard_behavior_preserved"
+
+            decision_records.append(
+                {
+                    "variable": variable,
+                    "policy_requested": self.missing_policy,
+                    "effective_policy": self.missing_policy,
+                    "missing_detected": bool(missing_detected),
+                    "n_missing_fit": n_missing,
+                    "action": action,
+                    "training_only": True,
+                    "backend": backend,
+                    "notes": (
+                        "Missing values are transformed to an explicit missing bin."
+                        if action == "separate_bin_created"
+                        else (
+                            "Current standard missing behavior was preserved."
+                            if action == "standard_behavior_preserved"
+                            else "No missing values were observed during fit."
+                        )
+                    ),
+                }
+            )
+
+        self.missing_profile_ = pd.DataFrame(profile_records)
+        self.missing_decision_log_ = pd.DataFrame(decision_records)
+        self.missing_policy_ = self.missing_policy
+        self.effective_missing_policy_ = self.missing_policy
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _missing_summary_from_profile(profile: pd.DataFrame | None) -> dict[str, Any]:
+        if profile is None or profile.empty or "is_missing_bin" not in profile.columns:
+            return {
+                "variables_with_missing_bins": 0,
+                "missing_profile_rows": 0,
+                "missing_rows": 0,
+            }
+        missing_rows = profile.loc[profile["is_missing_bin"].fillna(False).astype(bool)]
+        if missing_rows.empty:
+            return {
+                "variables_with_missing_bins": 0,
+                "missing_profile_rows": 0,
+                "missing_rows": 0,
+            }
+        n_values = pd.to_numeric(missing_rows.get("n", pd.Series(dtype=float)), errors="coerce").fillna(0)
+        return {
+            "variables_with_missing_bins": int(missing_rows["variable"].nunique(dropna=False)),
+            "missing_profile_rows": int(len(missing_rows)),
+            "missing_rows": int(n_values.sum()),
+        }
 
     # ------------------------------------------------------------------
     def _build_profile_from_transformed(self, transformed: pd.DataFrame, y: pd.Series) -> pd.DataFrame:
@@ -1534,6 +1853,7 @@ class Binner(BaseEstimator, TransformerMixin):
         profile = getattr(self, "fit_profile_", pd.DataFrame())
         if profile is None:
             profile = pd.DataFrame()
+        missing_summary = self._missing_summary_from_profile(profile)
 
         bin_alerts = []
         variable_status = []
@@ -1633,6 +1953,7 @@ class Binner(BaseEstimator, TransformerMixin):
         return {
             "validation_type": "fit",
             "status": "warning" if warning_count else "ok",
+            "missing_policy": self.missing_policy,
             "settings": settings,
             "summary": {
                 "variables_fitted": int(len(variable_status)),
@@ -1653,6 +1974,7 @@ class Binner(BaseEstimator, TransformerMixin):
                 ),
                 "possible_sample_size_issue": sample_size_issue,
                 "source_profile_status": source_profile_status,
+                **missing_summary,
             },
             "variable_status": variable_status,
             "bin_alerts": bin_alerts,
@@ -1691,6 +2013,7 @@ class Binner(BaseEstimator, TransformerMixin):
                 "validation_type": "transform",
                 "status": "skipped",
                 "backend": backend,
+                "missing_policy": self.missing_policy,
                 "settings": settings,
                 "reason": "target_not_available",
                 "reference_profile_source": getattr(self, "reference_profile_source_", "missing"),
@@ -1700,6 +2023,7 @@ class Binner(BaseEstimator, TransformerMixin):
                 "validation_type": "transform",
                 "status": "warning",
                 "backend": backend,
+                "missing_policy": self.missing_policy,
                 "settings": settings,
                 "reason": "reference_profile_missing",
                 "reference_profile_source": getattr(self, "reference_profile_source_", "missing"),
@@ -1728,11 +2052,13 @@ class Binner(BaseEstimator, TransformerMixin):
             if n_application_rows is not None
             else self._profile_n_rows(application_profile)
         )
+        application_missing_summary = self._missing_summary_from_profile(application_profile)
 
         return {
             "validation_type": "transform",
             "status": status,
             "backend": backend,
+            "missing_policy": self.missing_policy,
             "settings": settings,
             "reference_profile_source": getattr(self, "reference_profile_source_", "missing"),
             "summary": {
@@ -1751,6 +2077,7 @@ class Binner(BaseEstimator, TransformerMixin):
                     if not comparison.empty and comparison["share_abs_diff"].notna().any()
                     else None
                 ),
+                **application_missing_summary,
             },
             "event_rate_status": event_rate_alerts,
             "alerts": alerts,
@@ -2033,6 +2360,10 @@ class Binner(BaseEstimator, TransformerMixin):
         self.validation_report_ = None
         self.application_profile_ = None
         self.source_profile_ = None
+        self.missing_profile_ = pd.DataFrame()
+        self.missing_decision_log_ = pd.DataFrame()
+        self.missing_policy_ = self.missing_policy
+        self.effective_missing_policy_ = self.missing_policy
         self.validation_settings_ = None
         self.sampling_metadata_ = self._pandas_fit_sampling_metadata(len(X))
         self.input_backend_ = "pandas"
@@ -2045,6 +2376,7 @@ class Binner(BaseEstimator, TransformerMixin):
             "n_rows_fit": int(len(X)),
         }
         X_features = X.drop(columns=[time_col], errors="ignore") if time_col else X.copy()
+        self._check_missing_policy_pandas(X_features, selected_features, context="fit")
 
         num_cols, cat_cols = search_dtypes(
             pd.concat([X_features, y.rename("target")], axis=1),
@@ -2085,6 +2417,7 @@ class Binner(BaseEstimator, TransformerMixin):
                 min_event_rate_diff=self.min_event_rate_diff,
                 monotonic=self.monotonic,
                 check_stability=self.check_stability,
+                missing_policy=self.missing_policy,
             )
             self._per_feature_binners = {}
             self.best_params_ = {}
@@ -2125,6 +2458,7 @@ class Binner(BaseEstimator, TransformerMixin):
             self._compute_iv_metrics()
             self._refresh_min_n_bins_metadata()
             self.fit_profile_ = self._build_fit_profile(X_features, y)
+            self._build_missing_audit_from_fit(X_features, y, backend="pandas")
             self._refresh_reference_profile()
             if validate:
                 self.fit_validation_report_ = self._build_fit_validation_report()
@@ -2149,19 +2483,14 @@ class Binner(BaseEstimator, TransformerMixin):
             strat = get_strategy(self.strategy, **self._numeric_strategy_kwargs())
             strat.fit(X_features[[col]], y, monotonic_trend=self.monotonic)
 
-            summary = refine_bins(
+            summary = self._refine_bins_for_policy(
                 strat.bin_summary_,
                 min_er_delta=self.min_event_rate_diff,
                 trend=self.monotonic,
                 time_col=time_col,
                 check_stability=self.check_stability,
             )
-            summary = summary[
-                (summary["count"] > 0)
-                & (~summary["bin"].astype(str).str.lower().isin(["total", "special", "missing"]))
-                & (summary["bin"] != summary["variable"])
-                & (summary["bin"] != "")
-            ].reset_index(drop=True)
+            summary = self._filter_fitted_summary(summary)
             summary = self._prepare_binning_summary(summary)
 
             self._per_feature_binners[col] = strat
@@ -2170,22 +2499,20 @@ class Binner(BaseEstimator, TransformerMixin):
         for col in cat_cols:
             from .strategies.categorical import CategoricalBinning
 
-            strat = CategoricalBinning(max_bins=self.max_bins)
+            strat = CategoricalBinning(
+                max_bins=self.max_bins,
+                separate_missing=self.missing_policy == _SEPARATE_BIN_MISSING_POLICY,
+            )
             strat.fit(X_features[[col]], y)
 
-            summary = refine_bins(
+            summary = self._refine_bins_for_policy(
                 strat.bin_summary_,
                 min_er_delta=self.min_event_rate_diff,
                 trend=None,
                 time_col=None,
                 check_stability=False,
             )
-            summary = summary[
-                (summary["count"] > 0)
-                & (~summary["bin"].astype(str).str.lower().isin(["total", "special", "missing"]))
-                & (summary["bin"] != summary["variable"])
-                & (summary["bin"] != "")
-            ].reset_index(drop=True)
+            summary = self._filter_fitted_summary(summary)
             summary = summary.sort_values("event_rate", ascending=False).reset_index(drop=True)
             summary = self._prepare_binning_summary(summary)
 
@@ -2203,6 +2530,7 @@ class Binner(BaseEstimator, TransformerMixin):
         self._compute_iv_metrics()
         self._refresh_min_n_bins_metadata()
         self.fit_profile_ = self._build_fit_profile(X_features, y)
+        self._build_missing_audit_from_fit(X_features, y, backend="pandas")
         self._refresh_reference_profile()
         if validate:
             self.fit_validation_report_ = self._build_fit_validation_report()
@@ -2251,6 +2579,7 @@ class Binner(BaseEstimator, TransformerMixin):
             copy=copy,
         )
         X = self._coerce_force_numeric_columns(X, columns=selected_columns)
+        self._check_missing_policy_pandas(X, selected_columns, context="transform")
 
         out = {}
         for col in selected_columns:

--- a/riskbands/objectives.py
+++ b/riskbands/objectives.py
@@ -13,9 +13,10 @@ from .temporal_stability import event_rate_by_time, ks_over_time, temporal_separ
 
 EPSILON = 1e-9
 
+STANDARD_SCORE_STRATEGY = "standard"
 LEGACY_SCORE_STRATEGY = "legacy"
 STABLE_SCORE_STRATEGY = "stable"
-DEFAULT_SCORE_STRATEGY = LEGACY_SCORE_STRATEGY
+DEFAULT_SCORE_STRATEGY = STANDARD_SCORE_STRATEGY
 
 STABLE_COMPONENT_TO_WEIGHT = {
     "temporal_variance": "temporal_variance_weight",
@@ -36,8 +37,8 @@ STABLE_WEIGHT_ALIASES = {
 }
 
 
-DEFAULT_LEGACY_OBJECTIVE_CONFIG = {
-    "score_strategy": LEGACY_SCORE_STRATEGY,
+DEFAULT_STANDARD_OBJECTIVE_CONFIG = {
+    "score_strategy": STANDARD_SCORE_STRATEGY,
     "objective_direction": "maximize",
     "base_weights": {
         "separability": 0.35,
@@ -68,6 +69,8 @@ DEFAULT_LEGACY_OBJECTIVE_CONFIG = {
         "min_time_coverage": 0.75,
     },
 }
+
+DEFAULT_LEGACY_OBJECTIVE_CONFIG = deepcopy(DEFAULT_STANDARD_OBJECTIVE_CONFIG)
 
 
 @dataclass(frozen=True)
@@ -183,10 +186,14 @@ def resolve_score_strategy(
     score_strategy: str | None = None,
 ) -> str:
     strategy = score_strategy or (objective_kwargs or {}).get("score_strategy") or DEFAULT_SCORE_STRATEGY
-    if strategy not in {LEGACY_SCORE_STRATEGY, STABLE_SCORE_STRATEGY}:
+    if strategy == LEGACY_SCORE_STRATEGY:
+        return STANDARD_SCORE_STRATEGY
+    if strategy not in {STANDARD_SCORE_STRATEGY, STABLE_SCORE_STRATEGY}:
         raise ValueError(
             f"Unsupported score strategy '{strategy}'. "
-            f"Use '{LEGACY_SCORE_STRATEGY}' or '{STABLE_SCORE_STRATEGY}'."
+            f"Use '{STANDARD_SCORE_STRATEGY}' or '{STABLE_SCORE_STRATEGY}'. "
+            f"'{LEGACY_SCORE_STRATEGY}' is accepted only as a compatibility alias for "
+            f"'{STANDARD_SCORE_STRATEGY}'."
         )
     return strategy
 
@@ -233,7 +240,7 @@ def _resolve_stable_weight_inputs(
 def resolve_legacy_objective_config(
     objective_kwargs: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    config = deepcopy(DEFAULT_LEGACY_OBJECTIVE_CONFIG)
+    config = deepcopy(DEFAULT_STANDARD_OBJECTIVE_CONFIG)
     if objective_kwargs:
         filtered = {
             key: value
@@ -248,7 +255,7 @@ def resolve_legacy_objective_config(
             }
         }
         _deep_update(config, filtered)
-    config["score_strategy"] = LEGACY_SCORE_STRATEGY
+    config["score_strategy"] = STANDARD_SCORE_STRATEGY
     config["objective_direction"] = "maximize"
     return config
 
@@ -300,7 +307,7 @@ def resolve_objective_config(
     woe_shrinkage_strength: float | None = None,
 ) -> dict[str, Any]:
     strategy = resolve_score_strategy(objective_kwargs, score_strategy=score_strategy)
-    if strategy == LEGACY_SCORE_STRATEGY:
+    if strategy == STANDARD_SCORE_STRATEGY:
         return resolve_legacy_objective_config(objective_kwargs)
 
     return resolve_stable_objective_config(
@@ -841,7 +848,7 @@ def build_objective_components(
         normalization_strategy=normalization_strategy,
         woe_shrinkage_strength=woe_shrinkage_strength,
     )
-    if config["score_strategy"] == LEGACY_SCORE_STRATEGY:
+    if config["score_strategy"] == STANDARD_SCORE_STRATEGY:
         return _build_legacy_objective_components(
             binner,
             X,
@@ -897,7 +904,7 @@ def build_objective_components_from_diagnostics(
     if not time_col or time_col not in diagnostics.columns:
         raise ValueError("time_col must be provided or present in diagnostics attrs.")
 
-    if config["score_strategy"] == LEGACY_SCORE_STRATEGY:
+    if config["score_strategy"] == STANDARD_SCORE_STRATEGY:
         pivot = (
             diagnostics.pivot_table(index="bin_code", columns=time_col, values="event_rate")
             .sort_index(axis=1)
@@ -1037,7 +1044,7 @@ def _score_legacy_objective_components(
         "total_penalty": total_penalty,
         "comparison_score": float(score),
         "objective_direction": "maximize",
-        "score_strategy": LEGACY_SCORE_STRATEGY,
+        "score_strategy": STANDARD_SCORE_STRATEGY,
         "components": comps,
         "normalized_components": {},
         "weights": {},
@@ -1153,6 +1160,6 @@ def score_objective_components(
         normalization_strategy=normalization_strategy,
         woe_shrinkage_strength=woe_shrinkage_strength,
     )
-    if config["score_strategy"] == LEGACY_SCORE_STRATEGY:
+    if config["score_strategy"] == STANDARD_SCORE_STRATEGY:
         return _score_legacy_objective_components(components, objective_kwargs=config)
     return _score_stable_objective_components(components, objective_kwargs=config)

--- a/riskbands/optuna_optimizer.py
+++ b/riskbands/optuna_optimizer.py
@@ -17,7 +17,7 @@ import pandas as pd
 
 from .binning_engine import Binner
 from .objectives import (
-    DEFAULT_LEGACY_OBJECTIVE_CONFIG,
+    DEFAULT_STANDARD_OBJECTIVE_CONFIG,
     build_objective_components,
     resolve_objective_config,
     score_objective_components,
@@ -25,7 +25,7 @@ from .objectives import (
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_OBJECTIVE_CONFIG = deepcopy(DEFAULT_LEGACY_OBJECTIVE_CONFIG)
+DEFAULT_OBJECTIVE_CONFIG = deepcopy(DEFAULT_STANDARD_OBJECTIVE_CONFIG)
 
 
 def _flatten_dict(prefix: str, value: Any, out: dict[str, Any]) -> None:
@@ -118,7 +118,7 @@ def optimize_bins(
     """
     Execute Optuna and return the best parameters and fitted binner.
 
-    ``objective_kwargs`` is strategy-aware and can configure either the legacy
+    ``objective_kwargs`` is strategy-aware and can configure either the standard
     score or ``stable`` without coupling the rest of the package to
     Optuna specifics.
     """

--- a/riskbands/reporting.py
+++ b/riskbands/reporting.py
@@ -19,6 +19,7 @@ from .objectives import (
     build_objective_components,
     build_objective_components_from_diagnostics,
     resolve_objective_config,
+    resolve_score_strategy,
     score_objective_components,
 )
 from .temporal_stability import event_rate_by_time, ks_over_time, temporal_separability_score
@@ -99,6 +100,10 @@ OPTIONAL_BUNDLE_PROFILE_FIELDS = (
     "min_n_bins_metadata",
     "validation_settings",
     "data_schema",
+    "missing_policy",
+    "effective_missing_policy",
+    "missing_profile",
+    "missing_decision_log",
 )
 
 
@@ -377,10 +382,12 @@ def _objective_summary_for_variable(
     objective_kwargs: dict[str, Any] | None,
 ) -> tuple[dict[str, Any], str]:
     effective_objective_kwargs = _resolve_effective_objective_kwargs(binner, objective_kwargs)
-    score_strategy = _coalesce_text(
-        (effective_objective_kwargs or {}).get("score_strategy"),
-        getattr(binner, "score_strategy", None),
-        "legacy",
+    score_strategy = resolve_score_strategy(
+        score_strategy=_coalesce_text(
+            (effective_objective_kwargs or {}).get("score_strategy"),
+            getattr(binner, "score_strategy", None),
+            "standard",
+        )
     )
     summaries = getattr(binner, "objective_summaries_", None)
     if isinstance(summaries, dict) and summaries.get(variable):
@@ -394,7 +401,7 @@ def _objective_summary_for_variable(
         return {}, "unavailable"
 
     child_binner = _resolve_child_binner(binner, variable)
-    if score_strategy != "legacy" and diagnostics is not None and not diagnostics.empty:
+    if score_strategy != "standard" and diagnostics is not None and not diagnostics.empty:
         diagnostics_var = diagnostics.loc[diagnostics["variable"] == variable].copy()
         if not diagnostics_var.empty:
             components = build_objective_components_from_diagnostics(
@@ -407,7 +414,7 @@ def _objective_summary_for_variable(
             derived = score_objective_components(components, objective_kwargs=effective_objective_kwargs)
             return derived, "derived_from_diagnostics"
 
-    if score_strategy == "legacy":
+    if score_strategy == "standard":
         transformed = child_binner.transform(X[[variable]])
         bin_values = transformed if isinstance(transformed, pd.Series) else transformed[variable]
         components = {
@@ -468,7 +475,7 @@ def _objective_summary_for_variable(
             components["ks"] = _safe_float(ks_over_time(event_rate_by_time(tbl, "time")))
 
         derived = score_objective_components(components, objective_kwargs=effective_objective_kwargs)
-        return derived, "derived_legacy_objective"
+        return derived, "derived_standard_objective"
 
     cols = [variable]
     if time_col and time_col in X.columns:
@@ -485,7 +492,7 @@ def _objective_summary_for_variable(
     if iv_value is not None:
         components["iv"] = _safe_float(iv_value, default=0.0)
         if (
-            score_strategy != "legacy"
+            score_strategy != "standard"
             and (
                 time_col is None
                 or time_col not in X_eval.columns
@@ -618,7 +625,7 @@ def build_variable_audit_report(
             "score_strategy": _coalesce_text(
                 objective_summary.get("score_strategy"),
                 getattr(binner, "score_strategy", None),
-                "legacy",
+                "standard",
             ),
             "objective_direction": _coalesce_text(
                 objective_summary.get("objective_direction"),
@@ -918,7 +925,13 @@ def build_binner_metadata(
     metadata = {
         "riskbands_version": resolve_version(),
         "strategy": getattr(binner, "strategy", None),
-        "score_strategy": getattr(binner, "score_strategy", None),
+        "score_strategy": resolve_score_strategy(score_strategy=getattr(binner, "score_strategy", None)),
+        "missing_policy": getattr(binner, "missing_policy_", getattr(binner, "missing_policy", "standard")),
+        "effective_missing_policy": getattr(
+            binner,
+            "effective_missing_policy_",
+            getattr(binner, "missing_policy_", getattr(binner, "missing_policy", "standard")),
+        ),
         "objective_direction": objective_direction,
         "normalization_strategy": normalization_strategy,
         "woe_shrinkage_strength": (
@@ -964,6 +977,26 @@ def _collect_optional_bundle_profile_fields(binner: Binner) -> dict[str, Any]:
     return fields
 
 
+def _normalize_loaded_missing_policy(value: Any) -> str:
+    if value is None:
+        return "standard"
+    text = str(value)
+    if text == "legacy":
+        return "standard"
+    if text in {"standard", "separate_bin", "forbid"}:
+        return text
+    return text
+
+
+def _normalize_loaded_score_strategy(value: Any) -> Any:
+    if value is None:
+        return value
+    try:
+        return resolve_score_strategy(score_strategy=str(value))
+    except ValueError:
+        return value
+
+
 def _normalize_loaded_bundle_payload(payload: dict[str, Any]) -> dict[str, Any]:
     normalized = dict(payload)
     normalized.setdefault(
@@ -971,10 +1004,31 @@ def _normalize_loaded_bundle_payload(payload: dict[str, Any]) -> dict[str, Any]:
         str(normalized.get("artifact_version") or LEGACY_BUNDLE_SCHEMA_VERSION),
     )
     metadata = normalized.get("metadata")
+    if isinstance(metadata, dict):
+        metadata = dict(metadata)
+        metadata["score_strategy"] = _normalize_loaded_score_strategy(
+            metadata.get("score_strategy")
+        )
+        metadata["missing_policy"] = _normalize_loaded_missing_policy(
+            metadata.get("missing_policy")
+        )
+        metadata["effective_missing_policy"] = _normalize_loaded_missing_policy(
+            metadata.get("effective_missing_policy", metadata.get("missing_policy"))
+        )
+        normalized["metadata"] = metadata
     if "riskbands_version" not in normalized and isinstance(metadata, dict):
         normalized["riskbands_version"] = metadata.get("riskbands_version")
     for field in OPTIONAL_BUNDLE_PROFILE_FIELDS:
         normalized.setdefault(field, None)
+    normalized["missing_policy"] = _normalize_loaded_missing_policy(
+        normalized.get("missing_policy")
+    )
+    normalized["effective_missing_policy"] = _normalize_loaded_missing_policy(
+        normalized.get("effective_missing_policy", normalized.get("missing_policy"))
+    )
+    if isinstance(metadata, dict):
+        normalized["metadata"]["missing_policy"] = normalized["missing_policy"]
+        normalized["metadata"]["effective_missing_policy"] = normalized["effective_missing_policy"]
     if normalized.get("reference_profile") is None:
         if normalized.get("source_profile") is not None:
             normalized["reference_profile"] = normalized["source_profile"]
@@ -1026,6 +1080,10 @@ def load_bundle(path: PathLike) -> dict[str, Any]:
         "fit_validation_report": manifest.get("fit_validation_report"),
         "transform_validation_report": manifest.get("transform_validation_report"),
         "validation_report": manifest.get("validation_report"),
+        "missing_policy": manifest.get("missing_policy"),
+        "effective_missing_policy": manifest.get("effective_missing_policy"),
+        "missing_profile": manifest.get("missing_profile"),
+        "missing_decision_log": manifest.get("missing_decision_log"),
     }
 
 
@@ -1129,6 +1187,8 @@ def export_binner_bundle(binner: Binner, path: PathLike) -> Path:
     report = binner.report()
     diagnostics = _resolve_optional_table(binner, kind="bin")
     diagnostics_variable = _resolve_optional_table(binner, kind="variable")
+    missing_profile = getattr(binner, "missing_profile_", pd.DataFrame())
+    missing_decision_log = getattr(binner, "missing_decision_log_", pd.DataFrame())
 
     _write_csv(summary, target_dir / "summary.csv")
     _write_csv(score_details, target_dir / "score_details.csv")
@@ -1138,6 +1198,10 @@ def export_binner_bundle(binner: Binner, path: PathLike) -> Path:
         _write_csv(diagnostics, target_dir / "diagnostics.csv")
     if not diagnostics_variable.empty:
         _write_csv(diagnostics_variable, target_dir / "diagnostics_variable.csv")
+    if missing_profile is not None and not missing_profile.empty:
+        _write_csv(missing_profile, target_dir / "missing_profile.csv")
+    if missing_decision_log is not None and not missing_decision_log.empty:
+        _write_csv(missing_decision_log, target_dir / "missing_decision_log.csv")
     _write_csv(report, target_dir / "report.csv")
 
     feature_dir = target_dir / "feature_tables"
@@ -1184,6 +1248,16 @@ def export_binner_bundle(binner: Binner, path: PathLike) -> Path:
             "diagnostics_csv": "diagnostics.csv" if not diagnostics.empty else None,
             "diagnostics_variable_csv": (
                 "diagnostics_variable.csv" if not diagnostics_variable.empty else None
+            ),
+            "missing_profile_csv": (
+                "missing_profile.csv"
+                if missing_profile is not None and not missing_profile.empty
+                else None
+            ),
+            "missing_decision_log_csv": (
+                "missing_decision_log.csv"
+                if missing_decision_log is not None and not missing_decision_log.empty
+                else None
             ),
             "feature_tables": feature_artifacts,
             "optional_parquet": written_optional,
@@ -1253,6 +1327,12 @@ def _save_excel(binner: Binner, path: Path) -> None:
         audit = _resolve_variable_audit_report(binner)
         if audit is not None:
             audit.to_excel(writer, sheet_name="variable_audit", index=False)
+        missing_profile = getattr(binner, "missing_profile_", None)
+        if missing_profile is not None and not missing_profile.empty:
+            missing_profile.to_excel(writer, sheet_name="missing_profile", index=False)
+        missing_decision_log = getattr(binner, "missing_decision_log_", None)
+        if missing_decision_log is not None and not missing_decision_log.empty:
+            missing_decision_log.to_excel(writer, sheet_name="missing_decisions", index=False)
 
 
 # ------------------------------------------------------------------ #
@@ -1273,6 +1353,14 @@ def _save_json(binner: Binner, path: Path) -> None:
         info["objective_summary"] = _json_safe(binner.objective_summary_)
     if getattr(binner, "objective_summaries_", None) is not None:
         info["objective_summaries"] = _json_safe(binner.objective_summaries_)
+    if getattr(binner, "missing_policy_", None) is not None:
+        info["missing_policy"] = _json_safe(binner.missing_policy_)
+    if getattr(binner, "effective_missing_policy_", None) is not None:
+        info["effective_missing_policy"] = _json_safe(binner.effective_missing_policy_)
+    if getattr(binner, "missing_profile_", None) is not None:
+        info["missing_profile"] = _json_safe(binner.missing_profile_)
+    if getattr(binner, "missing_decision_log_", None) is not None:
+        info["missing_decision_log"] = _json_safe(binner.missing_decision_log_)
     pivot = getattr(binner, "_pivot_", None)
     if pivot is not None:
         info["pivot_event_rate"] = _json_ready_records(pivot.reset_index())

--- a/riskbands/strategies/categorical.py
+++ b/riskbands/strategies/categorical.py
@@ -20,10 +20,14 @@ class CategoricalBinning:
         rare_threshold: float = 0.01,
         max_bins: int = 6,
         min_bin_size: float = 0.05,
+        separate_missing: bool = False,
+        missing_bin_label: str = "Missing",
     ):
         self.rare_threshold = rare_threshold
         self.max_bins = max_bins
         self.min_bin_size = min_bin_size
+        self.separate_missing = bool(separate_missing)
+        self.missing_bin_label_ = missing_bin_label
         # Sentinel labels are categorical values, not secrets.
         self.missing_token_ = "_MISSING_"  # nosec B105
         self.rare_token_ = "_RARE_"  # nosec B105
@@ -70,6 +74,8 @@ class CategoricalBinning:
 
         prepared = normalized.mask(normalized.isin(self._rare_categories_set_), self.rare_token_)
         known = prepared.isin(self._known_categories_set_)
+        if self.separate_missing:
+            known |= prepared == self.missing_token_
         prepared = prepared.where(known, self.unknown_token_)
         return prepared.rename(getattr(self, "feature_name_", col))
 
@@ -95,7 +101,7 @@ class CategoricalBinning:
         col = self.feature_name_
         df = pd.DataFrame({"bin": codes.to_numpy(), "target": y.to_numpy()}, index=codes.index)
         summary = (
-            df.groupby("bin", sort=True, dropna=False)["target"]
+            df.groupby("bin", sort=False, dropna=False)["target"]
             .agg(count="count", event="sum")
             .reset_index()
         )
@@ -135,24 +141,39 @@ class CategoricalBinning:
 
         stats["non_event"] = stats["count"] - stats["event"]
         stats["event_rate"] = stats["event"] / stats["count"]
-        stats = stats.sort_values(
+        fit_stats = stats
+        if self.separate_missing:
+            fit_stats = stats.loc[stats["category"] != self.missing_token_].copy()
+
+        fit_stats = fit_stats.sort_values(
             by=["event_rate", "category"],
             ascending=[True, True],
             kind="mergesort",
         ).reset_index(drop=True)
 
-        max_bins = int(self.max_bins) if self.max_bins else len(stats)
-        n_bins = max(1, min(max_bins, len(stats)))
-        stats["bin"] = (stats.index.to_series() * n_bins // len(stats)).astype(int)
+        if fit_stats.empty:
+            mapping = {self.missing_token_: self.missing_bin_label_}
+            codes = prepared.map(mapping).fillna(self.missing_bin_label_).rename(self.feature_name_)
+            summary = self._build_summary_from_codes(codes, y)
+            default_bin = self.missing_bin_label_
+        else:
+            max_bins = int(self.max_bins) if self.max_bins else len(fit_stats)
+            n_bins = max(1, min(max_bins, len(fit_stats)))
+            fit_stats["bin"] = (fit_stats.index.to_series() * n_bins // len(fit_stats)).astype(int)
 
-        mapping = dict(zip(stats["category"], stats["bin"], strict=False))
-        codes = prepared.map(mapping).rename(self.feature_name_)
-        summary = self._build_summary_from_codes(codes, y)
-        default_bin = self._select_default_bin(summary)
+            mapping = dict(zip(fit_stats["category"], fit_stats["bin"], strict=False))
+            if self.separate_missing:
+                mapping[self.missing_token_] = self.missing_bin_label_
+            codes = prepared.map(mapping).rename(self.feature_name_)
+            summary = self._build_summary_from_codes(codes, y)
+            regular_summary = summary.loc[summary["bin"].astype(str) != self.missing_bin_label_]
+            default_bin = self._select_default_bin(regular_summary if not regular_summary.empty else summary)
 
         mapping = self._expand_rare_category_mapping(mapping)
         mapping[self.unknown_token_] = default_bin
-        if self.missing_token_ not in mapping:
+        if self.separate_missing:
+            mapping[self.missing_token_] = self.missing_bin_label_
+        elif self.missing_token_ not in mapping:
             mapping[self.missing_token_] = default_bin
 
         self.category_mapping_ = mapping
@@ -212,6 +233,10 @@ class CategoricalBinning:
         prepared = self._prepare_series(X, fit=True)
         target = self._coerce_target(y, prepared.index)
 
+        if self.separate_missing:
+            self._fit_manual(prepared, target, reason="separate_missing_policy")
+            return self
+
         try:
             codes, ob = self._fit_optimal_binning(prepared, target)
             self._encoder = (ob, "optimal")
@@ -238,5 +263,8 @@ class CategoricalBinning:
             codes = prepared.map(encoder).fillna(self.default_bin_).rename(self.feature_name_)
         else:  # pragma: no cover - defensive guard for old serialized objects.
             raise RuntimeError("Tipo de encoder desconhecido.")
+
+        if self.separate_missing:
+            codes = codes.where(prepared != self.missing_token_, self.missing_bin_label_)
 
         return pd.DataFrame({self.feature_name_: codes}, index=prepared.index)

--- a/tests/test_api_usability.py
+++ b/tests/test_api_usability.py
@@ -129,8 +129,8 @@ def test_summary_report_and_diagnostics_methods_are_friendly_aliases(demo_df: pd
     assert not report.empty
     assert not diagnostics.empty
     assert not variable_diagnostics.empty
-    assert report.iloc[0]["score_strategy"] == "legacy"
-    assert summary.iloc[0]["score_strategy"] == "legacy"
+    assert report.iloc[0]["score_strategy"] == "standard"
+    assert summary.iloc[0]["score_strategy"] == "standard"
 
 
 def test_score_table_audit_table_and_metadata_expose_effective_weights(demo_df: pd.DataFrame):
@@ -201,4 +201,4 @@ def test_plotly_notebook_exists_and_references_the_friendly_api():
     assert "fit(" in text
     assert "summary()" in text
     assert "stable" in text
-    assert "legacy" in text
+    assert "standard" in text

--- a/tests/test_missing_policy_bundle_persistence.py
+++ b/tests/test_missing_policy_bundle_persistence.py
@@ -1,0 +1,98 @@
+import json
+
+import pandas as pd
+
+from riskbands import RiskBands
+from riskbands.reporting import load_bundle, load_bundle_metadata
+from tests.test_missing_values_current_behavior import make_categorical_missing_frame, make_numeric_missing_frame
+
+
+def test_bundle_roundtrip_persists_standard_missing_policy(tmp_path):
+    df = make_numeric_missing_frame()
+    binner = RiskBands(missing_policy="standard", max_bins=3, min_event_rate_diff=0.0).fit(
+        df,
+        y="target",
+        column="score",
+    )
+
+    binner.export_bundle(tmp_path / "bundle")
+    loaded = load_bundle(tmp_path / "bundle")
+
+    assert loaded["missing_policy"] == "standard"
+    assert loaded["effective_missing_policy"] == "standard"
+    assert loaded["missing_decision_log"]
+
+
+def test_bundle_roundtrip_persists_separate_bin_missing_audit(tmp_path):
+    df = make_categorical_missing_frame()
+    binner = RiskBands(
+        missing_policy="separate_bin",
+        force_categorical=["grade"],
+        max_bins=4,
+        min_event_rate_diff=0.0,
+    ).fit(df, y="target", column="grade", validate=True)
+
+    binner.export_bundle(tmp_path / "bundle")
+    loaded = load_bundle(tmp_path / "bundle")
+
+    assert loaded["missing_policy"] == "separate_bin"
+    assert loaded["effective_missing_policy"] == "separate_bin"
+    assert loaded["missing_profile"][0]["bin_label"] == "Missing"
+    assert loaded["missing_decision_log"][0]["action"] == "separate_bin_created"
+    assert (tmp_path / "bundle" / "missing_profile.csv").exists()
+    assert (tmp_path / "bundle" / "missing_decision_log.csv").exists()
+
+
+def test_bundle_roundtrip_persists_forbid_without_missing(tmp_path):
+    df = pd.DataFrame({"score": [1.0, 2.0, 3.0, 4.0] * 8, "target": [0, 0, 1, 1] * 8})
+    binner = RiskBands(missing_policy="forbid", max_bins=2, min_event_rate_diff=0.0).fit(
+        df,
+        y="target",
+        column="score",
+    )
+
+    binner.export_bundle(tmp_path / "bundle")
+    loaded = load_bundle_metadata(tmp_path / "bundle")
+
+    assert loaded["missing_policy"] == "forbid"
+    assert loaded["missing_profile"] == []
+    assert loaded["missing_decision_log"][0]["action"] == "no_missing_detected"
+
+
+def test_old_bundle_without_missing_fields_loads_as_standard(tmp_path):
+    bundle_dir = tmp_path / "old_bundle"
+    bundle_dir.mkdir()
+    (bundle_dir / "metadata.json").write_text(
+        json.dumps({"artifact_type": "riskbands_audit_bundle", "artifact_version": "1.0", "metadata": {}}),
+        encoding="utf-8",
+    )
+
+    loaded = load_bundle_metadata(bundle_dir)
+
+    assert loaded["missing_policy"] == "standard"
+    assert loaded["effective_missing_policy"] == "standard"
+    assert loaded["missing_profile"] is None
+    assert loaded["missing_decision_log"] is None
+
+
+def test_old_bundle_with_legacy_missing_policy_loads_as_standard(tmp_path):
+    bundle_dir = tmp_path / "old_bundle"
+    bundle_dir.mkdir()
+    (bundle_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "artifact_type": "riskbands_audit_bundle",
+                "artifact_version": "1.0",
+                "missing_policy": "legacy",
+                "effective_missing_policy": "legacy",
+                "metadata": {"missing_policy": "legacy"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = load_bundle_metadata(bundle_dir)
+
+    assert loaded["missing_policy"] == "standard"
+    assert loaded["effective_missing_policy"] == "standard"
+    assert loaded["metadata"]["missing_policy"] == "standard"

--- a/tests/test_missing_policy_forbid.py
+++ b/tests/test_missing_policy_forbid.py
@@ -1,0 +1,117 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from riskbands import RiskBands
+
+pytest_plugins = ["tests.test_missing_values_pyspark_current_behavior"]
+
+
+def test_forbid_pandas_numeric_missing_fit_raises():
+    df = pd.DataFrame({"score": [1.0, np.nan, 3.0], "target": [0, 1, 0]})
+
+    with pytest.raises(ValueError, match="missing_policy='forbid'.*fit.*score=1"):
+        RiskBands(missing_policy="forbid").fit(df, y="target", column="score")
+
+
+def test_forbid_pandas_categorical_missing_fit_raises():
+    df = pd.DataFrame({"grade": ["A", None, "B"], "target": [0, 1, 0]})
+
+    with pytest.raises(ValueError, match="missing_policy='forbid'.*grade=1"):
+        RiskBands(missing_policy="forbid", force_categorical=["grade"]).fit(
+            df,
+            y="target",
+            column="grade",
+        )
+
+
+def test_forbid_pandas_transform_missing_raises():
+    df = pd.DataFrame({"score": [1.0, 2.0, 3.0, 4.0] * 8, "target": [0, 0, 1, 1] * 8})
+    binner = RiskBands(missing_policy="forbid", max_bins=2, min_event_rate_diff=0.0).fit(
+        df,
+        y="target",
+        column="score",
+    )
+
+    with pytest.raises(ValueError, match="missing_policy='forbid'.*transform.*score=1"):
+        binner.transform(pd.DataFrame({"score": [1.0, np.nan]}))
+
+
+def test_forbid_without_missing_fits_and_transforms():
+    df = pd.DataFrame({"score": [1.0, 2.0, 3.0, 4.0] * 8, "target": [0, 0, 1, 1] * 8})
+    binner = RiskBands(missing_policy="forbid", max_bins=2, min_event_rate_diff=0.0).fit(
+        df,
+        y="target",
+        column="score",
+    )
+
+    transformed = binner.transform(df[["score"]])
+
+    assert transformed.shape == (len(df), 1)
+    assert binner.missing_policy_ == "forbid"
+
+
+def test_standard_does_not_raise_on_missing():
+    df = pd.DataFrame({"score": [1.0, np.nan, 3.0, 4.0] * 8, "target": [0, 1, 0, 1] * 8})
+
+    binner = RiskBands(missing_policy="standard", max_bins=2, min_event_rate_diff=0.0).fit(
+        df,
+        y="target",
+        column="score",
+    )
+
+    assert "Missing" in set(binner.transform(df[["score"]])["score"])
+
+
+@pytest.mark.spark
+def test_forbid_spark_numeric_null_and_nan_fit_raises(spark_session):
+    from pyspark.sql import types as T
+
+    schema = T.StructType(
+        [
+            T.StructField("score", T.DoubleType(), True),
+            T.StructField("target", T.IntegerType(), True),
+        ]
+    )
+    sdf = spark_session.createDataFrame([(1.0, 0), (None, 1), (float("nan"), 0)], schema=schema)
+
+    with pytest.raises(ValueError, match="pyspark.*score=2"):
+        RiskBands(missing_policy="forbid").fit(sdf, y="target", column="score")
+
+
+@pytest.mark.spark
+def test_forbid_spark_categorical_null_fit_raises(spark_session):
+    from pyspark.sql import types as T
+
+    schema = T.StructType(
+        [
+            T.StructField("grade", T.StringType(), True),
+            T.StructField("target", T.IntegerType(), True),
+        ]
+    )
+    sdf = spark_session.createDataFrame([("A", 0), (None, 1), ("B", 0)], schema=schema)
+
+    with pytest.raises(ValueError, match="pyspark.*grade=1"):
+        RiskBands(missing_policy="forbid", force_categorical=["grade"]).fit(
+            sdf,
+            y="target",
+            column="grade",
+        )
+
+
+@pytest.mark.spark
+def test_forbid_pandas_fit_spark_numeric_null_and_nan_transform_raises(spark_session):
+    from pyspark.sql import types as T
+
+    df = pd.DataFrame({"score": [1.0, 2.0, 3.0, 4.0] * 8, "target": [0, 0, 1, 1] * 8})
+    binner = RiskBands(missing_policy="forbid", max_bins=2, min_event_rate_diff=0.0).fit(
+        df,
+        y="target",
+        column="score",
+    )
+
+    schema = T.StructType([T.StructField("score", T.DoubleType(), True)])
+    sdf = spark_session.createDataFrame([(1.0,), (None,), (float("nan"),)], schema=schema)
+
+    with pytest.raises(ValueError, match="missing_policy='forbid'.*transform.*pyspark.*score=2"):
+        binner.transform(sdf, column="score")

--- a/tests/test_missing_policy_parameter.py
+++ b/tests/test_missing_policy_parameter.py
@@ -1,0 +1,44 @@
+import pytest
+
+from riskbands import Binner, RiskBands
+from tests.test_missing_values_current_behavior import fit_categorical_missing_binner
+
+
+def test_missing_policy_default_is_standard():
+    binner = RiskBands()
+
+    assert binner.missing_policy == "standard"
+    assert binner.missing_policy_ == "standard"
+    assert binner.get_params()["missing_policy"] == "standard"
+
+
+@pytest.mark.parametrize("policy", ["standard", "separate_bin", "forbid"])
+def test_missing_policy_accepts_supported_values(policy):
+    binner = Binner(missing_policy=policy)
+
+    assert binner.missing_policy == policy
+    assert binner.missing_policy_ == policy
+
+
+def test_missing_policy_rejects_invalid_value():
+    with pytest.raises(ValueError, match="Unsupported missing_policy"):
+        RiskBands(missing_policy="merge_nearest_woe")
+
+
+def test_missing_policy_is_available_through_riskbands_alias():
+    assert RiskBands is Binner
+    assert RiskBands(missing_policy="separate_bin").missing_policy == "separate_bin"
+
+
+def test_standard_missing_policy_preserves_categorical_current_behavior():
+    binner, df = fit_categorical_missing_binner()
+    standard = RiskBands(
+        strategy="supervised",
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        force_categorical=["grade"],
+        missing_policy="standard",
+    )
+    standard.fit(df, y="target", column="grade")
+
+    assert standard.transform(df[["grade"]]).equals(binner.transform(df[["grade"]]))

--- a/tests/test_missing_policy_reporting.py
+++ b/tests/test_missing_policy_reporting.py
@@ -1,0 +1,51 @@
+import json
+
+from riskbands import RiskBands
+from tests.test_missing_values_current_behavior import make_categorical_missing_frame, make_numeric_missing_frame
+
+
+def test_missing_policy_reporting_exposes_missing_profile_and_decisions(tmp_path):
+    df = make_categorical_missing_frame()
+    binner = RiskBands(
+        force_categorical=["grade"],
+        missing_policy="separate_bin",
+        min_event_rate_diff=0.0,
+    ).fit(df, y="target", column="grade", validate=True)
+
+    bundle_dir = tmp_path / "bundle"
+    binner.export_bundle(bundle_dir)
+
+    assert not binner.missing_profile_.empty
+    assert not binner.missing_decision_log_.empty
+    assert (bundle_dir / "missing_profile.csv").exists()
+    assert (bundle_dir / "missing_decision_log.csv").exists()
+    assert binner.fit_validation_report_["summary"]["variables_with_missing_bins"] == 1
+
+
+def test_save_report_json_contains_missing_policy_fields(tmp_path):
+    df = make_numeric_missing_frame()
+    binner = RiskBands(missing_policy="separate_bin", min_event_rate_diff=0.0).fit(
+        df,
+        y="target",
+        column="score",
+    )
+    path = tmp_path / "report.json"
+
+    binner.save_report(path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+
+    assert payload["missing_policy"] == "separate_bin"
+    assert payload["effective_missing_policy"] == "separate_bin"
+    assert payload["missing_profile"][0]["bin_label"] == "Missing"
+
+
+def test_standard_reporting_preserves_missing_out_of_bin_summary():
+    df = make_numeric_missing_frame()
+    binner = RiskBands(missing_policy="standard", min_event_rate_diff=0.0).fit(
+        df,
+        y="target",
+        column="score",
+    )
+
+    assert "Missing" not in set(binner.bin_summary["bin"].astype(str))
+    assert "Missing" in set(binner.fit_profile_["bin_label"].astype(str))

--- a/tests/test_missing_policy_separate_bin_pandas.py
+++ b/tests/test_missing_policy_separate_bin_pandas.py
@@ -1,0 +1,92 @@
+import numpy as np
+import pandas as pd
+
+from riskbands import RiskBands
+from tests.test_missing_values_current_behavior import (
+    fit_categorical_missing_binner,
+    make_categorical_missing_frame,
+    make_numeric_missing_frame,
+)
+
+
+def test_separate_bin_numeric_missing_is_explicit_in_profile_and_summary():
+    df = make_numeric_missing_frame()
+    binner = RiskBands(max_bins=3, min_event_rate_diff=0.0, missing_policy="separate_bin")
+
+    binner.fit(df, y="target", column="score", validate=True)
+
+    transformed = binner.transform(df[["score"]])
+    missing_profile = binner.fit_profile_.loc[binner.fit_profile_["is_missing_bin"]]
+    assert set(transformed.loc[df["score"].isna(), "score"]) == {"Missing"}
+    assert len(missing_profile) == 1
+    assert "Missing" in set(binner.bin_summary["bin"].astype(str))
+    assert binner.fit_validation_report_["summary"]["variables_with_missing_bins"] == 1
+
+
+def test_separate_bin_categorical_missing_does_not_use_regular_default_bin():
+    df = make_categorical_missing_frame()
+    binner = RiskBands(
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        force_categorical=["grade"],
+        missing_policy="separate_bin",
+    )
+
+    binner.fit(df, y="target", column="grade", validate=True)
+    transformed = binner.transform(df[["grade"]])
+
+    assert set(transformed.loc[df["grade"].isna(), "grade"]) == {"Missing"}
+    missing_profile = binner.fit_profile_.loc[binner.fit_profile_["is_missing_bin"]]
+    assert len(missing_profile) == 1
+    assert bool(missing_profile.iloc[0]["is_regular_bin"]) is False
+    assert "Missing" in set(binner.get_bin_mapping("grade")["bin"].astype(str))
+    regular_labels = set(binner.fit_profile_.loc[binner.fit_profile_["is_regular_bin"], "bin_label"].astype(str))
+    assert "Missing" not in regular_labels
+
+
+def test_separate_bin_categorical_new_missing_in_transform_validate_is_visible():
+    df = pd.DataFrame({"grade": ["A", "B", "C", "D"] * 10, "target": [0, 1, 1, 0] * 10})
+    binner = RiskBands(
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        force_categorical=["grade"],
+        missing_policy="separate_bin",
+    ).fit(df, y="target", column="grade", validate=True)
+    app = pd.DataFrame({"grade": [None, np.nan, "A", "Z"], "target": [1, 0, 0, 1]})
+
+    transformed = binner.transform(app, column="grade", validate=True)
+    missing_profile = binner.application_profile_.loc[binner.application_profile_["is_missing_bin"]]
+
+    assert transformed.loc[[0, 1], "grade"].tolist() == ["Missing", "Missing"]
+    assert len(missing_profile) == 1
+    assert int(missing_profile.iloc[0]["n"]) == 2
+    assert binner.transform_validation_report_["summary"]["variables_with_missing_bins"] == 1
+
+
+def test_standard_categorical_missing_behavior_remains_current():
+    standard, df = fit_categorical_missing_binner()
+    explicit_standard = RiskBands(
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        force_categorical=["grade"],
+        missing_policy="standard",
+    ).fit(df, y="target", column="grade")
+
+    assert explicit_standard.transform(df[["grade"]]).equals(standard.transform(df[["grade"]]))
+    assert explicit_standard.fit_profile_.loc[explicit_standard.fit_profile_["is_missing_bin"]].empty
+
+
+def test_separate_bin_decision_log_records_training_only_action():
+    df = make_categorical_missing_frame()
+    binner = RiskBands(
+        force_categorical=["grade"],
+        missing_policy="separate_bin",
+        min_event_rate_diff=0.0,
+    ).fit(df, y="target", column="grade")
+
+    row = binner.missing_decision_log_.iloc[0]
+
+    assert row["variable"] == "grade"
+    assert row["action"] == "separate_bin_created"
+    assert bool(row["training_only"]) is True
+    assert binner.missing_profile_.iloc[0]["bin_label"] == "Missing"

--- a/tests/test_missing_policy_separate_bin_pyspark.py
+++ b/tests/test_missing_policy_separate_bin_pyspark.py
@@ -1,0 +1,85 @@
+from collections import Counter
+
+import pytest
+
+from riskbands import RiskBands
+from tests.test_missing_values_current_behavior import make_categorical_missing_frame, make_numeric_missing_frame
+from tests.test_missing_values_pyspark_current_behavior import install_to_pandas_guard
+
+pytestmark = pytest.mark.spark
+pytest_plugins = ["tests.test_missing_values_pyspark_current_behavior"]
+
+
+def test_separate_bin_pandas_fit_spark_categorical_null_is_missing(spark_session):
+    binner = RiskBands(
+        force_categorical=["grade"],
+        missing_policy="separate_bin",
+        min_event_rate_diff=0.0,
+    ).fit(make_categorical_missing_frame(), y="target", column="grade")
+    from pyspark.sql import types as T
+
+    schema = T.StructType(
+        [
+            T.StructField("grade", T.StringType(), True),
+            T.StructField("target", T.IntegerType(), True),
+        ]
+    )
+    sdf = spark_session.createDataFrame([(None, 1), ("A", 0), ("Z", 1)], schema=schema)
+
+    transformed = binner.transform(sdf, column="grade")
+    observed = transformed.toPandas()["grade"].tolist()
+
+    assert transformed.__class__.__module__.startswith("pyspark")
+    assert Counter(observed)["Missing"] == 1
+
+
+def test_separate_bin_pandas_fit_spark_numeric_null_and_nan_are_missing(spark_session):
+    binner = RiskBands(missing_policy="separate_bin", min_event_rate_diff=0.0).fit(
+        make_numeric_missing_frame(),
+        y="target",
+        column="score",
+    )
+    from pyspark.sql import types as T
+
+    schema = T.StructType(
+        [
+            T.StructField("score", T.DoubleType(), True),
+            T.StructField("target", T.IntegerType(), True),
+        ]
+    )
+    sdf = spark_session.createDataFrame([(None, 0), (float("nan"), 1), (1.0, 0)], schema=schema)
+
+    observed = binner.transform(sdf, column="score").toPandas()["score"].tolist()
+
+    assert Counter(observed)["Missing"] == 2
+
+
+def test_separate_bin_spark_fit_and_validate_keeps_aggregate_collection_guard(spark_session, monkeypatch):
+    from pyspark.sql import types as T
+
+    rows = [(None if idx % 7 == 0 else ("A" if idx % 2 == 0 else "B"), int(idx % 3 == 0)) for idx in range(80)]
+    schema = T.StructType(
+        [
+            T.StructField("grade", T.StringType(), True),
+            T.StructField("target", T.IntegerType(), True),
+        ]
+    )
+    sdf = spark_session.createDataFrame(rows, schema=schema).repartition(2)
+
+    binner = RiskBands(
+        force_categorical=["grade"],
+        missing_policy="separate_bin",
+        min_event_rate_diff=0.0,
+        sample_size=80,
+    ).fit(sdf, y="target", column="grade", validate=True)
+    calls = install_to_pandas_guard(monkeypatch, max_rows=30)
+
+    transformed = binner.transform(sdf, column="grade", validate=True)
+    missing_rows = binner.application_profile_.loc[binner.application_profile_["is_missing_bin"]]
+
+    assert transformed.__class__.__module__.startswith("pyspark")
+    assert calls
+    assert max(call["rows"] for call in calls) <= 30
+    assert len(missing_rows) == 1
+    assert missing_rows.iloc[0]["bin_label"] == "Missing"
+    assert binner.transform_validation_report_["backend"] == "pyspark"

--- a/tests/test_missing_values_bundle_current_behavior.py
+++ b/tests/test_missing_values_bundle_current_behavior.py
@@ -38,7 +38,7 @@ def test_bundle_roundtrip_preserves_existing_numeric_missing_profiles(tmp_path):
     assert manifest["validation_report"]["validation_type"] == "transform"
 
 
-def test_bundle_has_no_dedicated_missing_policy_schema_current_behavior(tmp_path):
+def test_bundle_has_standard_missing_policy_schema_current_behavior(tmp_path):
     binner, _ = fit_numeric_missing_binner(validate=True)
     bundle_dir = tmp_path / "bundle"
 
@@ -47,9 +47,12 @@ def test_bundle_has_no_dedicated_missing_policy_schema_current_behavior(tmp_path
     manifest = loaded["manifest"]
     metadata = manifest["metadata"]
 
-    for key in ("missing_policy", "effective_missing_policy", "missing_decision_log", "missing_profile"):
-        assert key not in manifest
-        assert key not in metadata
+    assert manifest["missing_policy"] == "standard"
+    assert manifest["effective_missing_policy"] == "standard"
+    assert metadata["missing_policy"] == "standard"
+    assert metadata["effective_missing_policy"] == "standard"
+    assert manifest["missing_profile"][0]["bin_label"] == "Missing"
+    assert manifest["missing_decision_log"][0]["action"] == "standard_behavior_preserved"
 
 
 def test_exporting_bundle_does_not_change_numeric_missing_transform_behavior(tmp_path):

--- a/tests/test_stable_score.py
+++ b/tests/test_stable_score.py
@@ -75,7 +75,7 @@ def _fit_reference_binner(X: pd.DataFrame, y: pd.Series, *, score_strategy: str 
     return binner
 
 
-def test_legacy_strategy_remains_default_and_maximization_oriented():
+def test_standard_strategy_remains_default_and_maximization_oriented():
     stable_components = {
         "iv": 0.25,
         "separability": 0.30,
@@ -104,7 +104,7 @@ def test_legacy_strategy_remains_default_and_maximization_oriented():
     stable_score = score_objective_components(stable_components)
     unstable_score = score_objective_components(unstable_components)
 
-    assert stable_score["score_strategy"] == "legacy"
+    assert stable_score["score_strategy"] == "standard"
     assert stable_score["objective_direction"] == "maximize"
     assert stable_score["score"] > unstable_score["score"]
 

--- a/tests/test_standard_aliases.py
+++ b/tests/test_standard_aliases.py
@@ -1,0 +1,81 @@
+import json
+
+import pandas as pd
+
+from riskbands import Binner
+from riskbands.objectives import resolve_score_strategy, score_objective_components
+from riskbands.reporting import load_bundle_metadata
+
+
+def test_score_strategy_standard_is_canonical_default():
+    binner = Binner()
+
+    assert binner.score_strategy == "standard"
+    assert binner.get_params()["score_strategy"] == "standard"
+    assert resolve_score_strategy(score_strategy="standard") == "standard"
+    assert score_objective_components({"iv": 0.1})["score_strategy"] == "standard"
+
+
+def test_score_strategy_legacy_is_compatibility_alias():
+    binner = Binner(score_strategy="legacy")
+
+    assert binner.score_strategy == "standard"
+    assert binner.get_params()["score_strategy"] == "standard"
+    assert resolve_score_strategy(score_strategy="legacy") == "standard"
+
+
+def test_set_params_normalizes_legacy_score_strategy_alias():
+    binner = Binner(score_strategy="stable")
+
+    binner.set_params(score_strategy="legacy")
+
+    assert binner.score_strategy == "standard"
+
+
+def test_new_bundle_exports_standard_score_strategy(tmp_path):
+    df = pd.DataFrame({"score": [-2, -1, 0, 1, 2, 3] * 10, "target": [0, 0, 0, 1, 1, 1] * 10})
+    binner = Binner(max_bins=3, min_event_rate_diff=0.0, score_strategy="legacy")
+    binner.fit(df, y="target", column="score")
+
+    binner.export_bundle(tmp_path / "bundle")
+    loaded = load_bundle_metadata(tmp_path / "bundle")
+
+    assert loaded["metadata"]["score_strategy"] == "standard"
+
+
+def test_derived_standard_objective_source_uses_public_standard_name():
+    df = pd.DataFrame({"score": [-2, -1, 0, 1, 2, 3] * 10, "target": [0, 0, 0, 1, 1, 1] * 10})
+    X = df[["score"]]
+    y = df["target"]
+    binner = Binner(max_bins=3, min_event_rate_diff=0.0, score_strategy="legacy").fit(
+        X,
+        y=y,
+        column="score",
+    )
+    binner.objective_summary_ = None
+    binner.objective_summaries_ = None
+
+    report = binner.variable_audit_report(X, y)
+
+    assert report.iloc[0]["score_strategy"] == "standard"
+    assert report.iloc[0]["objective_source"] == "derived_standard_objective"
+    assert "derived_legacy_objective" not in set(report["objective_source"])
+
+
+def test_old_bundle_score_strategy_legacy_loads_as_standard(tmp_path):
+    bundle_dir = tmp_path / "old_bundle"
+    bundle_dir.mkdir()
+    (bundle_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "artifact_type": "riskbands_audit_bundle",
+                "artifact_version": "1.0",
+                "metadata": {"score_strategy": "legacy"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = load_bundle_metadata(bundle_dir)
+
+    assert loaded["metadata"]["score_strategy"] == "standard"


### PR DESCRIPTION
Adds missing_policy='standard', 'separate_bin', and 'forbid'; standardizes legacy naming to standard with compatibility; persists missing audit profiles/logs; and adds pandas/PySpark tests, bundle coverage, reporting updates, and documentation.