### PR TITLE
Add missing policy documentation and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ candidatos e racional auditavel.
 [Benchmark PD vintage](https://joaaomaia.github.io/RiskBands/methodology/pd-vintage-benchmark/) |
 [Quickstart](https://joaaomaia.github.io/RiskBands/technical/quickstart/) |
 [Auditoria e plots](https://joaaomaia.github.io/RiskBands/technical/audit-and-plots/) |
-[API](https://joaaomaia.github.io/RiskBands/technical/api-overview/)
+[API](https://joaaomaia.github.io/RiskBands/technical/api-overview/) |
+[Missing policy](https://joaaomaia.github.io/RiskBands/technical/missing-policy/)
 
 ---
 
@@ -126,6 +127,7 @@ Porta tecnica:
 
 - [Instalacao](https://joaaomaia.github.io/RiskBands/technical/installation/)
 - [Quickstart](https://joaaomaia.github.io/RiskBands/technical/quickstart/)
+- [Missing policy](https://joaaomaia.github.io/RiskBands/technical/missing-policy/)
 - [Visao geral da API](https://joaaomaia.github.io/RiskBands/technical/api-overview/)
 - [Exemplos](https://joaaomaia.github.io/RiskBands/technical/examples/)
 
@@ -189,6 +191,33 @@ no binning:
 Bundles novos persistem `missing_policy`, `effective_missing_policy`,
 `missing_profile` e `missing_decision_log`. Bundles antigos sem esses campos
 carregam como `standard`.
+
+Guia dedicado:
+[docs/missing_policy_user_guide.md](docs/missing_policy_user_guide.md) ou
+[Missing policy no docs-site](https://joaaomaia.github.io/RiskBands/technical/missing-policy/).
+
+Exemplo minimo:
+
+```python
+from riskbands import RiskBands
+
+binner = RiskBands(
+    max_bins=4,
+    force_categorical=["rating"],
+    missing_policy="separate_bin",
+)
+
+binner.fit(df, y="target", columns=["score", "rating"], validate=True)
+df_binned = binner.transform(df[["score", "rating"]], validate=True)
+
+print(binner.missing_profile_)
+print(binner.missing_decision_log_)
+```
+
+Exemplos executaveis:
+
+- `python examples/missing_policy/missing_policy_pandas_demo.py`
+- `python examples/missing_policy/missing_policy_pyspark_demo.py`
 
 ## Destaques da versao 2.2.0
 

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -125,6 +125,7 @@ export default defineConfig({
             { label: 'Instalação', link: '/technical/installation/' },
             { label: 'Quickstart', link: '/technical/quickstart/' },
             { label: 'Score e estratégias', link: '/technical/score-strategy/' },
+            { label: 'Missing policy', link: '/technical/missing-policy/' },
             { label: 'Outputs e diagnóstico', link: '/technical/outputs/' },
             { label: 'Auditoria e plots', link: '/technical/audit-and-plots/' },
             { label: 'Optuna', link: '/technical/optuna/' },

--- a/docs-site/src/content/docs/index.md
+++ b/docs-site/src/content/docs/index.md
@@ -28,7 +28,7 @@ features:
     link: ./technical/outputs/
   - title: Missing values auditaveis
     description: Use `standard`, `separate_bin` ou `forbid` sem imputacao opaca e com trilha persistida nos bundles.
-    link: ./technical/api-overview/#missing-values
+    link: ./technical/missing-policy/
   - title: Optuna sem acoplamento
     description: Descubra quando vale ligar a busca externa e como ela se encaixa no mesmo objective do fluxo sem Optuna.
     link: ./technical/optuna/
@@ -73,8 +73,9 @@ Na prática, o projeto adiciona:
 1. Instale a biblioteca em Python.
 2. Rode o [Quickstart](./technical/quickstart/).
 3. Leia [Score e estratégias](./technical/score-strategy/) para entender `stable`.
-4. Use [Outputs e diagnóstico](./technical/outputs/) para aprender a interpretar o resultado.
-5. Vá para [Exemplos](./technical/examples/) ou para o [Benchmark PD vintage](./methodology/pd-vintage-benchmark/).
+4. Leia [Missing policy](./technical/missing-policy/) se a base tiver valores ausentes.
+5. Use [Outputs e diagnóstico](./technical/outputs/) para aprender a interpretar o resultado.
+6. Vá para [Exemplos](./technical/examples/) ou para o [Benchmark PD vintage](./methodology/pd-vintage-benchmark/).
 
 ## Fluxo mínimo
 
@@ -112,5 +113,6 @@ Tudo isso em uma forma comparável e orientada a minimização.
 ## Próximos passos
 
 - Quer começar a usar? Vá para [Quickstart](./technical/quickstart/).
+- Quer auditar missing values? Vá para [Missing policy](./technical/missing-policy/).
 - Quer entender a estratégia recomendada? Vá para [Score e estratégias](./technical/score-strategy/).
 - Quer evidência metodológica? Vá para [Benchmark PD vintage](./methodology/pd-vintage-benchmark/).

--- a/docs-site/src/content/docs/reference/release-notes.md
+++ b/docs-site/src/content/docs/reference/release-notes.md
@@ -3,6 +3,26 @@ title: "Release Notes"
 description: "Marcos de release em alto nível para o pacote público e para a documentação oficial."
 ---
 
+## Documentation update after v2.2.0
+
+Type: docs-only preparation.
+
+Status: documentation update after v2.2.0; no package version bump.
+
+Main points:
+
+- adds a focused missing-policy guide for `standard`, `separate_bin`, and `forbid`
+- adds small pandas and PySpark missing-policy demos
+- improves docs-site navigation for missing values, bundle fields, and audit logs
+- keeps PySpark documented as optional through `riskbands[spark]`
+- does not change core behavior, package version, publish status, tag, or release artifacts
+
+Notes:
+
+- merge policies remain future work
+- no opaque intelligent imputation is added
+- i18n is not part of this docs-only preparation
+
 ## v2.2.0
 
 Compatible minor release focused on auditable missing-value policy and compatibility.

--- a/docs-site/src/content/docs/technical/api-overview.md
+++ b/docs-site/src/content/docs/technical/api-overview.md
@@ -108,6 +108,12 @@ Hoje a API expõe duas estratégias explícitas:
 `separate_bin` nao faz imputacao opaca; ele torna o missing explicito e
 auditavel. Merge policies ainda nao fazem parte do contrato publico.
 
+Guia dedicado: [Missing policy](../missing-policy/).
+
+Depois do `fit`, inspecione `missing_profile_` e `missing_decision_log_` para
+ver volume, share, event rate e decisao tomada por variavel. Esses campos tambem
+sao persistidos em `export_bundle(...)`.
+
 Exemplo:
 
 ```python
@@ -143,4 +149,5 @@ Depois do primeiro `fit`, o trio mais útil costuma ser:
 - [Quickstart](../quickstart/)
 - [Auditoria e plots](../audit-and-plots/)
 - [Outputs e diagnóstico](../outputs/)
+- [Missing policy](../missing-policy/)
 - [Exemplos](../examples/)

--- a/docs-site/src/content/docs/technical/examples.md
+++ b/docs-site/src/content/docs/technical/examples.md
@@ -39,6 +39,24 @@ Esse fluxo já mostra:
 - `plot_bin_share_over_time(...)`
 - `plot_score_components(...)`
 
+### Missing policy pandas e PySpark
+
+Use estes scripts quando a pergunta principal for como tratar missing values de
+forma auditavel sem imputacao opaca.
+
+- [Demo pandas de missing policy](https://github.com/joaaomaia/RiskBands/blob/main/examples/missing_policy/missing_policy_pandas_demo.py)
+- [Demo PySpark de missing policy](https://github.com/joaaomaia/RiskBands/blob/main/examples/missing_policy/missing_policy_pyspark_demo.py)
+
+Eles mostram:
+
+- `missing_policy="standard"`
+- `missing_policy="separate_bin"`
+- `missing_policy="forbid"`
+- `missing_profile_`
+- `missing_decision_log_`
+- bundle com campos de missing policy
+- guarda opcional para PySpark
+
 ### PD vintage champion challenger
 
 É o exemplo de crédito mais direto para comparação entre candidatos.
@@ -71,8 +89,9 @@ Use este material quando a pergunta principal for:
 2. Quickstart
 3. Auditoria e plots
 4. Visão geral da API
-5. PD vintage champion challenger
-6. Benchmark PD vintage
+5. Missing policy
+6. PD vintage champion challenger
+7. Benchmark PD vintage
 
 ### Se você quer começar pela tese metodológica
 

--- a/docs-site/src/content/docs/technical/missing-policy.md
+++ b/docs-site/src/content/docs/technical/missing-policy.md
@@ -1,0 +1,148 @@
+---
+title: "Missing policy"
+description: "Como usar standard, separate_bin e forbid para tratar missing values de forma auditavel no RiskBands."
+---
+
+## Ideia central
+
+Em risco de credito, missing values podem carregar sinal proprio. Um campo
+ausente pode refletir origem de dados, canal, politica operacional ou mudanca
+de captura. Por isso, aplicar `fillna(...)` silencioso antes do binning pode
+esconder uma decisao relevante.
+
+`missing_policy` torna essa decisao explicita:
+
+```python
+from riskbands import RiskBands
+
+binner = RiskBands(missing_policy="separate_bin")
+```
+
+## Politicas
+
+| Politica | O que faz | Quando usar |
+| --- | --- | --- |
+| `standard` | Preserva o comportamento compativel atual. | Reproducao de fluxos existentes e compatibilidade. |
+| `separate_bin` | Cria bin explicito `Missing` para missing nas features selecionadas. | Analise auditavel de missing como grupo proprio. |
+| `forbid` | Falha em `fit` ou `transform` quando encontra missing. | Governanca que exige tratamento upstream antes do binning. |
+
+`legacy` pode aparecer em metadados antigos como compatibilidade, mas nao e
+recomendacao nova. O nome canonico atual e `standard`.
+
+## Exemplo pandas
+
+O script completo esta em
+[`examples/missing_policy/missing_policy_pandas_demo.py`](https://github.com/joaaomaia/RiskBands/blob/main/examples/missing_policy/missing_policy_pandas_demo.py).
+
+```python
+import numpy as np
+import pandas as pd
+
+from riskbands import RiskBands
+
+df = pd.DataFrame(
+    {
+        "score": [410.0, 450.0, np.nan, 620.0, 710.0] * 6,
+        "rating": ["A", "B", None, "C", "D"] * 6,
+        "target": [0, 0, 1, 1, 1] * 6,
+    }
+)
+
+binner = RiskBands(
+    max_bins=4,
+    min_event_rate_diff=0.0,
+    force_categorical=["rating"],
+    missing_policy="separate_bin",
+)
+
+binner.fit(df, y="target", columns=["score", "rating"], validate=True)
+df_binned = binner.transform(df[["score", "rating"]], validate=True)
+
+print(df_binned.head())
+print(binner.missing_profile_)
+print(binner.missing_decision_log_)
+```
+
+Rodar localmente:
+
+```bash
+python examples/missing_policy/missing_policy_pandas_demo.py
+```
+
+## Exemplo PySpark
+
+PySpark e extra opcional. A instalacao base nao instala Spark.
+
+```bash
+pip install "riskbands[spark]"
+```
+
+O script completo esta em
+[`examples/missing_policy/missing_policy_pyspark_demo.py`](https://github.com/joaaomaia/RiskBands/blob/main/examples/missing_policy/missing_policy_pyspark_demo.py).
+
+Ele usa:
+
+- `SparkSession` local pequena com `local[2]`;
+- `spark.sql.shuffle.partitions=2`;
+- dataset sintetico pequeno;
+- `missing_policy="separate_bin"`;
+- `transform(validate=True)`;
+- `missing_policy="forbid"` gerando erro claro;
+- nenhum UDF.
+
+```bash
+python examples/missing_policy/missing_policy_pyspark_demo.py
+```
+
+Se PySpark nao estiver instalado, o exemplo avisa como instalar o extra e sai
+sem tornar Spark uma dependencia base.
+
+## O que inspecionar
+
+Apos `fit(...)`, olhe:
+
+- `missing_policy_`
+- `effective_missing_policy_`
+- `missing_profile_`
+- `missing_decision_log_`
+- `fit_profile_`, `reference_profile_` e `application_profile_` quando houver
+  validacao.
+
+`missing_profile_` mostra volume, share, eventos, event rate, backend, contexto
+e se a linha representa bin missing. `missing_decision_log_` registra a acao
+tomada por variavel.
+
+## Bundle e reporting
+
+`export_bundle(...)` persiste a trilha de missing values:
+
+- `missing_policy`
+- `effective_missing_policy`
+- `missing_profile`
+- `missing_decision_log`
+
+```python
+from riskbands.reporting import load_bundle
+
+binner.export_bundle("riskbands_bundle")
+bundle = load_bundle("riskbands_bundle")
+
+print(bundle["missing_policy"])
+print(bundle["missing_profile"])
+```
+
+Bundles antigos sem esses campos continuam carregando como `standard`.
+
+## O que nao esta implementado
+
+Esta pagina documenta o contrato atual. Ela nao anuncia novas features.
+
+Ainda nao existem:
+
+- merge policies auditaveis para unir o bin missing a outro bin;
+- imputacao inteligente dentro do RiskBands;
+- similaridade comportamental automatica para missing;
+- fitting estatistico totalmente distribuido em Spark.
+
+O RiskBands ajuda a tornar a decisao defensavel e auditavel, mas nao garante
+conformidade regulatoria automaticamente.

--- a/docs-site/src/content/docs/technical/outputs.md
+++ b/docs-site/src/content/docs/technical/outputs.md
@@ -142,6 +142,13 @@ Bundles também persistem a trilha de missing values quando disponível:
 Esses campos registram a decisao de tratamento de missing values. Eles nao
 representam imputacao opaca nem merge policies.
 
+Use `missing_profile_` para revisar volume, share e event rate dos missing por
+variavel. Use `missing_decision_log_` para ver se a acao foi preservar o
+comportamento `standard`, criar bin `Missing` com `separate_bin` ou bloquear o
+fluxo com `forbid`.
+
+Guia dedicado: [Missing policy](../missing-policy/).
+
 ## Exemplo
 
 ```python

--- a/docs-site/src/content/docs/technical/quickstart.md
+++ b/docs-site/src/content/docs/technical/quickstart.md
@@ -65,6 +65,8 @@ antes do binning, use `missing_policy="forbid"`.
 
 Essas politicas nao fazem imputacao opaca e nao incluem merge policies.
 
+Para exemplos pandas e PySpark completos, veja [Missing policy](../missing-policy/).
+
 ## Por que esse fluxo é mais amigável
 
 Ele segue convenções familiares:
@@ -128,6 +130,7 @@ Se você precisa reproduzir um comportamento mais histórico ou comparar com a a
 ## Próximos passos
 
 - [Auditoria e plots](../audit-and-plots/)
+- [Missing policy](../missing-policy/)
 - [Outputs e diagnóstico](../outputs/)
 - [Score e estratégias](../score-strategy/)
 - [Exemplos](../examples/)

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -93,6 +93,21 @@ Missing policy semantics:
 No opaque missing-value imputation is added. Merge policies such as
 `merge_nearest_woe` and `merge_nearest_event_rate` are not part of v2.2.0.
 
+For user guidance and runnable examples, see
+[`docs/missing_policy_user_guide.md`](missing_policy_user_guide.md) and:
+
+- `examples/missing_policy/missing_policy_pandas_demo.py`
+- `examples/missing_policy/missing_policy_pyspark_demo.py`
+
+The main audit attributes are:
+
+- `missing_policy_`
+- `effective_missing_policy_`
+- `missing_profile_`
+- `missing_decision_log_`
+
+These fields are also persisted by `export_bundle(...)` when available.
+
 Main attributes after `fit`:
 
 - `bin_summary`

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,8 @@ Entry point for the project documentation.
   Main API contract and public package surface.
 - [docs/v2.2.0_user_guide.md](v2.2.0_user_guide.md)
   v2.2.0 import, missing policies, pandas/PySpark, validation, and bundle guide.
+- [docs/missing_policy_user_guide.md](missing_policy_user_guide.md)
+  Dedicated guide for `standard`, `separate_bin`, `forbid`, pandas/PySpark examples, audit fields, and bundle reporting.
 - [docs/migration.md](migration.md)
   Breaking migration guide for users coming from `NASABinning`.
 - [examples/README.md](../examples/README.md)
@@ -30,6 +32,10 @@ Entry point for the project documentation.
   Visual notebook version with benchmark board, vintage heatmaps and penalty breakdown.
 - [examples/temporal_stability/temporal_stability_example.py](../examples/temporal_stability/temporal_stability_example.py)
   Minimal temporal quickstart.
+- [examples/missing_policy/missing_policy_pandas_demo.py](../examples/missing_policy/missing_policy_pandas_demo.py)
+  Small pandas demo for missing-policy behavior, audit fields, and bundle roundtrip.
+- [examples/missing_policy/missing_policy_pyspark_demo.py](../examples/missing_policy/missing_policy_pyspark_demo.py)
+  Small optional PySpark demo for `separate_bin`, `forbid`, and `transform(validate=True)`.
 - [examples/pd_vintage_champion_challenger/pd_vintage_champion_challenger.py](../examples/pd_vintage_champion_challenger/pd_vintage_champion_challenger.py)
   Credit-risk / PD anchor example with vintages.
 
@@ -53,4 +59,3 @@ pytest -q --basetemp .pytest_tmp
 Light CI workflow:
 
 - [tests.yml](../.github/workflows/tests.yml)
-

--- a/docs/missing_policy_user_guide.md
+++ b/docs/missing_policy_user_guide.md
@@ -1,0 +1,241 @@
+# Missing policy user guide
+
+Este guia explica como usar `missing_policy` no RiskBands em fluxos pandas e
+PySpark, com foco em risco de credito, auditabilidade e revisao defensavel do
+binning. Ele complementa o contrato tecnico da v2.2.0 e prepara a trilha
+docs-only v2.2.0 documentation update.
+
+## Por que missing values importam
+
+Em risco de credito, valores ausentes raramente sao apenas "sujeira" estatistica.
+Um campo missing pode indicar falta de documentacao, origem diferente do cliente,
+produto novo, falha operacional, canal de captura incompleto ou mudanca de
+politica. Por isso, substituir missing values silenciosamente com `fillna(...)`
+antes do binning pode esconder um comportamento relevante.
+
+O RiskBands trata missing values como parte do contrato auditavel do binning. A
+decisao deve ficar visivel para quem revisa o modelo, para quem monitora drift e
+para quem precisa explicar por que determinado bin foi mantido, isolado ou
+bloqueado.
+
+## Politicas disponiveis
+
+Use `missing_policy` ao criar o `RiskBands`:
+
+```python
+from riskbands import RiskBands
+
+binner = RiskBands(missing_policy="separate_bin")
+```
+
+Valores aceitos:
+
+| Politica | Comportamento | Quando usar | Observacao |
+| --- | --- | --- | --- |
+| `standard` | Preserva o comportamento compativel atual. | Quando voce precisa manter compatibilidade com fluxos existentes. | E o default. |
+| `separate_bin` | Cria um bin explicito `Missing` quando ha missing nas features selecionadas. | Quando missing pode carregar sinal de risco e precisa aparecer no reporting. | Recomendado para analise auditavel de missing. |
+| `forbid` | Falha em `fit` ou `transform` se houver missing nas features selecionadas. | Quando a governanca exige que dados ausentes sejam tratados antes do binning. | Nao corrige os dados; bloqueia o fluxo. |
+
+`legacy` nao e recomendacao nova para `missing_policy`. Quando aparecer em
+metadados antigos, ele e tratado como compatibilidade historica e normalizado
+para `standard`.
+
+## `standard`
+
+`standard` e o default. Ele conserva a semantica existente da biblioteca para
+evitar quebra em usuarios atuais.
+
+```python
+binner = RiskBands(
+    max_bins=4,
+    missing_policy="standard",
+)
+```
+
+Use quando:
+
+- voce esta reproduzindo um fluxo ja aprovado;
+- quer comparar v2.2.x com uma execucao anterior;
+- ainda nao decidiu se missing deve ser explicitado como grupo proprio.
+
+Mesmo em `standard`, os campos de auditoria registram a politica efetiva e a
+decisao tomada quando missing values sao encontrados.
+
+## `separate_bin`
+
+`separate_bin` torna missing values explicitos como `Missing`. Isso evita que o
+analista perca de vista o volume, a taxa de evento e o peso do missing no
+resultado.
+
+```python
+binner = RiskBands(
+    max_bins=4,
+    force_categorical=["rating"],
+    missing_policy="separate_bin",
+)
+
+binner.fit(df, y="target", columns=["score", "rating"], validate=True)
+df_binned = binner.transform(df[["score", "rating"]], validate=True)
+```
+
+Use quando:
+
+- missing pode representar comportamento de risco proprio;
+- voce precisa mostrar share, event rate ou WoE do missing;
+- o bundle precisa guardar uma trilha explicita da decisao;
+- o time de model risk quer revisar se missing deve ficar separado no scorecard.
+
+Essa politica nao faz imputacao opaca. Ela separa missing como bin observavel.
+
+## `forbid`
+
+`forbid` e uma politica de governanca. Ela interrompe o fluxo quando missing
+values chegam a uma feature selecionada.
+
+```python
+binner = RiskBands(missing_policy="forbid")
+binner.fit(df, y="target", column="score")
+```
+
+Se `score` tiver missing, o `fit` falha com erro claro. O mesmo vale para
+`transform(...)`: um binner ajustado com `forbid` tambem falha quando a base de
+aplicacao contem missing nas features selecionadas.
+
+Use quando:
+
+- a origem de dados deve garantir completude antes do binning;
+- missing deve ser tratado por uma etapa upstream documentada;
+- a regra de producao nao aceita missing em variaveis criticas.
+
+## Exemplo pandas
+
+O exemplo completo esta em
+`examples/missing_policy/missing_policy_pandas_demo.py`.
+
+Resumo:
+
+```python
+import numpy as np
+import pandas as pd
+
+from riskbands import RiskBands
+
+df = pd.DataFrame(
+    {
+        "score": [410.0, 450.0, np.nan, 620.0, 710.0] * 6,
+        "rating": ["A", "B", None, "C", "D"] * 6,
+        "target": [0, 0, 1, 1, 1] * 6,
+    }
+)
+
+binner = RiskBands(
+    max_bins=4,
+    min_event_rate_diff=0.0,
+    force_categorical=["rating"],
+    missing_policy="separate_bin",
+)
+
+binner.fit(df, y="target", columns=["score", "rating"], validate=True)
+df_binned = binner.transform(df[["score", "rating"]], validate=True)
+
+print(df_binned.head())
+print(binner.missing_profile_)
+print(binner.missing_decision_log_)
+```
+
+## Exemplo PySpark
+
+O exemplo completo esta em
+`examples/missing_policy/missing_policy_pyspark_demo.py`.
+
+PySpark e opcional. A instalacao base do RiskBands nao instala Spark. Use:
+
+```bash
+pip install "riskbands[spark]"
+```
+
+Fluxo resumido:
+
+```python
+from riskbands import RiskBands
+
+binner = RiskBands(
+    max_bins=4,
+    min_event_rate_diff=0.0,
+    force_categorical=["rating"],
+    missing_policy="separate_bin",
+    sample_size=1000,
+)
+
+binner.fit(spark_df, y="target", columns=["score", "rating"], validate=True)
+spark_binned = binner.transform(
+    spark_df.select("score", "rating"),
+    columns=["score", "rating"],
+    validate=True,
+)
+```
+
+O exemplo usa `SparkSession` local pequena, `spark.sql.shuffle.partitions=2`,
+nao usa UDF e coleta apenas uma amostra pequena para demonstracao.
+
+## Como inspecionar a trilha
+
+Apos `fit(...)`, os principais campos sao:
+
+- `missing_policy_`: politica solicitada e normalizada.
+- `effective_missing_policy_`: politica efetivamente aplicada.
+- `missing_profile_`: linhas com volume, share, eventos, event rate, backend,
+  contexto e indicacao de bin missing.
+- `missing_decision_log_`: decisao por variavel, acao tomada e observacoes.
+- `fit_profile_`, `source_profile_`, `reference_profile_` e
+  `application_profile_`: perfis usados em validacao e monitoramento.
+
+Exemplo:
+
+```python
+profile = binner.missing_profile_
+decisions = binner.missing_decision_log_
+```
+
+## Bundle e reporting
+
+`export_bundle(...)` persiste os campos de missing policy quando disponiveis:
+
+- `missing_policy`
+- `effective_missing_policy`
+- `missing_profile`
+- `missing_decision_log`
+
+```python
+from riskbands.reporting import load_bundle
+
+binner.export_bundle("riskbands_bundle")
+bundle = load_bundle("riskbands_bundle")
+
+print(bundle["missing_policy"])
+print(bundle["missing_profile"])
+```
+
+Bundles antigos sem esses campos continuam carregando como `standard` para
+compatibilidade.
+
+## O que ainda nao existe
+
+Esta sprint nao implementa novas politicas nem muda o comportamento do core.
+Ainda nao existem:
+
+- merge policies auditaveis para unir o bin missing a outro bin;
+- imputacao inteligente dentro do RiskBands;
+- similaridade comportamental automatica para decidir destino de missing;
+- backend Spark distribuido completo para o fitting estatistico.
+
+Esses itens devem ser tratados como pesquisa ou trabalho futuro, nunca como
+funcionalidade disponivel.
+
+## Cuidados regulatorios
+
+Use linguagem de defensabilidade e auditabilidade. O RiskBands ajuda a tornar a
+decisao de missing values explicita, rastreavel e revisavel, mas isso nao e uma
+garantia automatica de conformidade regulatoria. A aprovacao depende do contexto
+da instituicao, da politica de dados, da documentacao do modelo e da revisao de
+governanca.

--- a/docs/releases/2.2.0_docs_update.md
+++ b/docs/releases/2.2.0_docs_update.md
@@ -1,0 +1,41 @@
+# RiskBands 2.2.0 documentation update
+
+Type: docs-only preparation.
+
+Status: prepared for documentation review.
+
+This note does not claim PyPI publication and does not create a tag. It records
+the documentation sprint prepared after v2.2.0 for review.
+
+## Highlights
+
+- Adds a dedicated missing-policy guide for `standard`, `separate_bin`, and `forbid`.
+- Adds a runnable pandas example for missing-policy behavior, audit fields, and bundle roundtrip.
+- Adds a runnable optional PySpark example for `separate_bin`, `forbid`, and `transform(validate=True)`.
+- Updates README, API docs, docs index, docs-site navigation, examples page, outputs page, and release notes.
+- Clarifies that PySpark remains optional through `riskbands[spark]`.
+- Clarifies that missing-policy bundle fields are `missing_policy`, `effective_missing_policy`, `missing_profile`, and `missing_decision_log`.
+
+## Scope
+
+- No `riskbands/` core changes.
+- No `pyproject.toml` changes.
+- No package version change.
+- No PyPI/TestPyPI publication.
+- No tag.
+- No automatic push.
+- No i18n implementation.
+
+## Out Of Scope
+
+- No merge policies are implemented.
+- No opaque intelligent imputation is added.
+- No behavioral similarity policy for missing values is added.
+- No full distributed Spark fitting backend is added.
+
+## Review status
+
+Documentation and example validation are tracked in:
+
+- `.tmp_chatgpt_exports/v221_docs_only_work/`
+- final review ZIP under `.tmp_chatgpt_exports/`

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,12 @@
 - `examples/stable_score/stable_score_demo.py`
   Demo minima comparando o score `legacy` com `stable` sobre a mesma cesta de candidatos, mostrando como a decisao muda quando a funcao objetivo passa a priorizar robustez temporal.
 
+- `examples/missing_policy/missing_policy_pandas_demo.py`
+  Demo pequena em pandas para `standard`, `separate_bin`, `forbid`, `missing_profile_`, `missing_decision_log_` e bundle.
+
+- `examples/missing_policy/missing_policy_pyspark_demo.py`
+  Demo pequena e opcional em PySpark para `separate_bin`, `forbid` e `transform(validate=True)`, com guarda quando PySpark nao esta instalado.
+
 - `examples/pd_vintage_benchmark/pd_vintage_benchmark.ipynb`
   Notebook principal da vitrine metodologica, com board comparativo, heatmaps, curvas por vintage e leitura honesta dos trade-offs.
 
@@ -30,6 +36,8 @@
 
 - Script: `python examples/pd_vintage_benchmark/pd_vintage_benchmark.py --all-scenarios`
 - Script: `python examples/stable_score/stable_score_demo.py`
+- Script: `python examples/missing_policy/missing_policy_pandas_demo.py`
+- Script optional Spark: `python examples/missing_policy/missing_policy_pyspark_demo.py`
 - Script + export HTML: `python examples/pd_vintage_benchmark/pd_vintage_benchmark.py --scenario temporal_reversal --export-html-dir benchmark_html`
 - Script: `python examples/temporal_stability/temporal_stability_example.py`
 - Script: `python examples/pd_vintage_champion_challenger/pd_vintage_champion_challenger.py`
@@ -42,6 +50,8 @@
   "Por que um binning estatico com IV alto pode ficar fragil no tempo?"
 - Comece por `riskbands_synthetic_plotly_comparative_demo.ipynb` se a sua pergunta principal for:
   "Qual e o jeito mais curto e familiar de usar o RiskBands hoje?"
+- Comece por `missing_policy/` se a sua pergunta principal for:
+  "Como tornar missing values visiveis, bloqueados ou auditaveis no binning?"
 - Start with `temporal_stability/` if you want to understand the mechanics of the API before going into credit-specific trade-offs.
 - Go to `pd_vintage_champion_challenger/` if your main question is:
   "How can a binning that looks stronger in train lose to a more robust alternative over time?"

--- a/examples/missing_policy/missing_policy_pandas_demo.py
+++ b/examples/missing_policy/missing_policy_pandas_demo.py
@@ -1,0 +1,153 @@
+"""Small pandas demo for RiskBands missing policies."""
+
+from __future__ import annotations
+
+from tempfile import TemporaryDirectory
+
+import numpy as np
+import pandas as pd
+
+from riskbands import RiskBands
+from riskbands.reporting import load_bundle
+
+
+FEATURES = ["score", "rating"]
+
+
+def make_demo_frame() -> pd.DataFrame:
+    """Create a tiny synthetic credit-risk-like dataset with missing values."""
+
+    score_pattern = [
+        410.0,
+        450.0,
+        480.0,
+        np.nan,
+        520.0,
+        560.0,
+        590.0,
+        630.0,
+        np.nan,
+        680.0,
+        710.0,
+        750.0,
+    ]
+    rating_pattern = [
+        "A",
+        "A",
+        "B",
+        "B",
+        None,
+        "C",
+        "C",
+        "D",
+        "D",
+        None,
+        "E",
+        "E",
+    ]
+    target_pattern = [0, 0, 0, 1, 0, 1, 0, 1, 1, 1, 1, 0]
+
+    return pd.DataFrame(
+        {
+            "score": score_pattern * 4,
+            "rating": rating_pattern * 4,
+            "target": target_pattern * 4,
+        }
+    )
+
+
+def _fit_policy(df: pd.DataFrame, policy: str) -> dict[str, object]:
+    binner = RiskBands(
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        force_categorical=["rating"],
+        missing_policy=policy,
+    )
+    binner.fit(df, y="target", columns=FEATURES, validate=True)
+    transformed = binner.transform(df[FEATURES], validate=True)
+
+    return {
+        "policy": policy,
+        "transformed_head": transformed.head(8),
+        "missing_profile": binner.missing_profile_.copy(),
+        "missing_decision_log": binner.missing_decision_log_.copy(),
+        "binner": binner,
+    }
+
+
+def _show(title: str, value: object) -> None:
+    print(f"\n=== {title} ===")
+    print(value)
+
+
+def run_pandas_missing_policy_demo() -> dict[str, object]:
+    """Run standard, separate_bin and forbid examples without persistent files."""
+
+    df = make_demo_frame()
+    standard = _fit_policy(df, "standard")
+    separate = _fit_policy(df, "separate_bin")
+
+    try:
+        RiskBands(
+            max_bins=4,
+            min_event_rate_diff=0.0,
+            force_categorical=["rating"],
+            missing_policy="forbid",
+        ).fit(df, y="target", columns=FEATURES)
+    except ValueError as exc:
+        forbid_fit_error = str(exc)
+    else:  # pragma: no cover - this would mean the policy contract changed.
+        forbid_fit_error = "UNEXPECTED: forbid did not fail on missing fit data."
+
+    clean_df = df.dropna(subset=FEATURES).copy()
+    forbid_clean = RiskBands(
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        force_categorical=["rating"],
+        missing_policy="forbid",
+    ).fit(clean_df, y="target", columns=FEATURES)
+    try:
+        forbid_clean.transform(df[FEATURES])
+    except ValueError as exc:
+        forbid_transform_error = str(exc)
+    else:  # pragma: no cover - this would mean the policy contract changed.
+        forbid_transform_error = "UNEXPECTED: forbid did not fail on missing transform data."
+
+    with TemporaryDirectory(prefix="riskbands_missing_policy_") as tmpdir:
+        separate["binner"].export_bundle(tmpdir)
+        bundle = load_bundle(tmpdir)
+        bundle_summary = {
+            "missing_policy": bundle["missing_policy"],
+            "effective_missing_policy": bundle["effective_missing_policy"],
+            "missing_profile_rows": len(bundle["missing_profile"]),
+            "missing_decision_log_rows": len(bundle["missing_decision_log"]),
+        }
+
+    return {
+        "dataset": df,
+        "standard": standard,
+        "separate_bin": separate,
+        "forbid_fit_error": forbid_fit_error,
+        "forbid_transform_error": forbid_transform_error,
+        "bundle_summary": bundle_summary,
+    }
+
+
+def main() -> None:
+    results = run_pandas_missing_policy_demo()
+
+    _show("Synthetic input", results["dataset"].head(10))
+
+    for policy in ["standard", "separate_bin"]:
+        result = results[policy]
+        _show(f"{policy} transformed head", result["transformed_head"])
+        _show(f"{policy} missing_profile_", result["missing_profile"])
+        _show(f"{policy} missing_decision_log_", result["missing_decision_log"])
+
+    _show("forbid fit error", results["forbid_fit_error"])
+    _show("forbid transform error", results["forbid_transform_error"])
+    _show("separate_bin bundle summary", results["bundle_summary"])
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/missing_policy/missing_policy_pyspark_demo.py
+++ b/examples/missing_policy/missing_policy_pyspark_demo.py
@@ -1,0 +1,148 @@
+"""Small optional PySpark demo for RiskBands missing policies."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from riskbands import RiskBands
+
+
+FEATURES = ["score", "rating"]
+
+
+def _configure_local_spark_environment() -> None:
+    os.environ.setdefault("SPARK_LOCAL_IP", "127.0.0.1")
+    os.environ.setdefault("PYTHONUTF8", "1")
+    os.environ.setdefault("PYSPARK_PYTHON", sys.executable)
+    os.environ.setdefault("PYSPARK_DRIVER_PYTHON", sys.executable)
+
+    if os.name == "nt" and not os.environ.get("JAVA_HOME"):
+        for candidate in [
+            Path("C:/Program Files/Microsoft/jdk-21.0.1.12-hotspot"),
+            Path("C:/Program Files/Java/jdk-22"),
+        ]:
+            if (candidate / "bin" / "java.exe").exists():
+                os.environ["JAVA_HOME"] = str(candidate)
+                break
+
+
+def _spark_imports():
+    try:
+        from pyspark.sql import SparkSession, types as T
+    except ImportError:
+        print(
+            "PySpark is not installed. Install the optional extra with "
+            '`pip install "riskbands[spark]"` to run this demo.'
+        )
+        return None, None
+
+    return SparkSession, T
+
+
+def _make_spark_frame(spark, types_module):
+    rows = [
+        (410.0, "A", 0),
+        (450.0, "A", 0),
+        (480.0, "B", 0),
+        (None, "B", 1),
+        (520.0, None, 0),
+        (560.0, "C", 1),
+        (590.0, "C", 0),
+        (630.0, "D", 1),
+        (None, "D", 1),
+        (680.0, None, 1),
+        (710.0, "E", 1),
+        (750.0, "E", 0),
+    ] * 4
+    schema = types_module.StructType(
+        [
+            types_module.StructField("score", types_module.DoubleType(), True),
+            types_module.StructField("rating", types_module.StringType(), True),
+            types_module.StructField("target", types_module.IntegerType(), False),
+        ]
+    )
+    return spark.createDataFrame(rows, schema=schema)
+
+
+def _show(title: str, value: object) -> None:
+    print(f"\n=== {title} ===")
+    print(value)
+
+
+def run_pyspark_missing_policy_demo() -> dict[str, object]:
+    """Run a small local Spark example, returning skip status when unavailable."""
+
+    _configure_local_spark_environment()
+    SparkSession, T = _spark_imports()
+    if SparkSession is None or T is None:
+        return {"skipped": True, "reason": "pyspark is not installed"}
+
+    spark_tmp = Path(".pytest_tmp/spark_missing_policy_demo")
+    spark_tmp.mkdir(parents=True, exist_ok=True)
+
+    spark = (
+        SparkSession.builder.master("local[2]")
+        .appName("riskbands-missing-policy-demo")
+        .config("spark.sql.shuffle.partitions", "2")
+        .config("spark.ui.enabled", "false")
+        .config("spark.local.dir", str(spark_tmp.resolve()))
+        .getOrCreate()
+    )
+    spark.sparkContext.setLogLevel("WARN")
+
+    try:
+        sdf = _make_spark_frame(spark, T)
+        binner = RiskBands(
+            max_bins=4,
+            min_event_rate_diff=0.0,
+            force_categorical=["rating"],
+            missing_policy="separate_bin",
+            sample_size=1000,
+        )
+        binner.fit(sdf, y="target", columns=FEATURES, validate=True)
+        transformed = binner.transform(
+            sdf.select(*FEATURES),
+            columns=FEATURES,
+            validate=True,
+        )
+        transformed_preview = transformed.limit(8).toPandas()
+
+        try:
+            RiskBands(
+                max_bins=4,
+                min_event_rate_diff=0.0,
+                force_categorical=["rating"],
+                missing_policy="forbid",
+            ).fit(sdf, y="target", columns=FEATURES)
+        except ValueError as exc:
+            forbid_fit_error = str(exc)
+        else:  # pragma: no cover - this would mean the policy contract changed.
+            forbid_fit_error = "UNEXPECTED: forbid did not fail on Spark missing data."
+
+        return {
+            "skipped": False,
+            "transformed_preview": transformed_preview,
+            "missing_profile": binner.missing_profile_.copy(),
+            "missing_decision_log": binner.missing_decision_log_.copy(),
+            "forbid_fit_error": forbid_fit_error,
+        }
+    finally:
+        spark.stop()
+
+
+def main() -> None:
+    results = run_pyspark_missing_policy_demo()
+    if results["skipped"]:
+        _show("PySpark demo skipped", results["reason"])
+        return
+
+    _show("separate_bin transformed preview", results["transformed_preview"])
+    _show("separate_bin missing_profile_", results["missing_profile"])
+    _show("separate_bin missing_decision_log_", results["missing_decision_log"])
+    _show("forbid fit error", results["forbid_fit_error"])
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -146,3 +146,36 @@ def test_stable_score_example_flow_smoke():
     assert len(results["baseline_note"]) > 20
 
 
+def test_missing_policy_pandas_example_flow_smoke():
+    module = _load_example_module(
+        "examples/missing_policy/missing_policy_pandas_demo.py"
+    )
+
+    results = module.run_pandas_missing_policy_demo()
+
+    assert {
+        "dataset",
+        "standard",
+        "separate_bin",
+        "forbid_fit_error",
+        "forbid_transform_error",
+        "bundle_summary",
+    } <= set(results)
+    assert not results["standard"]["missing_decision_log"].empty
+    assert not results["separate_bin"]["missing_profile"].empty
+    assert set(results["separate_bin"]["transformed_head"]["rating"].astype(str)) >= {"Missing"}
+    assert "missing_policy='forbid'" in results["forbid_fit_error"]
+    assert results["bundle_summary"]["missing_policy"] == "separate_bin"
+
+
+def test_missing_policy_pyspark_example_optional_guard(monkeypatch):
+    module = _load_example_module(
+        "examples/missing_policy/missing_policy_pyspark_demo.py"
+    )
+    monkeypatch.setattr(module, "_spark_imports", lambda: (None, None))
+
+    results = module.run_pyspark_missing_policy_demo()
+
+    assert results == {"skipped": True, "reason": "pyspark is not installed"}
+
+


### PR DESCRIPTION
Adds documentation and examples for auditable missing value policies introduced in v2.2.0. This is a docs/examples update only: no core package changes, no version bump, no i18n, and no merge-policy implementation.