### PR TITLE
Prepare RiskBands v2.2.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,25 @@ Bundles novos persistem `missing_policy`, `effective_missing_policy`,
 `missing_profile` e `missing_decision_log`. Bundles antigos sem esses campos
 carregam como `standard`.
 
+## Destaques da versao 2.2.0
+
+A versao 2.2.0 consolida a politica auditavel de missing values:
+
+- `missing_policy="standard"` permanece como default compativel.
+- `missing_policy="separate_bin"` cria bin explicito `Missing` quando essa escolha
+  for intencional.
+- `missing_policy="forbid"` falha quando missing values devem ser tratados antes
+  do binning.
+- `standard` e o nome canonico do score historico; `legacy` segue como alias
+  compativel.
+- pandas e PySpark seguem suportados, com PySpark opcional via
+  `riskbands[spark]` e restrito a `pyspark>=3.5,<4`.
+- bundles antigos seguem carregando como `standard` quando nao possuem os novos
+  campos de missing policy.
+
+Fora do escopo desta versao: merge policies, imputacao inteligente opaca e um
+backend Spark distribuido completo para fitting.
+
 ## Export auditavel e supply chain
 
 `export_bundle(...)` gera artefatos tabulares e JSON para auditoria. Nomes de

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,67 +4,72 @@
 
 - Project: `RiskBands`
 - Distribution: `riskbands`
-- Repository version: `2.1.0`
-- Planned release tag: `v2.1.0`
+- Repository version: `2.2.0`
+- Planned release tag: `v2.2.0`
 - Default branch: `main`
-- Status: prepared for v2.1.0 publication.
+- Preparation branch: `release/v2.2.0-prep`
+- Status: prepared for v2.2.0 publication after local validation.
 
-## 2.1.0 Release Notes
+No PyPI upload, TestPyPI upload, tag creation, or push is performed by Sprint C.
 
-Type: compatible minor release.
+## 2.2.0 Release Notes
+
+Type: compatible minor release preparation.
 
 ### Added
 
-- `RiskBands` as the preferred public name for the main estimator.
-- `Binner` remains available as a compatible alias.
-- `min_n_bins` as a soft, auditable quality rule.
-- `sample_size` for controlled PySpark fit sampling.
-- Automatic pandas/PySpark backend detection in `fit` and `transform`.
-- DataFrame type preservation: pandas inputs return pandas outputs, PySpark inputs return PySpark outputs.
-- `fit(validate=True)` with fit profiles, uncertainty diagnostics, `min_n_bins` status, sample/source comparison when available, and `fit_validation_report_`.
-- `transform(validate=True)` with application profiles compared against a stored `reference_profile` and `transform_validation_report_`.
-- v2.1.0 bundle metadata with fit/source/reference/application profiles, separate validation reports, backend metadata, sampling metadata, `min_n_bins` metadata, validation settings, and data schema when available.
-- Optional `spark` extra for PySpark support.
+- `missing_policy="standard"` as the default missing-value policy, preserving the Sprint A baseline behavior.
+- `missing_policy="separate_bin"` as an opt-in policy that creates explicit `Missing` bins, including categorical missing values.
+- `missing_policy="forbid"` for governance flows that must fail when selected features contain missing values.
+- pandas and PySpark support for the missing-policy contract.
+- Persistence of `missing_policy`, `effective_missing_policy`, `missing_profile`, and `missing_decision_log` in fitted objects and bundles.
 
 ### Changed
 
-- Bundle exports include `bundle_schema_version` while preserving existing artifact fields.
-- PySpark `fit` uses controlled sampling and the current pandas statistical engine.
-- PySpark `transform` and validation profiles use native Spark expressions and aggregated profiles, preserving Spark DataFrame output without collecting full validation datasets.
+- `standard` is the canonical name for the historical maximize-oriented score strategy.
+- `legacy` remains accepted only as a compatibility alias for `standard`.
+- New metadata and bundle fields use the canonical `standard` naming where applicable.
 
 ### Compatibility
 
 - Existing `from riskbands import Binner` and `Binner(...)` usage is preserved.
-- PySpark is not required for the base installation.
-- Spark tests are marked and skipped when PySpark is unavailable.
-- Legacy bundles without v2.1.0 profile fields continue to load through the bundle metadata loader.
+- `RiskBands` remains the preferred public estimator name and aliases `Binner`.
+- Bundles created before the missing-policy metadata existed continue to load as `standard`.
+- The base installation does not install PySpark.
+- PySpark support remains optional through `riskbands[spark]`.
+- The Spark extra remains constrained to `pyspark>=3.5,<4`.
 
-### Notes
+### Explicitly Out Of Scope
 
-- v2.1.0 does not implement a full distributed Spark fitting backend.
-- v2.1.0 does not publish automatically to PyPI or TestPyPI.
+- No merge policies are included in this target. `merge_nearest_woe`, `merge_nearest_event_rate`, and similar policies remain future work.
+- No opaque intelligent imputation is added.
+- No new full distributed Spark fitting backend is added.
+- No default change away from `missing_policy="standard"` is included.
 
 ## Workflows In Use
 
