### PR TITLE
Add English documentation site

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -31,6 +31,10 @@ export default defineConfig({
           label: 'Português (Brasil)',
           lang: 'pt-BR',
         },
+        en: {
+          label: 'English',
+          lang: 'en',
+        },
       },
       lastUpdated: true,
       social: [
@@ -121,41 +125,86 @@ export default defineConfig({
       sidebar: [
         {
           label: 'Porta técnica',
+          translations: { en: 'Technical guide' },
           items: [
-            { label: 'Instalação', link: '/technical/installation/' },
-            { label: 'Quickstart', link: '/technical/quickstart/' },
-            { label: 'Score e estratégias', link: '/technical/score-strategy/' },
-            { label: 'Missing policy', link: '/technical/missing-policy/' },
-            { label: 'Outputs e diagnóstico', link: '/technical/outputs/' },
-            { label: 'Auditoria e plots', link: '/technical/audit-and-plots/' },
-            { label: 'Optuna', link: '/technical/optuna/' },
-            { label: 'Visão geral da API', link: '/technical/api-overview/' },
-            { label: 'Exemplos', link: '/technical/examples/' },
+            { label: 'Instalação', translations: { en: 'Installation' }, slug: 'technical/installation' },
+            { label: 'Quickstart', slug: 'technical/quickstart' },
+            {
+              label: 'Score e estratégias',
+              translations: { en: 'Score and strategies' },
+              slug: 'technical/score-strategy',
+            },
+            { label: 'Missing policy', slug: 'technical/missing-policy' },
+            {
+              label: 'Outputs e diagnóstico',
+              translations: { en: 'Outputs and diagnostics' },
+              slug: 'technical/outputs',
+            },
+            {
+              label: 'Auditoria e plots',
+              translations: { en: 'Audit and plots' },
+              slug: 'technical/audit-and-plots',
+            },
+            { label: 'Optuna', slug: 'technical/optuna' },
+            {
+              label: 'Visão geral da API',
+              translations: { en: 'API overview' },
+              slug: 'technical/api-overview',
+            },
+            { label: 'Exemplos', translations: { en: 'Examples' }, slug: 'technical/examples' },
           ],
         },
         {
           label: 'Porta metodológica',
+          translations: { en: 'Methodology' },
           items: [
-            { label: 'Por que RiskBands', link: '/methodology/why-riskbands/' },
+            {
+              label: 'Por que RiskBands',
+              translations: { en: 'Why RiskBands' },
+              slug: 'methodology/why-riskbands',
+            },
             {
               label: 'Por que não usar apenas OptimalBinning',
-              link: '/methodology/why-not-only-optimal-binning/',
+              translations: { en: 'Why not only OptimalBinning' },
+              slug: 'methodology/why-not-only-optimal-binning',
             },
-            { label: 'Benchmark PD vintage', link: '/methodology/pd-vintage-benchmark/' },
-            { label: 'Como ler os gráficos', link: '/methodology/how-to-read-the-charts/' },
+            {
+              label: 'Benchmark PD vintage',
+              translations: { en: 'PD vintage benchmark' },
+              slug: 'methodology/pd-vintage-benchmark',
+            },
+            {
+              label: 'Como ler os gráficos',
+              translations: { en: 'How to read the charts' },
+              slug: 'methodology/how-to-read-the-charts',
+            },
             {
               label: 'Robustez temporal em risco de crédito',
-              link: '/methodology/temporal-robustness-in-credit-risk/',
+              translations: { en: 'Temporal robustness in credit risk' },
+              slug: 'methodology/temporal-robustness-in-credit-risk',
             },
           ],
         },
         {
           label: 'Projeto',
+          translations: { en: 'Project' },
           items: [
-            { label: 'Release Notes', link: '/reference/release-notes/' },
-            { label: 'Evolução após v1.0.0', link: '/reference/after-v1-0/' },
-            { label: 'Publicações', link: '/reference/publications/' },
-            { label: 'Desenvolvimento', link: '/project/development/' },
+            { label: 'Release Notes', slug: 'reference/release-notes' },
+            {
+              label: 'Evolução após v1.0.0',
+              translations: { en: 'Evolution after v1.0.0' },
+              slug: 'reference/after-v1-0',
+            },
+            {
+              label: 'Publicações',
+              translations: { en: 'Publications' },
+              slug: 'reference/publications',
+            },
+            {
+              label: 'Desenvolvimento',
+              translations: { en: 'Development' },
+              slug: 'project/development',
+            },
           ],
         },
       ],

--- a/docs-site/src/content/docs/en/index.md
+++ b/docs-site/src/content/docs/en/index.md
@@ -1,0 +1,118 @@
+---
+title: "RiskBands documentation"
+description: "Official RiskBands documentation for temporal-robust binning, stable scoring, friendly onboarding, and credit-ready workflows."
+template: splash
+hero:
+  title: RiskBands
+  tagline: >-
+    Binning for credit risk with a focus on temporal robustness. RiskBands helps
+    move from a static IV reading to a more defensible decision across
+    separation, stability, and auditability.
+  actions:
+    - text: Get started
+      link: ./technical/quickstart/
+      icon: right-arrow
+    - text: Understand the stable score
+      link: ./technical/score-strategy/
+      icon: right-arrow
+      variant: minimal
+features:
+  - title: Quick start
+    description: Installation, a minimal first example, and the recommended `RiskBands` workflow in a sklearn/pandas style.
+    link: ./technical/quickstart/
+  - title: Score strategy
+    description: Understand `standard` vs `stable`, when to use each one, and how to think about separation versus temporal robustness.
+    link: ./technical/score-strategy/
+  - title: Readable outputs
+    description: Learn how to interpret `summary()`, `report()`, `score_details()`, `diagnostics()`, and `binning_table()`.
+    link: ./technical/outputs/
+  - title: Auditable missing values
+    description: Use `standard`, `separate_bin`, or `forbid` without opaque imputation and with a persisted audit trail in bundles.
+    link: ./technical/missing-policy/
+  - title: API overview
+    description: See the public surface for onboarding, audit, temporal reading, exports, and public plots.
+    link: ./technical/api-overview/
+  - title: Examples
+    description: Follow scripts and notebooks for quickstart, benchmark, audit, missing policy, and friendly API usage.
+    link: ./technical/examples/
+  - title: Release notes
+    description: Review the main public package and documentation milestones without changing release status.
+    link: ./reference/release-notes/
+---
+
+## What RiskBands is
+
+RiskBands is a Python library for building, comparing, and auditing binning
+candidates when the real question is not only "which cut has the highest IV?",
+but:
+
+> which solution remains more defensible when time becomes part of the analysis?
+
+It was designed for cases such as:
+
+- PD models
+- credit scorecards
+- vintage or cohort analysis
+- variables with temporal drift
+- structures with rare bins, fragile coverage, or ranking reversals
+
+## Why use it
+
+`OptimalBinning` already solves static cuts very well. RiskBands helps decide
+whether that cut is still the best answer when behavior is opened by period.
+
+In practice, the project adds:
+
+- temporal diagnostics by variable, bin, and period
+- a temporal-robustness-oriented score with the `stable` strategy
+- candidate comparison through `BinComparator`
+- auditable reports explaining why a candidate won
+
+## Recommended path for a new user
+
+1. Install the Python package.
+2. Run the [Quickstart](./technical/quickstart/).
+3. Read [Score and strategies](./technical/score-strategy/) to understand `stable`.
+4. Read [Missing policy](./technical/missing-policy/) if your data contains missing values.
+5. Use [Outputs and diagnostics](./technical/outputs/) to learn how to read the result.
+6. Continue with [Examples](./technical/examples/) or the methodology pages in the pt-BR documentation.
+
+## Minimal flow
+
+```python
+from riskbands import RiskBands
+
+binner = RiskBands(
+    strategy="supervised",
+    score_strategy="stable",
+    max_n_bins=5,
+    check_stability=True,
+    missing_policy="standard",
+)
+
+binner.fit(df, y="target", column="score", time_col="month")
+summary = binner.summary()
+score_details = binner.score_details()
+```
+
+## What makes the `stable` score different
+
+`stable` does not choose the best candidate only by static IV.
+
+It combines:
+
+- temporal variance of shrunken WoE
+- drift between windows
+- ranking inversions between bins
+- separation
+- entropy
+- PSI
+
+All of these are combined in a comparable minimization-oriented objective.
+
+## Next steps
+
+- Want to start using it? Go to [Quickstart](./technical/quickstart/).
+- Need to audit missing values? Go to [Missing policy](./technical/missing-policy/).
+- Want to understand the recommended strategy? Go to [Score and strategies](./technical/score-strategy/).
+- Want the public API map? Go to [API overview](./technical/api-overview/).

--- a/docs-site/src/content/docs/en/methodology/how-to-read-the-charts.md
+++ b/docs-site/src/content/docs/en/methodology/how-to-read-the-charts.md
@@ -1,0 +1,14 @@
+---
+title: "How to read the charts"
+description: "Translation backlog note for the chart-reading guide."
+---
+
+## Translation backlog
+
+This page has not been fully translated in this sprint.
+
+Use the pt-BR page for the complete methodological content:
+
+- [Como ler os graficos](../../../methodology/how-to-read-the-charts/)
+
+The English translation is tracked in `docs/i18n_ptbr_en_strategy.md`.

--- a/docs-site/src/content/docs/en/methodology/pd-vintage-benchmark.md
+++ b/docs-site/src/content/docs/en/methodology/pd-vintage-benchmark.md
@@ -1,0 +1,14 @@
+---
+title: "PD vintage benchmark"
+description: "Translation backlog note for the PD vintage benchmark page."
+---
+
+## Translation backlog
+
+This page has not been fully translated in this sprint.
+
+Use the pt-BR page for the complete methodological content:
+
+- [Benchmark PD vintage](../../../methodology/pd-vintage-benchmark/)
+
+The English translation is tracked in `docs/i18n_ptbr_en_strategy.md`.

--- a/docs-site/src/content/docs/en/methodology/temporal-robustness-in-credit-risk.md
+++ b/docs-site/src/content/docs/en/methodology/temporal-robustness-in-credit-risk.md
@@ -1,0 +1,112 @@
+---
+title: "Temporal robustness in credit risk"
+description: "Why temporal stability, coverage, and reversals matter in binning for PD and scorecards."
+---
+
+## What temporal robustness means here
+
+In the context of RiskBands, temporal robustness is not a vague label for
+"stability".
+
+It represents the practical ability of a binning candidate to remain
+interpretable and defensible when the variable is observed across different
+periods or vintages.
+
+## Signals that matter most
+
+### Coverage
+
+If a bin loses too much volume in certain periods, the aggregate structure may
+still look good while the operational interpretation has already weakened.
+
+### Rare bins
+
+Rare bins are often a warning that the structure is too sensitive for
+production and governance use.
+
+### Ordering reversals
+
+When the expected event-rate order changes from one vintage to another, the
+binning tends to become harder to defend, especially in scorecards and PD.
+
+### Volatility
+
+High volatility in event rate, WoE, or bin share suggests that the candidate may
+not be structurally stable, even with attractive aggregate separation.
+
+## Why credit is different
+
+Credit portfolios move over time in ways that make temporal robustness an
+operational concern:
+
+- approval mix changes
+- underwriting policies change
+- deterioration can concentrate in specific score regions
+- vintage reading naturally appears in committees and validation
+
+For that reason, a candidate that looks excellent in aggregate can still be the
+wrong choice.
+
+## The role of aggregate metrics
+
+The point is not to abandon aggregate metrics.
+
+IV and KS remain important. What changes is the reading:
+
+- first, they show separation quality
+- then, temporal analysis shows whether that separation remains sustainable over time
+
+## Two scenarios that calibrate the reading
+
+<div class="rb-grid rb-grid--2">
+  <figure class="rb-figure rb-figure--wide rb-figure--compact">
+    <iframe
+      src="../../../benchmark-assets/stable_credit_metric_comparison.html"
+      title="Stable Credit scenario - metric comparison"
+      loading="lazy"
+    ></iframe>
+    <figcaption>
+      In <em>Stable Credit</em>, the temporal layer does not need to force a
+      change: temporal robustness can also validate the static candidate when
+      the trade-off does not require a switch.
+    </figcaption>
+  </figure>
+  <figure class="rb-figure rb-figure--wide rb-figure--compact">
+    <iframe
+      src="../../../benchmark-assets/temporal_reversal_metric_comparison.html"
+      title="Temporal Reversal scenario - metric comparison"
+      loading="lazy"
+    ></iframe>
+    <figcaption>
+      In <em>Temporal Reversal</em>, the final candidate's gain appears because
+      the benchmark stops looking only at aggregate discrimination.
+    </figcaption>
+  </figure>
+</div>
+
+## Where fragility usually appears
+
+<figure class="rb-figure rb-figure--wide rb-figure--medium">
+  <iframe
+    src="../../../benchmark-assets/temporal_reversal_selected_heatmap.html"
+    title="Temporal robustness heatmap in the benchmark"
+    loading="lazy"
+  ></iframe>
+  <figcaption>
+    Temporal fragility is rarely homogeneous. It often appears in specific
+    regions of the variable or in more recent vintages, and the heatmap is a
+    fast way to locate it.
+  </figcaption>
+</figure>
+
+## Practical takeaway
+
+Temporal robustness does not mean "always choose the smoothest candidate".
+
+It means:
+
+- explicitly measuring the temporal trade-off
+- comparing it against static separation
+- making a decision with a rationale that survives challenge and governance
+
+That is exactly the decision frame RiskBands tries to offer.

--- a/docs-site/src/content/docs/en/methodology/why-not-only-optimal-binning.md
+++ b/docs-site/src/content/docs/en/methodology/why-not-only-optimal-binning.md
@@ -1,0 +1,112 @@
+---
+title: "Why not only OptimalBinning"
+description: "An honest explanation of where OptimalBinning is already strong and where RiskBands adds the decision layer credit teams need under temporal stress."
+---
+
+## Start with the honest point
+
+`OptimalBinning` already solves the static cutting problem very well.
+
+RiskBands does not need to deny that. On the contrary: in the current
+repository, the numeric supervised strategy uses `optbinning.OptimalBinning` in
+the backend.
+
+This means the correct message is not:
+
+- "RiskBands completely replaces OptimalBinning"
+
+The correct message is:
+
+- "RiskBands reuses a strong static cut when it makes sense and adds the layers needed for credit selection under temporal stress"
+
+## What static search does not answer by itself
+
+Static search is excellent for questions such as:
+
+- where are the best aggregate cuts?
+- how can static separation be maximized?
+
+But credit teams also need to answer questions such as:
+
+- does ordering between bins survive by vintage?
+- where does the event rate cross over time?
+- which bins lose coverage?
+- are we accepting a candidate with hidden structural fragility?
+- if two candidates are plausible, which one has the more defensible rationale?
+
+## What RiskBands adds on top
+
+| Layer | Role |
+| --- | --- |
+| Temporal diagnostics | Look beyond aggregate separation |
+| Structural penalties | Penalize fragile bins, low coverage, reversals, and volatility |
+| Candidate comparison | Put static, temporal, and balanced candidates on the same scale |
+| Auditable rationale | Explain why a candidate won in terms closer to the business |
+| Credit-oriented score | Balance discrimination with temporal defensibility |
+
+## An honest comparison
+
+<div class="rb-grid rb-grid--2">
+  <div class="rb-card rb-card--positive">
+    <span class="rb-kicker">When static remains enough</span>
+    <p>
+      If behavior by vintage remains coherent and the structure does not lose
+      coverage, RiskBands can simply confirm the static winner.
+    </p>
+  </div>
+  <div class="rb-card rb-card--warn">
+    <span class="rb-kicker">When the static answer is not enough</span>
+    <p>
+      If vintage reading reveals crossings, rare bins, or loss of coherence,
+      maximizing only IV stops being a comfortable answer for credit.
+    </p>
+  </div>
+</div>
+
+## Where Optuna fits, without exaggeration
+
+The project can also use `Optuna` as an optional search layer in supervised
+flows.
+
+This point matters, but it should not be confused with the main RiskBands
+thesis.
+
+Optuna enters to explore configurations when that makes sense. The real
+differentiator remains the scale used to judge candidates:
+
+- separation
+- temporal stability
+- coverage
+- reversals
+- structural fragility
+- auditable objective score
+
+## Why this matters in PD
+
+In credit, the practical decision is rarely:
+
+- "what is the best set of static cuts from a mathematical point of view?"
+
+It is usually closer to:
+
+- "what is the best set of cuts that I can still defend when the portfolio changes over time?"
+
+RiskBands was designed to occupy that space.
+
+<figure class="rb-figure rb-figure--wide rb-figure--medium">
+  <iframe
+    src="../../../benchmark-assets/temporal_reversal_aggregate_vs_vintage.html"
+    title="Aggregate versus vintage reading in the benchmark"
+    loading="lazy"
+  ></iframe>
+  <figcaption>
+    This visual helps answer directly why the problem does not end with the
+    static cut: the aggregate can remain competitive while the vintage view
+    reveals loss of coherence.
+  </figcaption>
+</figure>
+
+## Related pages
+
+- [Why RiskBands](../why-riskbands/)
+- [Temporal robustness in credit risk](../temporal-robustness-in-credit-risk/)

--- a/docs-site/src/content/docs/en/methodology/why-riskbands.md
+++ b/docs-site/src/content/docs/en/methodology/why-riskbands.md
@@ -1,0 +1,78 @@
+---
+title: "Why RiskBands"
+description: "The project's central thesis in one page: static cut quality is not enough when the decision has to survive over time."
+---
+
+## The core problem
+
+In many credit-risk workflows, a variable is judged mainly by aggregate
+separation. This is useful, but incomplete.
+
+A binning candidate may look strong in:
+
+- aggregate IV
+- aggregate KS
+- visually clean static cuts
+
+and still become hard to defend when the analysis is opened by vintage:
+
+- event-rate behavior by vintage
+- coverage loss in specific periods
+- rare bins
+- ordering reversals
+- structural fragility under composition shift
+
+## What RiskBands tries to solve
+
+RiskBands exists for the point where a team needs to answer:
+
+> which binning candidate remains more defensible when the temporal view truly enters the decision?
+
+That is why the project is built around:
+
+- temporal diagnostics
+- candidate comparison
+- structural penalties
+- auditable rationale
+
+## What the project is not saying
+
+RiskBands does not start from the assumption that every static solution is
+wrong.
+
+A good temporal layer should sometimes:
+
+- confirm the static winner
+
+and in other cases:
+
+- replace the static winner with a more robust alternative
+
+Both outcomes can be correct. The project's value is judging the trade-off
+better, not forcing a temporal choice every time.
+
+## Why this is especially relevant in credit
+
+Credit work is naturally sensitive to:
+
+- origination vintages
+- changes in approval mix
+- localized deterioration
+- governance and defensibility requirements
+
+This makes the binning decision more operational than purely mathematical.
+
+## The practical promise
+
+RiskBands tries to help move from a sentence like:
+
+- "this candidate won on IV"
+
+to a sentence like:
+
+- "this candidate won because it keeps balancing discrimination, temporal stability, coverage, and structural robustness as the portfolio moves through time"
+
+## Related pages
+
+- [Why not only OptimalBinning](../why-not-only-optimal-binning/)
+- [Temporal robustness in credit risk](../temporal-robustness-in-credit-risk/)

--- a/docs-site/src/content/docs/en/project/development.md
+++ b/docs-site/src/content/docs/en/project/development.md
@@ -1,0 +1,14 @@
+---
+title: "Development"
+description: "Translation backlog note for the development page."
+---
+
+## Translation backlog
+
+This page has not been fully translated in this sprint.
+
+Use the pt-BR page for the complete maintainer/development content:
+
+- [Desenvolvimento](../../../project/development/)
+
+The English translation is tracked in `docs/i18n_ptbr_en_strategy.md`.

--- a/docs-site/src/content/docs/en/reference/after-v1-0.md
+++ b/docs-site/src/content/docs/en/reference/after-v1-0.md
@@ -1,0 +1,14 @@
+---
+title: "Evolution after v1.0.0"
+description: "Translation backlog note for the project evolution page."
+---
+
+## Translation backlog
+
+This page has not been fully translated in this sprint.
+
+Use the pt-BR page for the complete project history:
+
+- [Evolucao apos v1.0.0](../../../reference/after-v1-0/)
+
+The English translation is tracked in `docs/i18n_ptbr_en_strategy.md`.

--- a/docs-site/src/content/docs/en/reference/publications.md
+++ b/docs-site/src/content/docs/en/reference/publications.md
@@ -1,0 +1,14 @@
+---
+title: "Publications"
+description: "Translation backlog note for the publications page."
+---
+
+## Translation backlog
+
+This page has not been fully translated in this sprint.
+
+Use the pt-BR page for the complete content:
+
+- [Publications pt-BR page](../../../reference/publications/)
+
+The English translation is tracked in `docs/i18n_ptbr_en_strategy.md`.

--- a/docs-site/src/content/docs/en/reference/release-notes.md
+++ b/docs-site/src/content/docs/en/reference/release-notes.md
@@ -1,0 +1,148 @@
+---
+title: "Release Notes"
+description: "High-level release milestones for the public package and the official documentation."
+---
+
+## Documentation update after v2.2.0
+
+Type: docs-only preparation.
+
+Status: documentation update after v2.2.0; no package version bump.
+
+Main points:
+
+- adds a focused missing-policy guide for `standard`, `separate_bin`, and `forbid`
+- adds small pandas and PySpark missing-policy demos
+- improves docs-site navigation for missing values, bundle fields, and audit logs
+- keeps PySpark documented as optional through `riskbands[spark]`
+- does not change core behavior, package version, publish status, tag, or release artifacts
+
+Notes:
+
+- merge policies remain future work
+- no opaque intelligent imputation is added
+- i18n is handled as a later docs-site sprint, without changing package release status
+
+## v2.2.0
+
+Compatible minor release focused on auditable missing-value policy and compatibility.
+
+Main points:
+
+- `missing_policy="standard"` is the default and preserves the Sprint A baseline behavior
+- `missing_policy="separate_bin"` is opt-in and creates explicit `Missing` bins, including categorical missing values
+- `missing_policy="forbid"` raises during `fit` or `transform` when selected features contain missing values
+- `standard` is the canonical name for the historical maximize-oriented score strategy
+- `legacy` remains accepted as a compatibility alias for `standard`
+- pandas and PySpark inputs are supported by the missing-policy contract
+- bundles persist `missing_policy`, `effective_missing_policy`, `missing_profile`, and `missing_decision_log`
+- old bundles without these fields continue to load as `standard`
+- PySpark remains optional through `riskbands[spark]` with `pyspark>=3.5,<4`
+
+Notes:
+
+- merge policies such as `merge_nearest_woe` and `merge_nearest_event_rate` are not part of this target
+- no opaque intelligent imputation is added
+- a full distributed Spark fitting backend is not part of this target
+
+## v2.1.0
+
+Compatible minor release focused on the preferred `RiskBands` name, optional
+PySpark paths, and validation profiles.
+
+Main points:
+
+- `RiskBands` is the preferred public estimator name; `Binner` remains compatible
+- `min_n_bins` records a soft quality status without forcing artificial cuts
+- `sample_size` controls PySpark fit sampling
+- pandas/PySpark inputs are detected automatically in `fit` and `transform`
+- pandas outputs remain pandas; PySpark outputs remain PySpark
+- `fit(validate=True)` and `transform(validate=True)` create validation profiles with separate fit and transform reports
+- v2.1.0 bundles persist schema/version metadata, profiles, separate validation reports, sampling/backend metadata, and data schema when available
+- PySpark remains optional through `riskbands[spark]` with `pyspark>=3.5,<4`
+
+Notes:
+
+- PySpark fit uses controlled sampling plus the current pandas engine
+- PySpark transform and validation profiles use native Spark expressions and aggregated profiles
+- A full distributed Spark fitting backend is not part of this release
+
+## v2.0.3
+
+Patch release focused on release hardening and deterministic operational behavior.
+
+Main points:
+
+- stronger categorical handling for rare categories, missing values, and unknown categories
+- safer `export_bundle(...)` outputs with sanitized names and a traceable manifest
+- explicit `force_numeric` support
+- stronger quality gates with `ruff`, coverage-enabled `pytest`, `pip check`, `bandit`, and `pip-audit`
+- supply-chain constraints to avoid the vulnerable `ortools 9.11.4210 -> protobuf 5.26.1` resolver path
+- README and release governance updates for pandas, Spark/Databricks usage, overrides, auditable export, assets, and local prompts
+
+## v2.0.2
+
+Release focused on real auditability, friendlier inspection, and a more robust
+public experience.
+
+Main points:
+
+- new public export layer with `export_binnings_json(...)`
+- new auditable bundle with `export_bundle(...)`
+- stronger `metadata_`, including score weights and effective fit context
+- new public tables `score_table()` and `audit_table()`
+- more discoverable aliases for bin inspection
+- new public plot layer for bad rate, heatmap, temporal share, and score components
+- fix to temporal alignment in the supervised strategy, improving diagnostics and visualizations
+- documentation benchmark assets regenerated with wider charts and fewer empty traces
+- docs site reinforced for onboarding, audit, and visual interpretation
+
+## v2.0.1
+
+Patch release to close the public publication with consistency:
+
+- fixes `riskbands.__version__` resolution in the installed package outside the source tree
+- adds regression test for distributed metadata version reading
+- fully preserves the rename to `stable`, the new documentation, and the release flow for the `v2` series
+
+## v2.0.0
+
+Public consolidation release:
+
+- definitive rename of the public `score_strategy` value from `generalization_v1` to `stable`
+- removal of the old name from the public API, examples, smoke tests, labels, and main documentation
+- docs site reorganized for onboarding, first steps, and clearer navigation for new users
+- dedicated pages for `score_strategy`, `normalization_strategy`, `woe_shrinkage_strength`, Optuna, and output interpretation
+- notebooks and examples aligned with the friendly sklearn/pandas-style flow
+- explicit release flow preparation for validation, GitHub Pages, and PyPI publication through Trusted Publishing
+
+## v1.2.0
+
+Important evolution of public API ergonomics:
+
+- `Binner` more aligned with sklearn and pandas conventions
+- friendly support for `fit(df, y="target", column="feature")`
+- `transform(...)` and `fit_transform(...)` with more predictable behavior for `DataFrame` and `Series`
+- public aliases such as `max_n_bins` and `monotonic_trend`
+- new inspection methods: `binning_table()`, `summary()`, `report()`, `score_details()`, `diagnostics()`, and `plot_stability()`
+- easier-to-discover post-fit attributes
+- new Plotly notebook with synthetic data for library onboarding
+
+## v1.1.0
+
+Important evolution of the scoring layer:
+
+- legacy path preserved explicitly as `legacy`
+- new temporal objective introduced and now exposed publicly as `stable`
+- configurable weights, `absolute` normalization, and WoE shrinkage
+- consistent integration with `Binner`, `BinComparator`, auditable reports, and Optuna
+- new minimal example comparing `legacy` versus `stable`
+
+## v1.0.0
+
+Important structural changes already reflected in the repository:
+
+- destructive rename to `riskbands`
+- `Binner` established as the main public class
+- legacy `nasabinning` namespace removed
+- documentation direction oriented toward benchmarks established in repository examples

--- a/docs-site/src/content/docs/en/technical/api-overview.md
+++ b/docs-site/src/content/docs/en/technical/api-overview.md
@@ -1,0 +1,154 @@
+---
+title: "API overview"
+description: "Map of the public RiskBands surface, focused on onboarding, audit, and friendly temporal reading."
+---
+
+## Recommended entry point
+
+In most cases, the ideal flow for a new user is:
+
+1. instantiate `RiskBands`
+2. run `fit(...)`
+3. inspect `summary()`, `score_table()`, and `audit_table()`
+4. apply `transform(...)`
+5. export auditable artifacts
+6. use the public plots for temporal reading
+
+## Main public surface
+
+```python
+from riskbands import RiskBands, Binner, BinComparator
+from riskbands.temporal_stability import (
+    ks_over_time,
+    psi_over_time,
+    temporal_separability_score,
+)
+```
+
+## What became friendlier
+
+Without aggressive changes to the core, the public `Binner` API became closer
+to familiar sklearn and pandas patterns:
+
+- `fit(df, y="target", column="score")`
+- `fit(df["score"], y=df["target"])`
+- `transform(df)` or `transform(df["score"])`
+- `fit_transform(...)`
+- `summary()`
+- `score_details()`
+- `score_table()`
+- `report()`
+- `audit_table()`
+- `diagnostics()`
+- `binning_table()`
+- `feature_binning_table()`
+- `plot_bad_rate_over_time()`
+- `plot_bad_rate_heatmap()`
+- `plot_bin_share_over_time()`
+- `plot_score_components()`
+- `export_binnings_json()`
+- `export_bundle()`
+
+Friendlier configuration aliases were also added:
+
+- `max_n_bins` as an alias for `max_bins`
+- `monotonic_trend` as an alias for `monotonic`
+
+## Core blocks
+
+| Component | Role in the flow | Why it matters |
+| --- | --- | --- |
+| `RiskBands` / `Binner` | Main entry point | Fits, transforms, summarizes, exports, and plots without requiring internal structures |
+| `summary()` | Short post-fit summary | Helps quickly understand bins, IV, and score |
+| `score_table()` | Short objective explanation | Exposes final score, weights, and the most relevant components |
+| `audit_table()` | Consolidated auditable review | Combines cuts, score, penalties, coverage, and rationale |
+| `diagnostics()` | Detailed temporal reading | Opens stability by bin or by variable |
+| `export_binnings_json()` | Single JSON artifact | Makes versioning and governance easier |
+| `export_bundle()` | Complete audit package | Generates JSON, CSV, and feature-level tables |
+| `BinComparator` | Champion/challenger comparison | Remains central when the problem is choosing between multiple candidates |
+
+## Recommended single-candidate flow
+
+```python
+binner = RiskBands(
+    strategy="supervised",
+    score_strategy="stable",
+    max_n_bins=5,
+    check_stability=True,
+    missing_policy="standard",
+)
+
+binner.fit(df, y="target", column="score", time_col="month")
+
+score_bins = binner.transform(df["score"])
+summary = binner.summary()
+score_table = binner.score_table()
+audit_table = binner.audit_table()
+
+binner.export_binnings_json("artifacts/riskbands_binnings.json")
+binner.export_bundle("artifacts/run_2026_04_14")
+```
+
+## Score strategies
+
+Today the API exposes two explicit strategies:
+
+- `standard`
+  Keeps the historical maximization-oriented score. `legacy` remains accepted
+  only as a compatibility alias.
+- `stable`
+  Introduces the temporal-robustness-oriented minimization objective.
+
+## Missing values
+
+`missing_policy` accepts:
+
+- `standard`: compatible default with the current behavior
+- `separate_bin`: opt-in explicit `Missing` bin
+- `forbid`: error during `fit` or `transform` if selected features contain missing values
+
+`separate_bin` does not perform opaque imputation; it makes missing values
+explicit and auditable. Merge policies are not part of the public contract yet.
+
+Dedicated guide: [Missing policy](../missing-policy/).
+
+After `fit`, inspect `missing_profile_` and `missing_decision_log_` to see
+volume, share, event rate, and the decision taken per variable. These fields
+are also persisted by `export_bundle(...)`.
+
+Example:
+
+```python
+binner = RiskBands(
+    strategy="supervised",
+    check_stability=True,
+    time_col="month",
+    missing_policy="separate_bin",
+    score_strategy="stable",
+    score_weights={
+        "temporal_variance_weight": 0.22,
+        "window_drift_weight": 0.18,
+        "rank_inversion_weight": 0.20,
+        "separation_weight": 0.20,
+        "entropy_weight": 0.08,
+        "psi_weight": 0.12,
+    },
+    normalization_strategy="absolute",
+    woe_shrinkage_strength=40.0,
+)
+```
+
+## What to inspect next
+
+After the first `fit`, the most useful trio is usually:
+
+- `summary()` for a short reading
+- `score_table()` to understand score and weights
+- `audit_table()` to open the auditable review
+
+## Next steps
+
+- [Quickstart](../quickstart/)
+- [Outputs and diagnostics](../outputs/)
+- [Missing policy](../missing-policy/)
+- [Examples](../examples/)

--- a/docs-site/src/content/docs/en/technical/audit-and-plots.md
+++ b/docs-site/src/content/docs/en/technical/audit-and-plots.md
@@ -1,0 +1,14 @@
+---
+title: "Audit and plots"
+description: "Translation backlog note for the audit and plots guide."
+---
+
+## Translation backlog
+
+This page has not been fully translated in this sprint.
+
+Use the pt-BR page for the complete technical content:
+
+- [Auditoria e plots](../../../technical/audit-and-plots/)
+
+The English translation is tracked in `docs/i18n_ptbr_en_strategy.md`.

--- a/docs-site/src/content/docs/en/technical/examples.md
+++ b/docs-site/src/content/docs/en/technical/examples.md
@@ -1,0 +1,104 @@
+---
+title: "Examples"
+description: "Scripts and notebooks for quickstart, benchmark, audit, and friendly RiskBands API demonstrations."
+---
+
+## Start here
+
+### API ergonomics notebook
+
+This is the recommended entry point for learning RiskBands with a workflow that
+feels closer to pandas and sklearn.
+
+- [Synthetic notebook with Plotly](https://github.com/joaaomaia/RiskBands/blob/main/examples/riskbands_synthetic_plotly_comparative_demo.ipynb)
+
+This material shows:
+
+- `fit(df, y="target", column="score", time_col="month")`
+- `transform(df["score"])`
+- `summary()`
+- `binning_table()`
+- `score_details()`
+- `diagnostics()`
+- comparison between `standard` and `stable`
+
+### Temporal stability quickstart
+
+This is the shortest entry point to the temporal layer, now with score table,
+audit table, and auditable export.
+
+- [Quickstart script](https://github.com/joaaomaia/RiskBands/blob/main/examples/temporal_stability/temporal_stability_example.py)
+- [Quickstart notebook](https://github.com/joaaomaia/RiskBands/blob/main/examples/temporal_stability/temporal_stability_example.ipynb)
+
+This flow already shows:
+
+- `score_table()`
+- `audit_table()`
+- `export_binnings_json(...)`
+- `export_bundle(...)`
+- `plot_bad_rate_over_time(...)`
+- `plot_bad_rate_heatmap(...)`
+- `plot_bin_share_over_time(...)`
+- `plot_score_components(...)`
+
+### Missing policy with pandas and PySpark
+
+Use these scripts when the main question is how to handle missing values in an
+auditable way without opaque imputation.
+
+- [pandas missing policy demo](https://github.com/joaaomaia/RiskBands/blob/main/examples/missing_policy/missing_policy_pandas_demo.py)
+- [PySpark missing policy demo](https://github.com/joaaomaia/RiskBands/blob/main/examples/missing_policy/missing_policy_pyspark_demo.py)
+
+They show:
+
+- `missing_policy="standard"`
+- `missing_policy="separate_bin"`
+- `missing_policy="forbid"`
+- `missing_profile_`
+- `missing_decision_log_`
+- bundle fields for missing policy
+- optional guard for PySpark
+
+### PD vintage champion/challenger
+
+This is the most direct credit example for comparing candidates.
+
+- [Champion/challenger script](https://github.com/joaaomaia/RiskBands/blob/main/examples/pd_vintage_champion_challenger/pd_vintage_champion_challenger.py)
+- [Champion/challenger notebook](https://github.com/joaaomaia/RiskBands/blob/main/examples/pd_vintage_champion_challenger/pd_vintage_champion_challenger.ipynb)
+
+### PD vintage benchmark
+
+This is the strongest methodology showcase in the project today.
+
+- [Benchmark script](https://github.com/joaaomaia/RiskBands/blob/main/examples/pd_vintage_benchmark/pd_vintage_benchmark.py)
+- [Benchmark notebook](https://github.com/joaaomaia/RiskBands/blob/main/examples/pd_vintage_benchmark/pd_vintage_benchmark.ipynb)
+
+Use this material when the main question is:
+
+> why can a candidate with stronger aggregate IV still be the wrong choice for credit when time enters the decision?
+
+### `stable` score demo
+
+This is the minimal example for seeing the change between the legacy score and
+the current recommended temporal strategy.
+
+- [Demo script](https://github.com/joaaomaia/RiskBands/blob/main/examples/stable_score/stable_score_demo.py)
+
+## Suggested reading order
+
+### If you want to start with the API
+
+1. Synthetic notebook with Plotly
+2. Quickstart
+3. API overview
+4. Outputs and diagnostics
+5. Missing policy
+6. PD vintage champion/challenger
+7. PD vintage benchmark
+
+### If you want to start with the methodology
+
+1. Why RiskBands
+2. Why not only OptimalBinning
+3. PD vintage benchmark
+4. How to read the charts

--- a/docs-site/src/content/docs/en/technical/installation.md
+++ b/docs-site/src/content/docs/en/technical/installation.md
@@ -1,0 +1,90 @@
+---
+title: "Installation"
+description: "How to install RiskBands from PyPI, prepare the development environment, and run the documentation locally."
+---
+
+## Recommended installation
+
+For daily use:
+
+```bash
+pip install riskbands
+```
+
+If you also want the visual extras used in notebooks and Plotly demos:
+
+```bash
+pip install "riskbands[viz]"
+```
+
+To use the optional PySpark fit/transform paths:
+
+```bash
+pip install "riskbands[spark]"
+```
+
+The base package does not install PySpark. The `spark` extra uses
+`pyspark>=3.5,<4`.
+
+## Development environment
+
+To work on the local repository, run tests, and execute notebooks:
+
+```bash
+git clone https://github.com/joaaomaia/RiskBands.git
+cd RiskBands
+pip install -e .[dev]
+```
+
+The `dev` extra adds useful tools for:
+
+- tests with `pytest`
+- notebooks with `ipykernel`
+- `.xlsx` export
+- Plotly visualizations
+- release build and validation
+
+## Main library dependencies
+
+The main installation covers the project core:
+
+- `pandas`
+- `numpy`
+- `scikit-learn`
+- `optbinning`
+- `optuna`
+- `category_encoders`
+
+## Practical notes
+
+- `.xlsx` export requires a compatible engine such as `openpyxl`.
+- The numeric supervised flow reuses `optbinning`.
+- Optuna usage is optional.
+
+## Local documentation
+
+The documentation site lives in `docs-site/` and uses Astro + Starlight.
+
+To run it locally:
+
+```bash
+cd docs-site
+npm ci
+npm run dev
+```
+
+To generate a production build:
+
+```bash
+cd docs-site
+npm ci
+npm run build
+```
+
+## After installation
+
+The best next step is usually:
+
+1. [Quickstart](../quickstart/)
+2. [Score and strategies](../score-strategy/)
+3. [Outputs and diagnostics](../outputs/)

--- a/docs-site/src/content/docs/en/technical/missing-policy.md
+++ b/docs-site/src/content/docs/en/technical/missing-policy.md
@@ -1,0 +1,148 @@
+---
+title: "Missing policy"
+description: "How to use standard, separate_bin, and forbid to handle missing values with an auditable trail in RiskBands."
+---
+
+## Core idea
+
+In credit risk, missing values can carry their own signal. A missing field may
+reflect data source, channel, operational policy, or a change in capture. For
+that reason, silently applying `fillna(...)` before binning can hide a relevant
+decision.
+
+`missing_policy` makes that decision explicit:
+
+```python
+from riskbands import RiskBands
+
+binner = RiskBands(missing_policy="separate_bin")
+```
+
+## Policies
+
+| Policy | What it does | When to use |
+| --- | --- | --- |
+| `standard` | Preserves the current compatible behavior. | Reproducing existing flows and compatibility. |
+| `separate_bin` | Creates an explicit `Missing` bin for missing values in selected features. | Auditable analysis of missing values as their own group. |
+| `forbid` | Fails during `fit` or `transform` when missing values are found. | Governance that requires upstream treatment before binning. |
+
+`legacy` may appear in old metadata for compatibility, but it is not a new
+recommendation. The current canonical name is `standard`.
+
+## pandas example
+
+The complete script is available at
+[`examples/missing_policy/missing_policy_pandas_demo.py`](https://github.com/joaaomaia/RiskBands/blob/main/examples/missing_policy/missing_policy_pandas_demo.py).
+
+```python
+import numpy as np
+import pandas as pd
+
+from riskbands import RiskBands
+
+df = pd.DataFrame(
+    {
+        "score": [410.0, 450.0, np.nan, 620.0, 710.0] * 6,
+        "rating": ["A", "B", None, "C", "D"] * 6,
+        "target": [0, 0, 1, 1, 1] * 6,
+    }
+)
+
+binner = RiskBands(
+    max_bins=4,
+    min_event_rate_diff=0.0,
+    force_categorical=["rating"],
+    missing_policy="separate_bin",
+)
+
+binner.fit(df, y="target", columns=["score", "rating"], validate=True)
+df_binned = binner.transform(df[["score", "rating"]], validate=True)
+
+print(df_binned.head())
+print(binner.missing_profile_)
+print(binner.missing_decision_log_)
+```
+
+Run locally:
+
+```bash
+python examples/missing_policy/missing_policy_pandas_demo.py
+```
+
+## PySpark example
+
+PySpark is an optional extra. The base installation does not install Spark.
+
+```bash
+pip install "riskbands[spark]"
+```
+
+The complete script is available at
+[`examples/missing_policy/missing_policy_pyspark_demo.py`](https://github.com/joaaomaia/RiskBands/blob/main/examples/missing_policy/missing_policy_pyspark_demo.py).
+
+It uses:
+
+- a small local `SparkSession` with `local[2]`;
+- `spark.sql.shuffle.partitions=2`;
+- a small synthetic dataset;
+- `missing_policy="separate_bin"`;
+- `transform(validate=True)`;
+- `missing_policy="forbid"` producing a clear error;
+- no UDF.
+
+```bash
+python examples/missing_policy/missing_policy_pyspark_demo.py
+```
+
+If PySpark is not installed, the example prints how to install the extra and
+exits without making Spark a base dependency.
+
+## What to inspect
+
+After `fit(...)`, look at:
+
+- `missing_policy_`
+- `effective_missing_policy_`
+- `missing_profile_`
+- `missing_decision_log_`
+- `fit_profile_`, `reference_profile_`, and `application_profile_` when
+  validation is enabled.
+
+`missing_profile_` shows volume, share, events, event rate, backend, context,
+and whether the row represents a missing bin. `missing_decision_log_` records
+the action taken per variable.
+
+## Bundle and reporting
+
+`export_bundle(...)` persists the missing-values trail:
+
+- `missing_policy`
+- `effective_missing_policy`
+- `missing_profile`
+- `missing_decision_log`
+
+```python
+from riskbands.reporting import load_bundle
+
+binner.export_bundle("riskbands_bundle")
+bundle = load_bundle("riskbands_bundle")
+
+print(bundle["missing_policy"])
+print(bundle["missing_profile"])
+```
+
+Old bundles without these fields continue to load as `standard`.
+
+## What is not implemented
+
+This page documents the current contract. It does not announce new features.
+
+There are not yet:
+
+- auditable merge policies to merge the missing bin into another bin;
+- intelligent imputation inside RiskBands;
+- automatic behavioral similarity for missing values;
+- fully distributed statistical fitting in Spark.
+
+RiskBands helps make the decision defensible and auditable, but it does not
+automatically guarantee regulatory compliance.

--- a/docs-site/src/content/docs/en/technical/optuna.md
+++ b/docs-site/src/content/docs/en/technical/optuna.md
@@ -1,0 +1,14 @@
+---
+title: "Optuna"
+description: "Translation backlog note for the Optuna guide."
+---
+
+## Translation backlog
+
+This page has not been fully translated in this sprint.
+
+Use the pt-BR page for the complete technical content:
+
+- [Optuna](../../../technical/optuna/)
+
+The English translation is tracked in `docs/i18n_ptbr_en_strategy.md`.

--- a/docs-site/src/content/docs/en/technical/outputs.md
+++ b/docs-site/src/content/docs/en/technical/outputs.md
@@ -1,0 +1,166 @@
+---
+title: "Outputs and diagnostics"
+description: "How to interpret the main Binner outputs after fit, with a focus on audit, score, and temporal reading."
+---
+
+## What appears after `fit`
+
+After fitting a `Binner`, the public API exposes friendlier artifacts for
+inspection:
+
+- `binning_table()`
+- `feature_binning_table()` and `get_binning_table()`
+- `summary()`
+- `score_details()`
+- `score_table()`
+- `report()`
+- `audit_table()`
+- `diagnostics()`
+- `plot_stability()`
+- `plot_bad_rate_over_time()`
+- `plot_bad_rate_heatmap()`
+- `plot_bin_share_over_time()`
+- `plot_score_components()`
+- `export_binnings_json()`
+- `export_bundle()`
+
+Useful post-fit attributes are also available, such as:
+
+- `binning_table_`
+- `summary_`
+- `score_details_`
+- `score_table_`
+- `audit_table_`
+- `report_`
+- `metadata_`
+- `score_`
+- `comparison_score_`
+
+## `binning_table()`
+
+Use it when you want to see final cuts or bins directly.
+
+Questions it helps answer:
+
+- how many bins were kept?
+- which intervals or groups were formed?
+- what is the bin order?
+
+## `score_table()`
+
+This is the shortest notebook table when the central question is:
+
+- why did this score come out this way?
+- which weights entered?
+- which components mattered most?
+- which normalization is active?
+
+It exposes:
+
+- `objective_score`
+- `objective_preference_score`
+- `weight_profile`
+- `normalized_component_profile`
+- `raw_component_profile`
+- detailed `objective_weight_*`, `objective_norm_*`, and `objective_raw_*` columns
+
+## `audit_table()`
+
+This is the most useful table for auditable review and model risk.
+
+It combines in a single view:
+
+- cuts
+- IV and temporal score
+- score and penalties
+- coverage, rare bins, and reversals
+- summarized rationale
+
+## `diagnostics()`
+
+Use `diagnostics(kind="bin")` when you want to open detail by bin and period.
+
+Use `diagnostics(kind="variable")` when you want the aggregated temporal
+summary by variable.
+
+It is the best entry point to investigate:
+
+- coverage
+- event-rate volatility
+- WoE volatility
+- bin share
+- ranking reversals
+- monotonicity breaks
+
+## `metadata_`
+
+Post-fit metadata is now more auditable.
+
+It includes:
+
+- `riskbands` version
+- `strategy`
+- `score_strategy`
+- `normalization_strategy`
+- `woe_shrinkage_strength`
+- provided weights and effective weights
+- `target_name`
+- `time_col`
+- fitted features
+
+## Auditable export
+
+### `export_binnings_json(path)`
+
+Generates a single JSON with:
+
+- general fit metadata
+- score weights
+- bins by feature
+- summary, score details, and audit by feature
+
+### `export_bundle(path)`
+
+Generates an audit package with:
+
+- readable JSON
+- CSVs ready for notebooks or governance
+- feature-level tables
+- optional Parquet when an engine is available
+
+## Fast score reading
+
+A simple rule:
+
+- `standard`: higher raw score is better
+- `stable`: lower raw score is better
+
+If you want a consolidated scale for comparison across strategies, also look
+at `objective_preference_score`.
+
+Bundles also persist the missing-values trail when available:
+`missing_policy`, `effective_missing_policy`, `missing_profile`, and
+`missing_decision_log`.
+
+These fields record the missing-values treatment decision. They do not
+represent opaque imputation or merge policies.
+
+Use `missing_profile_` to review missing volume, share, and event rate by
+variable. Use `missing_decision_log_` to see whether the action was to preserve
+`standard` behavior, create a `Missing` bin with `separate_bin`, or block the
+flow with `forbid`.
+
+Dedicated guide: [Missing policy](../missing-policy/).
+
+## Example
+
+```python
+binner.fit(df, y="target", column="score", time_col="month")
+
+table = binner.binning_table()
+score_table = binner.score_table()
+audit_table = binner.audit_table()
+
+binner.export_binnings_json("artifacts/riskbands_binnings.json")
+binner.export_bundle("artifacts/run_2026_04_14")
+```

--- a/docs-site/src/content/docs/en/technical/quickstart.md
+++ b/docs-site/src/content/docs/en/technical/quickstart.md
@@ -1,0 +1,141 @@
+---
+title: Quickstart
+description: "Fit your first RiskBands object with the project's friendliest API and inspect score, audit, export, and plots in a few steps."
+---
+
+## The recommended flow today
+
+For a new user, the simplest and most complete path is:
+
+1. create a `RiskBands`
+2. fit it with `fit(df, y="target", column="score", time_col="month")`
+3. inspect `summary()`
+4. open `score_table()` and `audit_table()`
+5. export the auditable artifacts
+6. use the public plots for temporal reading
+
+```python
+import numpy as np
+import pandas as pd
+
+from riskbands import RiskBands
+
+rng = np.random.default_rng(0)
+n = 800
+
+df = pd.DataFrame({"score": rng.normal(size=n)})
+df["month"] = rng.choice([202301, 202302, 202303, 202304], size=n)
+
+proba = 0.20 + 0.15 * df["score"] + 0.02 * (df["month"] - 202301)
+proba = np.clip(proba, 0.01, 0.99)
+df["target"] = (rng.random(n) < proba).astype(int)
+
+binner = RiskBands(
+    strategy="supervised",
+    max_n_bins=5,
+    check_stability=True,
+    missing_policy="standard",
+    score_strategy="stable",
+    normalization_strategy="absolute",
+    woe_shrinkage_strength=35.0,
+)
+
+binner.fit(df, y="target", column="score", time_col="month")
+
+score_bins = binner.transform(df["score"])
+summary = binner.summary()
+score_table = binner.score_table()
+audit_table = binner.audit_table()
+
+binner.export_binnings_json("artifacts/riskbands_binnings.json")
+binner.export_bundle("artifacts/quickstart_run")
+
+binner.plot_bad_rate_over_time(df, y="target", column="score", time_col="month")
+binner.plot_bad_rate_heatmap(df, y="target", column="score", time_col="month")
+binner.plot_bin_share_over_time(df, y="target", column="score", time_col="month")
+binner.plot_score_components(column="score")
+```
+
+## Missing values
+
+The default `missing_policy="standard"` preserves current behavior. When you
+need to audit missing values explicitly, use `missing_policy="separate_bin"`.
+When missing values must be blocked before binning, use
+`missing_policy="forbid"`.
+
+These policies do not perform opaque imputation and do not include merge
+policies.
+
+For complete pandas and PySpark examples, see
+[Missing policy](../missing-policy/).
+
+## Why this flow is friendlier
+
+It follows familiar conventions:
+
+- `fit(...)`
+- `transform(...)`
+- `fit_transform(...)`
+- pandas `DataFrame` and `Series` as the first option
+- short tables for notebooks before opening full detail
+
+It also avoids requiring you to assemble pivots, bundles, or internal
+dictionaries at the beginning.
+
+## What to look at first
+
+### `summary()`
+
+This is the best first stop after fitting.
+
+Use it when you want to answer quickly:
+
+- how many bins were kept?
+- what was the IV?
+- which score strategy is active?
+- are there relevant temporal warnings?
+
+### `score_table()`
+
+This is the shortest reading for explaining the objective.
+
+It helps inspect:
+
+- final score
+- comparison score
+- objective direction
+- weights used
+- the most relevant components and penalties
+
+### `audit_table()`
+
+This is the consolidated view for auditable review.
+
+It combines:
+
+- final cuts
+- score
+- coverage
+- rare bins
+- reversals
+- summarized rationale
+
+## When to use `stable`
+
+For a new user, `stable` is usually the best public strategy to start with
+when:
+
+- a temporal column exists
+- stability really matters
+- you want to balance separation and robustness
+
+If you need to reproduce a more historical behavior or compare against the
+previous approach, use `standard`.
+
+## Next steps
+
+- [Missing policy](../missing-policy/)
+- [Outputs and diagnostics](../outputs/)
+- [Score and strategies](../score-strategy/)
+- [API overview](../api-overview/)
+- [Examples](../examples/)

--- a/docs-site/src/content/docs/en/technical/score-strategy.md
+++ b/docs-site/src/content/docs/en/technical/score-strategy.md
@@ -1,0 +1,135 @@
+---
+title: "Score and strategies"
+description: "How to think about `strategy`, `score_strategy`, `stable`, `normalization_strategy`, and `woe_shrinkage_strength` in RiskBands."
+---
+
+## Two strategy levels
+
+In RiskBands, it helps to separate two decisions:
+
+1. `strategy`
+   Decides how the binning is built.
+2. `score_strategy`
+   Decides how candidates are evaluated and compared.
+
+## `strategy`
+
+Today the API mainly exposes:
+
+- `supervised`
+- `unsupervised`
+
+In general:
+
+- use `supervised` when the target is available and you want cuts guided by separation;
+- use `unsupervised` when you want a simpler structure or an internal comparison baseline.
+
+## `score_strategy`
+
+The valid public values now are:
+
+- `standard`
+- `stable`
+
+`standard` is the canonical name of the historical maximization-oriented score.
+`legacy` remains accepted only as a compatibility alias.
+
+## When to use `stable`
+
+`stable` is the preferred strategy when the real question is:
+
+> among plausible candidates, which one best balances separation and temporal robustness?
+
+It is especially useful when you care about:
+
+- temporal variance of WoE
+- drift between windows
+- ranking inversions between bins
+- PSI
+- enough separation without sacrificing stability
+
+In practical terms, `stable` is minimization-oriented:
+
+- lower `objective_score` is better
+- higher `objective_preference_score` still helps with consolidated comparisons
+
+## When to use `standard`
+
+`standard` remains useful when you want to:
+
+- reproduce the project's historical reading
+- compare against previous behavior
+- use a score closer to the older formulation based on positive components minus penalties
+
+## `normalization_strategy`
+
+Today the supported value is:
+
+- `absolute`
+
+It exists to put objective components on a comparable scale even when only one
+candidate is being evaluated.
+
+In practice, it:
+
+- avoids summing incompatible magnitudes
+- helps read normalized components in `score_details()`
+- keeps the objective usable with and without Optuna
+
+## `woe_shrinkage_strength`
+
+This parameter controls how much temporal WoE is pulled toward a more stable
+reference before entering score components.
+
+Practical intuition:
+
+- higher value: more smoothing, less sensitivity to noise and small bins
+- lower value: more fidelity to observed behavior, with greater sensitivity to oscillation
+
+When to increase it:
+
+- small datasets
+- rare bins
+- short or noisy time series
+
+When to reduce it:
+
+- larger samples
+- well-supported bins
+- need to capture finer temporal variation
+
+## Complete example
+
+```python
+from riskbands import RiskBands
+
+binner = RiskBands(
+    strategy="supervised",
+    score_strategy="stable",
+    score_weights={
+        "temporal_variance_weight": 0.22,
+        "window_drift_weight": 0.18,
+        "rank_inversion_weight": 0.20,
+        "separation_weight": 0.20,
+        "entropy_weight": 0.08,
+        "psi_weight": 0.12,
+    },
+    normalization_strategy="absolute",
+    woe_shrinkage_strength=35.0,
+    check_stability=True,
+)
+```
+
+## How to think about separation versus stability
+
+A practical rule:
+
+- if you only maximize static IV, you may choose a temporally fragile candidate;
+- if you only maximize stability, you may choose an almost useless candidate;
+- `stable` tries to balance these two forces explicitly.
+
+## Next steps
+
+- [Outputs and diagnostics](../outputs/)
+- [API overview](../api-overview/)
+- [Quickstart](../quickstart/)

--- a/docs/i18n_ptbr_en_strategy.md
+++ b/docs/i18n_ptbr_en_strategy.md
@@ -1,0 +1,134 @@
+# RiskBands docs i18n strategy: pt-BR + English
+
+## Product decision
+
+RiskBands documentation uses pt-BR as the default language and English as the
+secondary language.
+
+- pt-BR remains at the current unprefixed URLs.
+- English lives under `/en/`.
+- Existing pt-BR URLs must not be moved to `/pt-br/`.
+- The current sprint is docs-only and is not a release announcement.
+
+## Route strategy
+
+The Starlight configuration uses a root locale for pt-BR:
+
+```js
+locales: {
+  root: {
+    label: 'Português (Brasil)',
+    lang: 'pt-BR',
+  },
+  en: {
+    label: 'English',
+    lang: 'en',
+  },
+}
+```
+
+Examples:
+
+| pt-BR route | English route |
+| --- | --- |
+| `/` | `/en/` |
+| `/technical/quickstart/` | `/en/technical/quickstart/` |
+| `/technical/missing-policy/` | `/en/technical/missing-policy/` |
+| `/reference/release-notes/` | `/en/reference/release-notes/` |
+
+## Pages translated in this sprint
+
+Priority pages translated:
+
+- `index`
+- `technical/installation`
+- `technical/quickstart`
+- `technical/api-overview`
+- `technical/missing-policy`
+- `technical/outputs`
+- `technical/score-strategy`
+- `technical/examples`
+- `reference/release-notes`
+
+Optional methodology pages also translated:
+
+- `methodology/why-riskbands`
+- `methodology/why-not-only-optimal-binning`
+- `methodology/temporal-robustness-in-credit-risk`
+
+## Pages still in translation backlog
+
+These pages currently have English backlog notice stubs under `/en/`, but still
+need full translation:
+
+- `technical/audit-and-plots`
+- `technical/optuna`
+- `methodology/pd-vintage-benchmark`
+- `methodology/how-to-read-the-charts`
+- `reference/after-v1-0`
+- `reference/publications`
+- `project/development`
+
+The stubs prevent untranslated pt-BR fallback content from being indexed as
+English while keeping the `/en/` route structure complete.
+
+## How to add a new page in both languages
+
+1. Add or update the pt-BR page at the current unprefixed slug, for example:
+
+   ```text
+   docs-site/src/content/docs/technical/new-page.md
+   ```
+
+2. Add the English equivalent with the same slug under `en/`:
+
+   ```text
+   docs-site/src/content/docs/en/technical/new-page.md
+   ```
+
+3. If the page is included in the sidebar, add or update the sidebar item in
+   `docs-site/astro.config.mjs` using `slug`, not a hard-coded absolute `link`.
+
+4. Add `translations` for sidebar labels when the default label is pt-BR.
+
+## Link rules
+
+- In pt-BR pages, preserve current relative links whenever possible.
+- In EN pages, prefer relative links to English pages, for example
+  `../missing-policy/` or `./technical/quickstart/`.
+- When an EN backlog stub links to the full pt-BR page, use a relative path that
+  escapes `/en/`, for example `../../../technical/optuna/`.
+- Avoid hard-coded root links like `/technical/...` in Markdown content because
+  they can bypass a GitHub Pages base path.
+- Preserve API identifiers and configuration values exactly, including:
+  `missing_policy`, `standard`, `separate_bin`, `forbid`, `RiskBands`, and
+  `Binner`.
+
+## Build validation
+
+From the repository root:
+
+```bash
+npm --prefix docs-site run build
+```
+
+If dependencies are missing:
+
+```bash
+npm --prefix docs-site ci
+npm --prefix docs-site run build
+```
+
+After a successful build, verify:
+
+- pt-BR routes still exist without a locale prefix.
+- `/en/` routes exist for translated pages.
+- `docs-site/dist/sitemap-index.xml` and `docs-site/dist/sitemap-0.xml` exist.
+- `docs-site/dist/pagefind/` contains metadata for both `en` and `pt-br`.
+
+## Next steps
+
+- Fully translate backlog notice pages.
+- Review EN terminology for credit-risk consistency.
+- Consider adding focused link-check automation for `docs-site/dist/`.
+- Keep release announcements separate from docs i18n work.


### PR DESCRIPTION
Adds a first bilingual documentation structure with pt-BR preserved as the default/root language and English available under /en/. This is docs-only: no package/core changes, no version bump, no release announcement, and no merge-policy implementation.