-- `tests.yml`: regular CI test suite
-- `release-validation.yml`: tag-oriented release validation with package build, `twine check`, wheel smoke, and sdist smoke
-- `docs-deploy.yml`: Astro/Starlight build plus GitHub Pages deploy on pushes to `main`
-- `publish-testpypi.yml`: optional TestPyPI publication via Trusted Publishing
-- `publish-pypi.yml`: PyPI publication via Trusted Publishing
+- `tests.yml`: regular CI test suite.
+- `release-validation.yml`: package build, `twine check`, wheel smoke, and sdist smoke for PRs, `main`, manual dispatch, and tags.
+- `docs-deploy.yml`: Astro/Starlight build plus GitHub Pages deploy on pushes to `main` and manual dispatch.
+- `publish-testpypi.yml`: optional TestPyPI publication via Trusted Publishing. Run manually only after review.
+- `publish-pypi.yml`: PyPI publication via Trusted Publishing. Run manually only after review.
 
 ## Release Sequence
 
-1. Update versioned files and release notes to the target version.
-2. Run the complete local validation suite before creating the tag.
-3. Commit the final release preparation changes.
-4. Create the annotated git tag `v2.1.0` only after local validation is green.
-5. Push `main` and the tag.
-6. Confirm `release-validation.yml` is green for the pushed tag.
-7. Optionally run `publish-testpypi.yml` on the tag. This is recommended for packaging, metadata, dependency, and installation changes.
-8. Run `publish-pypi.yml` on the same stable tag only after release validation is green.
-9. Confirm `docs-deploy.yml` is green after the push to `main`.
+1. Prepare versioned files and release notes for `2.2.0`.
+2. Run the complete local validation suite.
+3. Confirm docs-site build.
+4. Confirm package build, `twine check`, smoke base install, and smoke `[spark]` install.
+5. Confirm no tag, push, PyPI upload, or TestPyPI upload was performed during Sprint C.
+6. Commit the final release-prep changes after review.
+7. Create the annotated git tag `v2.2.0` manually only after review approval.
+8. Push `main` and the tag manually.
+9. Confirm `release-validation.yml` is green for the pushed tag.
+10. Optionally run `publish-testpypi.yml` on the reviewed tag.
+11. Run `publish-pypi.yml` on the same stable tag only after release validation and optional TestPyPI smoke checks are green.
+12. Confirm `docs-deploy.yml` is green after the push to `main`.
 
-Do not replace an artifact that has already been published. If a defect is found after PyPI publication, yank the affected release and prepare a new version.
+Do not replace an artifact that already exists on a package index. If a defect is found after PyPI publication, yank the affected version and prepare a new version.
 
 ## Local Validation
 
@@ -78,37 +83,42 @@ python -m pip install -e .[dev]
 python -m pip check
 python -m ruff check riskbands tests
 python -m bandit -q -r riskbands
-python -m pytest -q --cov=riskbands --cov-report=term-missing --basetemp .pytest_tmp/v210-final
+python -m pytest -q --cov=riskbands --cov-report=term-missing --basetemp .pytest_tmp/v220-final
+python -m pytest -m spark --basetemp .pytest_tmp/v220-spark
 python -m pip_audit
+Remove-Item -Recurse -Force dist, build, *.egg-info -ErrorAction SilentlyContinue
 python -m build
 python -m twine check dist/*
 ```
 
-Wheel smoke test:
+Wheel smoke test, base install:
 
 ```powershell
-python -m venv .venv-smoke-210
-.\.venv-smoke-210\Scripts\python.exe -m pip install --upgrade pip
-.\.venv-smoke-210\Scripts\python.exe -m pip install dist/riskbands-2.1.0-py3-none-any.whl
-.\.venv-smoke-210\Scripts\python.exe .\scripts\smoke_test_installed_package.py --expected-version 2.1.0
+python -m venv .pytest_tmp\v220-smoke-base
+.\.pytest_tmp\v220-smoke-base\Scripts\python.exe -m pip install --upgrade pip
+.\.pytest_tmp\v220-smoke-base\Scripts\python.exe -m pip install dist/riskbands-2.2.0-py3-none-any.whl
+.\.pytest_tmp\v220-smoke-base\Scripts\python.exe .\scripts\smoke_test_installed_package.py --expected-version 2.2.0
+.\.pytest_tmp\v220-smoke-base\Scripts\python.exe -c "import importlib.util, riskbands; from riskbands import RiskBands, Binner; print('version:', riskbands.__version__); print('RiskBands is Binner:', RiskBands is Binner); print('pyspark_installed:', importlib.util.find_spec('pyspark') is not None); assert riskbands.__version__ == '2.2.0'; assert RiskBands is Binner; assert importlib.util.find_spec('pyspark') is None"
 ```
 
-Wheel smoke test with the `viz` extra:
+Wheel smoke test with the `spark` extra:
 
 ```powershell
-python -m venv .venv-smoke-210-viz
-.\.venv-smoke-210-viz\Scripts\python.exe -m pip install --upgrade pip
-.\.venv-smoke-210-viz\Scripts\python.exe -m pip install "dist/riskbands-2.1.0-py3-none-any.whl[viz]"
-.\.venv-smoke-210-viz\Scripts\python.exe .\scripts\smoke_test_installed_package.py --expected-version 2.1.0 --check-viz
+python -m venv .pytest_tmp\v220-smoke-spark
+.\.pytest_tmp\v220-smoke-spark\Scripts\python.exe -m pip install --upgrade pip
+.\.pytest_tmp\v220-smoke-spark\Scripts\python.exe -m pip install "dist/riskbands-2.2.0-py3-none-any.whl[spark]"
+.\.pytest_tmp\v220-smoke-spark\Scripts\python.exe .\scripts\smoke_test_installed_package.py --expected-version 2.2.0
+.\.pytest_tmp\v220-smoke-spark\Scripts\python.exe -c "import pyspark; print('pyspark:', pyspark.__version__); assert int(pyspark.__version__.split('.')[0]) == 3"
 ```
 
 Sdist smoke test:
 
 ```powershell
-python -m venv .venv-smoke-210-sdist
-.\.venv-smoke-210-sdist\Scripts\python.exe -m pip install --upgrade pip
-.\.venv-smoke-210-sdist\Scripts\python.exe -m pip install dist/riskbands-2.1.0.tar.gz
-.\.venv-smoke-210-sdist\Scripts\python.exe .\scripts\smoke_test_installed_package.py --expected-version 2.1.0
+python -m venv .pytest_tmp\v220-smoke-sdist
+.\.pytest_tmp\v220-smoke-sdist\Scripts\python.exe -m pip install --upgrade pip
+.\.pytest_tmp\v220-smoke-sdist\Scripts\python.exe -m pip install dist/riskbands-2.2.0.tar.gz
+.\.pytest_tmp\v220-smoke-sdist\Scripts\python.exe .\scripts\smoke_test_installed_package.py --expected-version 2.2.0
+.\.pytest_tmp\v220-smoke-sdist\Scripts\python.exe -c "import importlib.util; print('pyspark_installed:', importlib.util.find_spec('pyspark') is not None); assert importlib.util.find_spec('pyspark') is None"
 ```
 
 Docs-site validation:
@@ -122,40 +132,37 @@ npm --prefix docs-site run build
 
 Both publication workflows require:
 
-- the workflow to run against a git tag, not a branch
-- the tag name to match `v<pyproject version>`
+- the workflow to run against a git tag, not a branch;
+- the tag name to match `v<pyproject version>`;
+- the package version to be stable, such as `2.2.0`.
 
-For this target, the planned tag is `v2.1.0`. `publish-pypi.yml` requires a stable semantic version such as `2.1.0`; do not publish an `rc` version unless the project explicitly adopts a release-candidate publishing policy.
+For this target, the planned tag is `v2.2.0`. Do not create the tag during Sprint C.
 
 ## TestPyPI
 
-`publish-testpypi.yml` is optional but recommended when the release changes packaging, metadata, dependencies, or installation behaviour.
+`publish-testpypi.yml` is optional but recommended when release preparation changes packaging, metadata, dependencies, or installation behavior.
 
 After a successful TestPyPI upload, smoke test with:
 
 ```powershell
-python -m venv .venv-testpypi
-.\.venv-testpypi\Scripts\python.exe -m pip install --upgrade pip
-.\.venv-testpypi\Scripts\python.exe -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ riskbands==2.1.0
-.\.venv-testpypi\Scripts\python.exe .\scripts\smoke_test_installed_package.py --expected-version 2.1.0
-```
-
-Optional visualization extra:
-
-```powershell
-.\.venv-testpypi\Scripts\python.exe -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ "riskbands[viz]==2.1.0"
-.\.venv-testpypi\Scripts\python.exe .\scripts\smoke_test_installed_package.py --expected-version 2.1.0 --check-viz
+python -m venv .pytest_tmp\v220-testpypi
+.\.pytest_tmp\v220-testpypi\Scripts\python.exe -m pip install --upgrade pip
+.\.pytest_tmp\v220-testpypi\Scripts\python.exe -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ riskbands==2.2.0
+.\.pytest_tmp\v220-testpypi\Scripts\python.exe .\scripts\smoke_test_installed_package.py --expected-version 2.2.0 --expect-no-pyspark
+.\.pytest_tmp\v220-testpypi\Scripts\python.exe -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ "riskbands[spark]==2.2.0"
+.\.pytest_tmp\v220-testpypi\Scripts\python.exe .\scripts\smoke_test_installed_package.py --expected-version 2.2.0 --check-spark --expect-pyspark-major 3
 ```
 
 ## PyPI
 
-Run `publish-pypi.yml` manually on `v2.1.0` only after:
+Run `publish-pypi.yml` manually on `v2.2.0` only after:
 
-- local validation is complete and green
-- `release-validation.yml` is green on the pushed tag
-- the tag points to the intended release commit
-- the PyPI trusted publisher is configured for repository `joaaomaia/RiskBands`
-- the `pypi` GitHub environment is approved when required
+- local validation is complete and green;
+- `release-validation.yml` is green on the pushed tag;
+- the tag points to the intended release commit;
+- optional TestPyPI validation has completed, if used;
+- the PyPI trusted publisher is configured for repository `joaaomaia/RiskBands`;
+- the `pypi` GitHub environment is approved when required.
 
 ## Docs Site
 
@@ -172,4 +179,4 @@ npm --prefix docs-site run build
 
 - If validation or packaging fails before publication, fix forward on the branch and tag only when the final version is ready.
 - If TestPyPI succeeds but smoke tests fail, do not publish to PyPI; prepare the next version instead.
-- If PyPI succeeds and a defect is found afterwards, yank the bad release on PyPI and cut a new stable version rather than replacing artifacts.
+- If PyPI succeeds and a defect is found afterwards, yank the affected version and prepare a new stable version rather than replacing artifacts.

--- a/docs-site/src/content/docs/index.md
+++ b/docs-site/src/content/docs/index.md
@@ -26,6 +26,9 @@ features:
   - title: Outputs fáceis de ler
     description: Veja como interpretar `summary()`, `report()`, `score_details()`, `diagnostics()` e `binning_table()`.
     link: ./technical/outputs/
+  - title: Missing values auditaveis
+    description: Use `standard`, `separate_bin` ou `forbid` sem imputacao opaca e com trilha persistida nos bundles.
+    link: ./technical/api-overview/#missing-values
   - title: Optuna sem acoplamento
     description: Descubra quando vale ligar a busca externa e como ela se encaixa no mesmo objective do fluxo sem Optuna.
     link: ./technical/optuna/
@@ -76,13 +79,14 @@ Na prática, o projeto adiciona:
 ## Fluxo mínimo
 
 ```python
-from riskbands import Binner
+from riskbands import RiskBands
 
-binner = Binner(
+binner = RiskBands(
     strategy="supervised",
     score_strategy="stable",
     max_n_bins=5,
     check_stability=True,
+    missing_policy="standard",
 )
 
 binner.fit(df, y="target", column="score", time_col="month")

--- a/docs-site/src/content/docs/reference/release-notes.md
+++ b/docs-site/src/content/docs/reference/release-notes.md
@@ -3,11 +3,31 @@ title: "Release Notes"
 description: "Marcos de release em alto nível para o pacote público e para a documentação oficial."
 ---
 
+## v2.2.0
+
+Compatible minor release focused on auditable missing-value policy and compatibility.
+
+Main points:
+
+- `missing_policy="standard"` is the default and preserves the Sprint A baseline behavior
+- `missing_policy="separate_bin"` is opt-in and creates explicit `Missing` bins, including categorical missing values
+- `missing_policy="forbid"` raises during `fit` or `transform` when selected features contain missing values
+- `standard` is the canonical name for the historical maximize-oriented score strategy
+- `legacy` remains accepted as a compatibility alias for `standard`
+- pandas and PySpark inputs are supported by the missing-policy contract
+- bundles persist `missing_policy`, `effective_missing_policy`, `missing_profile`, and `missing_decision_log`
+- old bundles without these fields continue to load as `standard`
+- PySpark remains optional through `riskbands[spark]` with `pyspark>=3.5,<4`
+
+Notes:
+
+- merge policies such as `merge_nearest_woe` and `merge_nearest_event_rate` are not part of this target
+- no opaque intelligent imputation is added
+- a full distributed Spark fitting backend is not part of this target
+
 ## v2.1.0
 
 Compatible minor release focused on the preferred `RiskBands` name, optional PySpark paths, and validation profiles.
-
-Status: prepared for v2.1.0 publication.
 
 Main points:
 
@@ -29,8 +49,6 @@ Notes:
 ## v2.0.3
 
 Patch release focused on release hardening and deterministic operational behaviour.
-
-Status: prepared for v2.0.3 publication.
 
 Main points:
 

--- a/docs-site/src/content/docs/technical/api-overview.md
+++ b/docs-site/src/content/docs/technical/api-overview.md
@@ -7,7 +7,7 @@ description: "Mapa da superfície pública do RiskBands, com foco em onboarding,
 
 Na maior parte dos casos, o fluxo ideal para um usuário novo é:
 
-1. instanciar `Binner`
+1. instanciar `RiskBands`
 2. rodar `fit(...)`
 3. inspecionar `summary()`, `score_table()` e `audit_table()`
 4. aplicar `transform(...)`
@@ -17,7 +17,7 @@ Na maior parte dos casos, o fluxo ideal para um usuário novo é:
 ## Superfície pública principal
 
 ```python
-from riskbands import Binner, BinComparator
+from riskbands import RiskBands, Binner, BinComparator
 from riskbands.temporal_stability import (
     ks_over_time,
     psi_over_time,
@@ -57,7 +57,7 @@ Também foram adicionados aliases mais amigáveis para configuração:
 
 | Componente | Papel no fluxo | Por que importa |
 | --- | --- | --- |
-| `Binner` | Porta de entrada principal | Ajusta, transforma, resume, exporta e plota sem exigir estruturas internas |
+| `RiskBands` / `Binner` | Porta de entrada principal | Ajusta, transforma, resume, exporta e plota sem exigir estruturas internas |
 | `summary()` | Resumo curto pós-fit | Ajuda a entender rapidamente bins, IV e score |
 | `score_table()` | Explicação curta do objective | Expõe score final, pesos e componentes mais relevantes |
 | `audit_table()` | Revisão auditável consolidada | Junta cuts, score, penalidades, cobertura e rationale |
@@ -69,11 +69,12 @@ Também foram adicionados aliases mais amigáveis para configuração:
 ## Fluxo recomendado para candidato único
 
 ```python
-binner = Binner(
+binner = RiskBands(
     strategy="supervised",
     score_strategy="stable",
     max_n_bins=5,
     check_stability=True,
+    missing_policy="standard",
 )
 
 binner.fit(df, y="target", column="score", time_col="month")
@@ -104,13 +105,17 @@ Hoje a API expõe duas estratégias explícitas:
 - `separate_bin`: opt-in para bin explícito `Missing`
 - `forbid`: erro em `fit` ou `transform` se houver missing nas features selecionadas
 
+`separate_bin` nao faz imputacao opaca; ele torna o missing explicito e
+auditavel. Merge policies ainda nao fazem parte do contrato publico.
+
 Exemplo:
 
 ```python
-binner = Binner(
+binner = RiskBands(
     strategy="supervised",
     check_stability=True,
     time_col="month",
+    missing_policy="separate_bin",
     score_strategy="stable",
     score_weights={
         "temporal_variance_weight": 0.22,

--- a/docs-site/src/content/docs/technical/audit-and-plots.md
+++ b/docs-site/src/content/docs/technical/audit-and-plots.md
@@ -18,11 +18,12 @@ O `Binner` agora expõe uma superfície pública mais direta para:
 ```python
 from pathlib import Path
 
-from riskbands import Binner
+from riskbands import RiskBands
 
-binner = Binner(
+binner = RiskBands(
     strategy="supervised",
     check_stability=True,
+    missing_policy="standard",
     score_strategy="stable",
     score_weights={
         "temporal_variance_weight": 0.24,

--- a/docs-site/src/content/docs/technical/optuna.md
+++ b/docs-site/src/content/docs/technical/optuna.md
@@ -35,14 +35,15 @@ Considere Optuna quando:
 ## Como ele se encaixa no fluxo
 
 ```python
-from riskbands import Binner
+from riskbands import RiskBands
 
-binner = Binner(
+binner = RiskBands(
     strategy="supervised",
     use_optuna=True,
     score_strategy="stable",
     strategy_kwargs={"n_trials": 20},
     check_stability=True,
+    missing_policy="standard",
 )
 
 binner.fit(df, y="target", column="score", time_col="month")

--- a/docs-site/src/content/docs/technical/outputs.md
+++ b/docs-site/src/content/docs/technical/outputs.md
@@ -139,6 +139,9 @@ Bundles também persistem a trilha de missing values quando disponível:
 `missing_policy`, `effective_missing_policy`, `missing_profile` e
 `missing_decision_log`.
 
+Esses campos registram a decisao de tratamento de missing values. Eles nao
+representam imputacao opaca nem merge policies.
+
 ## Exemplo
 
 ```python

--- a/docs-site/src/content/docs/technical/quickstart.md
+++ b/docs-site/src/content/docs/technical/quickstart.md
@@ -1,13 +1,13 @@
 ---
 title: Quickstart
-description: "Ajuste seu primeiro Binner com a API mais amigável do RiskBands e inspecione score, auditoria, export e plots em poucos passos."
+description: "Ajuste seu primeiro RiskBands com a API mais amigavel do projeto e inspecione score, auditoria, export e plots em poucos passos."
 ---
 
 ## O fluxo recomendado hoje
 
 Para um usuário novo, o caminho mais simples e completo é:
 
-1. criar um `Binner`
+1. criar um `RiskBands`
 2. ajustar com `fit(df, y="target", column="score", time_col="month")`
 3. olhar `summary()`
 4. abrir `score_table()` e `audit_table()`
@@ -18,7 +18,7 @@ Para um usuário novo, o caminho mais simples e completo é:
 import numpy as np
 import pandas as pd
 
-from riskbands import Binner
+from riskbands import RiskBands
 
 rng = np.random.default_rng(0)
 n = 800
@@ -30,10 +30,11 @@ proba = 0.20 + 0.15 * df["score"] + 0.02 * (df["month"] - 202301)
 proba = np.clip(proba, 0.01, 0.99)
 df["target"] = (rng.random(n) < proba).astype(int)
 
-binner = Binner(
+binner = RiskBands(
     strategy="supervised",
     max_n_bins=5,
     check_stability=True,
+    missing_policy="standard",
     score_strategy="stable",
     normalization_strategy="absolute",
     woe_shrinkage_strength=35.0,
@@ -54,6 +55,15 @@ binner.plot_bad_rate_heatmap(df, y="target", column="score", time_col="month")
 binner.plot_bin_share_over_time(df, y="target", column="score", time_col="month")
 binner.plot_score_components(column="score")
 ```
+
+## Missing values
+
+O default `missing_policy="standard"` preserva o comportamento atual. Quando
+voce precisa auditar missing values explicitamente, use
+`missing_policy="separate_bin"`. Quando missing values devem ser bloqueados
+antes do binning, use `missing_policy="forbid"`.
+
+Essas politicas nao fazem imputacao opaca e nao incluem merge policies.
 
 ## Por que esse fluxo é mais amigável
 

--- a/docs-site/src/content/docs/technical/score-strategy.md
+++ b/docs-site/src/content/docs/technical/score-strategy.md
@@ -98,9 +98,9 @@ Quando reduzir:
 ## Exemplo completo
 
 ```python
-from riskbands import Binner
+from riskbands import RiskBands
 
-binner = Binner(
+binner = RiskBands(
     strategy="supervised",
     score_strategy="stable",
     score_weights={

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -15,7 +15,7 @@ from riskbands import (
 
 Current version:
 
-- `2.1.0`
+- `2.2.0`
 
 ## `RiskBands` / `Binner`
 
@@ -84,6 +84,15 @@ Notes:
 - `from riskbands import Binner` remains available for compatibility.
 - `save_report("...xlsx")` requires an XLSX writer engine such as `openpyxl` or `xlsxwriter`.
 
+Missing policy semantics:
+
+- `standard`: preserves the current missing-value behavior and is the default.
+- `separate_bin`: creates an explicit, auditable `Missing` bin.
+- `forbid`: raises a clear error in `fit` or `transform` when selected features contain missing values.
+
+No opaque missing-value imputation is added. Merge policies such as
+`merge_nearest_woe` and `merge_nearest_event_rate` are not part of v2.2.0.
+
 Main attributes after `fit`:
 
 - `bin_summary`
@@ -104,7 +113,7 @@ Main attributes after `fit`:
 - `transform_validation_report_` when `transform(validate=True)` was requested
 - `validation_report_` as the latest validation report compatibility alias
 - `fit_profile_`, `source_profile_`, and `reference_profile_` when available
-- `missing_policy_`, `missing_profile_`, and `missing_decision_log_`
+- `missing_policy_`, `effective_missing_policy_`, `missing_profile_`, and `missing_decision_log_`
 - `iv_`
 - `iv_by_variable_`
 - `objective_config_`
@@ -248,4 +257,3 @@ Compared profiles:
 - [examples/temporal_stability/temporal_stability_example.ipynb](../examples/temporal_stability/temporal_stability_example.ipynb)
 - [examples/pd_vintage_champion_challenger/pd_vintage_champion_challenger.py](../examples/pd_vintage_champion_challenger/pd_vintage_champion_challenger.py)
 - [examples/pd_vintage_champion_challenger/pd_vintage_champion_challenger.ipynb](../examples/pd_vintage_champion_challenger/pd_vintage_champion_challenger.ipynb)
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-﻿# RiskBands Docs
+# RiskBands Docs
 
 Entry point for the project documentation.
 
@@ -18,8 +18,8 @@ Entry point for the project documentation.
   Project overview, installation, quickstart, and positioning.
 - [docs/api_reference.md](api_reference.md)
   Main API contract and public package surface.
-- [docs/v2.1.0_user_guide.md](v2.1.0_user_guide.md)
-  v2.1.0 import, pandas/PySpark, validation, and bundle guide.
+- [docs/v2.2.0_user_guide.md](v2.2.0_user_guide.md)
+  v2.2.0 import, missing policies, pandas/PySpark, validation, and bundle guide.
 - [docs/migration.md](migration.md)
   Breaking migration guide for users coming from `NASABinning`.
 - [examples/README.md](../examples/README.md)

--- a/docs/releases/2.2.0.md
+++ b/docs/releases/2.2.0.md
@@ -1,0 +1,43 @@
+# RiskBands 2.2.0
+
+Type: compatible minor release.
+
+## Highlights
+
+- Adds `missing_policy="standard"` as the default policy, preserving the Sprint A baseline behavior.
+- Adds `missing_policy="separate_bin"` as an opt-in policy for explicit `Missing` bins, including categorical missing values.
+- Adds `missing_policy="forbid"` for governance workflows that must reject missing values during `fit` or `transform`.
+- Keeps `standard` as the canonical name for the historical maximize-oriented score strategy.
+- Keeps `legacy` as a compatibility alias for `standard`.
+- Supports the missing-policy contract on pandas and PySpark inputs.
+- Persists `missing_policy`, `effective_missing_policy`, `missing_profile`, and `missing_decision_log` in fitted objects and bundles.
+
+## Compatibility
+
+- Existing `from riskbands import Binner` code continues to work.
+- `RiskBands` remains the preferred public estimator name and aliases `Binner`.
+- Bundles without the v2.2.0 missing-policy fields continue to load as `standard`.
+- Base installation does not install PySpark.
+- Spark support remains optional through `riskbands[spark]`.
+- The Spark extra remains constrained to `pyspark>=3.5,<4`.
+
+## Out Of Scope
+
+- No merge policies are included. `merge_nearest_woe`, `merge_nearest_event_rate`, and related policies remain future work.
+- No opaque intelligent imputation is added.
+- No new full distributed Spark fitting backend is added.
+- The default remains `missing_policy="standard"`.
+
+## Required Validation Before Publication
+
+- `python -m pytest`
+- `python -m pytest -m spark` in an environment with PySpark and Java
+- `python -m ruff check riskbands tests`
+- `python -m bandit -q -r riskbands`
+- `python -m pip_audit`
+- `python -m build`
+- `python -m twine check dist/*`
+- wheel smoke test for the base install, confirming PySpark is absent
+- wheel smoke test for `riskbands[spark]`, confirming PySpark 3.x
+
+PyPI/TestPyPI publication, tag creation, and push are manual release steps outside this note.

--- a/docs/releases/2.2.0_publication_checklist.md
+++ b/docs/releases/2.2.0_publication_checklist.md
@@ -1,0 +1,90 @@
+# RiskBands 2.2.0 Publication Checklist
+
+Status: READY_FOR_MANUAL_REVIEW. Local release preparation completed on 2026-05-17. No publication, tag, or push was performed.
+
+## Target
+
+- [x] Version target: `2.2.0`.
+- [x] Branch: `release/v2.2.0-prep`.
+- [x] Base commit: `53d67f36704a68ef8e44e8f1e4ea3354b18920f1`.
+- [x] Planned tag: `v2.2.0`.
+- [x] Local `git tag --list v2.2.0`: no tag.
+- [x] Remote `git ls-remote --tags origin refs/tags/v2.2.0`: no tag.
+- [x] PyPI/TestPyPI upload: not performed.
+- [x] Push: not performed.
+
+## Version And Packaging
+
+- [x] `pyproject.toml` has `version = "2.2.0"`.
+- [x] Spark extra remains optional and constrained to `pyspark>=3.5,<4`.
+- [x] Built artifacts:
+  - `dist/riskbands-2.2.0.tar.gz`
+  - `dist/riskbands-2.2.0-py3-none-any.whl`
+- [x] Wheel metadata includes `Requires-Dist: pyspark<4,>=3.5; extra == "spark"`.
+- [x] `twine check dist/*`: PASS.
+
+## Functional Gates
+
+| Gate | Result |
+| --- | --- |
+| Version import | PASS: `riskbands.__version__ == "2.2.0"` and `RiskBands is Binner` |
+| Compatibility/bundle suite | PASS: 42 passed |
+| Missing policy focused suite | PASS: 37 passed |
+| Full core pytest | PASS: 219 passed |
+| Real Spark pytest | PASS: 20 selected, 20 passed |
+| Docs-site build | PASS: `astro check` 0 errors/warnings/hints, 19 pages built |
+| Ruff | PASS |
+| Bandit | PASS |
+| pip check | PASS |
+| pip-audit | PASS outside sandbox after proxy block |
+| Build | PASS outside sandbox after build-isolation index block |
+| Twine check | PASS |
+| Smoke base | PASS: `pyspark_installed=False` |
+| Smoke `[spark]` | PASS: PySpark `3.5.8` |
+
+## Compatibility Assertions
+
+- [x] `RiskBands` remains the preferred public estimator.
+- [x] `Binner` remains compatible.
+- [x] `score_strategy="standard"` is canonical.
+- [x] `score_strategy="legacy"` remains a compatibility alias and normalizes to `standard`.
+- [x] `missing_policy="standard"` remains the default.
+- [x] Old bundles without missing-policy fields load as `standard`.
+- [x] Old bundles with `legacy` missing policy normalize to `standard`.
+- [x] New bundles persist `missing_policy`, `effective_missing_policy`, `missing_profile`, and `missing_decision_log`.
+- [x] `separate_bin` transform remains stable after bundle export/load.
+- [x] `forbid` works after bundle export/load when inputs have no missing values.
+
+## Residual Notes
+
+- Spark cleanup on Windows printed `ERRO: Acesso negado` after tests, but commands exited 0 and tests passed.
+- `pip-audit`, isolated build, and clean smoke installs required out-of-sandbox network access.
+- Temporary smoke venvs printed warnings about stale `pip-24.0.dist-info` after pip upgrade; `pip check` still passed.
+- Docs-site build exited 0 and printed `Entry docs -> 404 was not found.` as a non-failing Starlight/Pagefind message.
+
+## Manual Steps After Review
+
+Prepare a PR:
+
+```bash
+git commit -m "Prepare RiskBands v2.2.0 release"
+git push -u origin release/v2.2.0-prep
+gh pr create --base main --head release/v2.2.0-prep
+```
+
+After merge and final review:
+
+```bash
+git switch main
+git pull --ff-only origin main
+git tag -a v2.2.0 -m "Release v2.2.0"
+git push origin v2.2.0
+```
+
+Publish only after the tag validation workflow is green:
+
+```bash
+gh workflow run publish-pypi.yml --ref v2.2.0
+```
+
+Optional TestPyPI rehearsal can be run before PyPI if the maintainer wants an extra package-index smoke.

--- a/docs/releases/2.2.0_release_prep_report.md
+++ b/docs/releases/2.2.0_release_prep_report.md
@@ -1,0 +1,79 @@
+# RiskBands 2.2.0 Release Prep Report
+
+Status: READY_FOR_MANUAL_REVIEW.
+
+Date: 2026-05-17
+
+Branch: `release/v2.2.0-prep`
+
+Base commit: `53d67f36704a68ef8e44e8f1e4ea3354b18920f1`
+
+## Scope
+
+This preparation updates RiskBands to `2.2.0` after the Sprint B missing-policy work. It does not publish, tag, or push.
+
+The release notes and docs cover:
+
+- `missing_policy="standard"` as the default.
+- `missing_policy="separate_bin"` as explicit/auditable missing bins.
+- `missing_policy="forbid"` as a governance error path.
+- `standard` as the canonical score-strategy name.
+- `legacy` as a compatibility alias.
+- pandas and PySpark support.
+- persistence of missing-policy audit fields in bundles.
+- old bundle compatibility.
+- optional Spark extra with `pyspark>=3.5,<4`.
+- no merge policies, no opaque imputation, and no new full distributed Spark fitting backend.
+
+## Validation Summary
+
+| Area | Evidence |
+| --- | --- |
+| Version | `pyproject.toml` version `2.2.0`; import check printed `2.2.0` |
+| Public API | `RiskBands is Binner: True` |
+| Docs-site | `npm --prefix docs-site run build` passed outside sandbox |
+| Compatibility | 42 compatibility/bundle tests passed |
+| Full tests | 219 tests passed |
+| Spark real | `pytest -m spark` selected 20 tests and all passed |
+| Ruff | `All checks passed!` |
+| Bandit | No findings reported |
+| pip-audit | `No known vulnerabilities found` |
+| Build | `riskbands-2.2.0.tar.gz` and `riskbands-2.2.0-py3-none-any.whl` built |
+| Twine | Both artifacts passed |
+| Smoke base | Version `2.2.0`, `RiskBands is Binner: True`, `pyspark_installed: False` |
+| Smoke spark | Version `2.2.0`, `RiskBands is Binner: True`, `pyspark: 3.5.8` |
+
+## Artifacts
+
+```text
+dist/riskbands-2.2.0.tar.gz
+SHA256 619A52C5790F30D4E38AB1E02ECEC8054698C21AC6A23FF3CA6DFE9B7B3C3103
+
+dist/riskbands-2.2.0-py3-none-any.whl
+SHA256 5A79E5D07E241BB4747195ACE14D875521C240B5D208480634AB49A5A6A8887D
+```
+
+## Non-Actions Confirmed
+
+- No `v2.2.0` tag was created locally.
+- No remote `v2.2.0` tag was found.
+- No push was performed.
+- No PyPI upload was performed.
+- No TestPyPI upload was performed.
+- No `twine upload` command was run.
+
+## Residual Observations
+
+- Networked commands required approval outside the sandbox: branch protection/tag checks, pip-audit, isolated build dependencies, and clean smoke installs.
+- Spark tests on Windows printed `ERRO: Acesso negado` during cleanup after passing with exit code 0.
+- Clean smoke venvs emitted stale pip metadata warnings after upgrading pip, but `pip check` passed.
+- Docs-site build emitted `Entry docs -> 404 was not found.` after a successful exit code 0 build.
+
+## Recommended Manual Flow
+
+1. Review the release-prep branch and final ZIP.
+2. Commit the release-prep changes.
+3. Push `release/v2.2.0-prep`.
+4. Open a PR into `main`.
+5. After merge and green validation, create and push annotated tag `v2.2.0`.
+6. Run the publication workflow manually only after tag validation is green.

--- a/docs/v2.2.0_missing_policy_design.md
+++ b/docs/v2.2.0_missing_policy_design.md
@@ -1,7 +1,7 @@
 # v2.2.0 Missing Policy Design
 
 This internal design note records the implemented Sprint B contract. It does not
-claim that a v2.2.0 release has been published.
+claim package-index availability for v2.2.0.
 
 ## Public Contract
 

--- a/docs/v2.2.0_user_guide.md
+++ b/docs/v2.2.0_user_guide.md
@@ -1,0 +1,141 @@
+# RiskBands v2.2.0 User Guide
+
+RiskBands v2.2.0 keeps the same fit/transform workflow and adds an explicit,
+auditable missing-value policy contract. The preferred class name is
+`RiskBands`; `Binner` remains compatible.
+
+## Imports
+
+Recommended:
+
+```python
+from riskbands import RiskBands
+
+binner = RiskBands(...)
+```
+
+Short alias:
+
+```python
+from riskbands import RiskBands as rb
+
+binner = rb(...)
+```
+
+Package alias:
+
+```python
+import riskbands as rb
+
+binner = rb.RiskBands(...)
+```
+
+Compatibility:
+
+```python
+from riskbands import Binner
+
+binner = Binner(...)
+```
+
+Do not use `import RiskBands as rb`; v2.2.0 does not add a capitalized package or callable module.
+
+## Missing Policies
+
+`missing_policy` controls how missing values in selected features are handled:
+
+```python
+RiskBands(missing_policy="standard")
+RiskBands(missing_policy="separate_bin")
+RiskBands(missing_policy="forbid")
+```
+
+- `standard` is the default and preserves the current behavior.
+- `separate_bin` is opt-in and creates an explicit, auditable `Missing` bin.
+- `forbid` raises a clear error in `fit` or `transform` when selected features contain missing values.
+
+No opaque missing-value imputation is added. Merge policies such as
+`merge_nearest_woe` and `merge_nearest_event_rate` are not part of v2.2.0.
+
+## Pandas
+
+```python
+from riskbands import RiskBands
+
+binner = RiskBands(
+    min_n_bins=3,
+    missing_policy="standard",
+)
+
+binner.fit(df_train, target="default_12m", validate=True)
+
+df_binned = binner.transform(df_oot, validate=True)
+```
+
+`min_n_bins` is a soft quality rule. If good bins cannot reach the requested
+minimum, RiskBands keeps the valid binning and records status metadata instead
+of creating artificial cuts.
+
+## PySpark
+
+The base install does not install PySpark. Use the optional Spark extra when
+Spark DataFrame support is needed:
+
+```bash
+pip install "riskbands[spark]"
+```
+
+The extra is constrained to `pyspark>=3.5,<4`.
+
+```python
+from riskbands import RiskBands
+
+binner = RiskBands(
+    min_n_bins=3,
+    sample_size=50_000,
+    missing_policy="separate_bin",
+)
+
+binner.fit(spark_train, target="default_12m", validate=True)
+
+spark_binned = binner.transform(spark_oot, validate=True)
+```
+
+Spark fit uses controlled sampling, converts that sample to pandas, then uses
+the current pandas statistical engine. Spark transform preserves a Spark
+DataFrame and uses native Spark expressions, not Python UDFs. Spark validation
+builds aggregated profiles in Spark and collects only the small variable/bin
+profile result.
+
+RiskBands does not add a new full distributed Spark fitting backend in v2.2.0.
+
+## Score Strategy
+
+Use `standard` as the canonical name for the historical maximize-oriented score
+strategy. `legacy` remains accepted only as a compatibility alias.
+
+For temporal robustness workflows, `stable` remains the public strategy focused
+on balancing separation and stability.
+
+## Bundle
+
+```python
+from riskbands.reporting import load_bundle
+
+binner.export_bundle("riskbands_bundle")
+
+bundle = load_bundle("riskbands_bundle")
+reference_profile = bundle["reference_profile"]
+```
+
+The v2.2.0 bundle stores schema/version metadata, binnings, fit/source/reference
+profiles, validation reports, sampling metadata, backend metadata, `min_n_bins`
+metadata, validation settings, data schema when available, and the missing-value
+audit fields:
+
+- `missing_policy`
+- `effective_missing_policy`
+- `missing_profile`
+- `missing_decision_log`
+
+Bundles created before these fields existed continue to load as `standard`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "riskbands"
-version = "2.1.0"
+version = "2.2.0"
 description = "Interpretable binning with temporal stability diagnostics for credit risk, PD, and scorecard workflows."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Prepares RiskBands v2.2.0 release metadata, release notes, documentation, validation checklist, and packaging smoke evidence after the auditable missing value policies sprint.