### PR TITLE
Add nearest event rate missing merge policy

### DIFF
--- a/docs/missing_merge_nearest_event_rate_design.md
+++ b/docs/missing_merge_nearest_event_rate_design.md
@@ -1,0 +1,126 @@
+# Missing Merge Nearest Event Rate Design
+
+This note documents the internal E1 implementation of auditable missing-value
+merge behavior. It is not a public release note and does not imply a published
+version.
+
+## Implemented API
+
+The E1 API adds a narrow merge mode:
+
+```python
+RiskBands(
+    missing_policy="merge",
+    missing_merge_criterion="nearest_event_rate",
+    missing_merge_fallback="separate_bin",
+)
+```
+
+Supported values in this sprint:
+
+- `missing_policy`: `standard`, `separate_bin`, `forbid`, `merge`.
+- `missing_merge_criterion`: `nearest_event_rate` only.
+- `missing_merge_fallback`: `separate_bin` or `raise`.
+
+`legacy` remains a compatibility alias for `standard`. The default
+`missing_policy` remains `standard`.
+
+## Fit Behavior
+
+During pandas fit, merge mode treats missing values as an observable training
+group before final routing:
+
+1. Detect missing values for each fitted variable.
+2. Build an internal profile where missing is visible as `Missing`.
+3. Compute the missing group's event rate.
+4. Compute event rates for regular candidate bins.
+5. Select the candidate with the smallest absolute event-rate distance.
+6. Break ties by larger candidate `n`, then lower `bin_order`.
+7. Persist the selected mapping and candidate audit data.
+8. Remove the standalone `Missing` row from final `bin_summary` for variables
+   whose missing group was merged.
+
+The final transform output routes missing values to the learned destination bin,
+but the original missing group remains visible in audit fields.
+
+## Transform Behavior
+
+Transform never learns a merge decision. It only uses fit-time decisions stored
+in `missing_merge_map_`.
+
+If missing values were not observed during fit and appear during transform:
+
+- `missing_merge_fallback="separate_bin"` returns `Missing`.
+- `missing_merge_fallback="raise"` raises a clear error.
+
+The transform fallback path records `missing_transform_fallback_log_`.
+
+## Audit Trail
+
+The implementation preserves missing visibility through:
+
+- `missing_profile_`
+- `missing_decision_log_`
+- `missing_merge_candidates_`
+- `missing_merge_map_`
+- `missing_transform_fallback_log_`
+
+Important decision log fields include:
+
+- `missing_merge_criterion`
+- `missing_merge_fallback`
+- `event_rate_missing_fit`
+- `selected_bin_label`
+- `selected_bin_event_rate`
+- `distance`
+- `tie_break_applied`
+- `candidate_bins`
+- `metrics_before`
+- `metrics_after`
+- `training_only`
+
+Bundle export and JSON/Excel report paths persist the merge audit fields.
+
+## PySpark Boundary
+
+E1 does not implement PySpark merge routing. PySpark fit or transform with
+`missing_policy="merge"` raises:
+
+```text
+missing_policy="merge" with PySpark is not implemented in this release. Use pandas fit/transform or missing_policy="separate_bin"/"forbid".
+```
+
+Existing Spark behavior for `standard`, `separate_bin`, and `forbid` remains in
+scope and is covered by Spark regression tests.
+
+## Limitations
+
+- No `nearest_woe` criterion.
+- No `temporal_stable` criterion.
+- No `monotonic_neighbor` criterion.
+- No custom criterion.
+- No threshold tuning beyond exact nearest event-rate distance.
+- No full PySpark implementation.
+- No use of transform/OOT target data to choose a merge destination.
+
+## Future Work
+
+Sprint E2 can add `nearest_woe` if the WOE definition and smoothing rules are
+made explicit for low-count or zero-event bins.
+
+Later sprints can consider:
+
+- `temporal_stable`, using period-level missing and candidate stability.
+- `monotonic_neighbor`, using ordered-bin constraints.
+- Native Spark transform routing when learned pandas merge maps can be applied
+  without full DataFrame collection.
+- Additional governance controls such as minimum missing count or maximum event
+  rate distance.
+
+## Usage Criteria
+
+Use `missing_policy="merge"` only when the missing group is meaningful, should
+not be hidden, and routing it to the closest observed risk band is acceptable for
+model governance. Prefer `separate_bin` when missingness should remain a visible
+standalone segment in transformed data. Prefer `forbid` when missing values must
+be resolved upstream.

--- a/riskbands/binning_engine.py
+++ b/riskbands/binning_engine.py
@@ -24,12 +24,28 @@ _MAX_PROFILE_ROWS_TO_COLLECT = 100_000
 _STANDARD_MISSING_POLICY = "standard"
 _SEPARATE_BIN_MISSING_POLICY = "separate_bin"
 _FORBID_MISSING_POLICY = "forbid"
+_MERGE_MISSING_POLICY = "merge"
 _LEGACY_POLICY_ALIAS = "legacy"
 _VALID_MISSING_POLICIES = {
     _STANDARD_MISSING_POLICY,
     _SEPARATE_BIN_MISSING_POLICY,
     _FORBID_MISSING_POLICY,
+    _MERGE_MISSING_POLICY,
 }
+_NEAREST_EVENT_RATE_MISSING_MERGE_CRITERION = "nearest_event_rate"
+_VALID_MISSING_MERGE_CRITERIA = {
+    _NEAREST_EVENT_RATE_MISSING_MERGE_CRITERION,
+}
+_SEPARATE_BIN_MISSING_MERGE_FALLBACK = "separate_bin"
+_RAISE_MISSING_MERGE_FALLBACK = "raise"
+_VALID_MISSING_MERGE_FALLBACKS = {
+    _SEPARATE_BIN_MISSING_MERGE_FALLBACK,
+    _RAISE_MISSING_MERGE_FALLBACK,
+}
+_PYSPARK_MISSING_MERGE_UNIMPLEMENTED_MESSAGE = (
+    'missing_policy="merge" with PySpark is not implemented in this release. '
+    'Use pandas fit/transform or missing_policy="separate_bin"/"forbid".'
+)
 
 
 class Binner(BaseEstimator, TransformerMixin):
@@ -51,6 +67,8 @@ class Binner(BaseEstimator, TransformerMixin):
         force_categorical: list[str] | None = None,
         force_numeric: list[str] | None = None,
         missing_policy: str = "standard",
+        missing_merge_criterion: str | None = None,
+        missing_merge_fallback: str = "separate_bin",
         score_strategy: str = "standard",
         score_weights: dict | None = None,
         normalization_strategy: str = "absolute",
@@ -83,8 +101,15 @@ class Binner(BaseEstimator, TransformerMixin):
         self.force_categorical = force_categorical or []
         self.force_numeric = force_numeric or []
         self.missing_policy = self._normalize_missing_policy(missing_policy)
+        self.missing_merge_criterion = self._normalize_missing_merge_criterion(
+            missing_merge_criterion,
+            missing_policy=self.missing_policy,
+        )
+        self.missing_merge_fallback = self._normalize_missing_merge_fallback(missing_merge_fallback)
         self.missing_policy_ = self.missing_policy
         self.effective_missing_policy_ = self.missing_policy
+        self.missing_merge_criterion_ = self.missing_merge_criterion
+        self.missing_merge_fallback_ = self.missing_merge_fallback
         self.objective_kwargs = objective_kwargs or {}
         score_strategy = resolve_score_strategy(score_strategy=score_strategy)
         if "score_strategy" in self.objective_kwargs:
@@ -134,6 +159,16 @@ class Binner(BaseEstimator, TransformerMixin):
             )
         if "missing_policy" in params:
             params["missing_policy"] = self._normalize_missing_policy(params["missing_policy"])
+        prospective_missing_policy = params.get("missing_policy", self.missing_policy)
+        if "missing_merge_criterion" in params or "missing_policy" in params:
+            params["missing_merge_criterion"] = self._normalize_missing_merge_criterion(
+                params.get("missing_merge_criterion", self.missing_merge_criterion),
+                missing_policy=prospective_missing_policy,
+            )
+        if "missing_merge_fallback" in params:
+            params["missing_merge_fallback"] = self._normalize_missing_merge_fallback(
+                params["missing_merge_fallback"]
+            )
         if "min_n_bins" in params:
             params["min_n_bins"] = self._validate_min_n_bins(params["min_n_bins"])
         if "sample_size" in params:
@@ -153,6 +188,8 @@ class Binner(BaseEstimator, TransformerMixin):
         self.monotonic_trend = self.monotonic
         self.missing_policy_ = self.missing_policy
         self.effective_missing_policy_ = self.missing_policy
+        self.missing_merge_criterion_ = self.missing_merge_criterion
+        self.missing_merge_fallback_ = self.missing_merge_fallback
         return result
 
     # ------------------------------------------------------------------
@@ -167,6 +204,43 @@ class Binner(BaseEstimator, TransformerMixin):
                 f"Unsupported missing_policy '{policy}'. Use one of: {allowed}."
             )
         return policy
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _normalize_missing_merge_criterion(
+        value: str | None,
+        *,
+        missing_policy: str,
+    ) -> str | None:
+        if value is None:
+            if missing_policy == _MERGE_MISSING_POLICY:
+                raise ValueError(
+                    "`missing_merge_criterion` is required when missing_policy='merge'. "
+                    "Use 'nearest_event_rate'."
+                )
+            return None
+        criterion = str(value)
+        if missing_policy != _MERGE_MISSING_POLICY:
+            raise ValueError(
+                "`missing_merge_criterion` can only be used with missing_policy='merge'."
+            )
+        if criterion not in _VALID_MISSING_MERGE_CRITERIA:
+            allowed = ", ".join(f"'{item}'" for item in sorted(_VALID_MISSING_MERGE_CRITERIA))
+            raise ValueError(
+                f"Unsupported missing_merge_criterion '{criterion}'. Use one of: {allowed}."
+            )
+        return criterion
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _normalize_missing_merge_fallback(value: str | None) -> str:
+        fallback = _SEPARATE_BIN_MISSING_MERGE_FALLBACK if value is None else str(value)
+        if fallback not in _VALID_MISSING_MERGE_FALLBACKS:
+            allowed = ", ".join(f"'{item}'" for item in sorted(_VALID_MISSING_MERGE_FALLBACKS))
+            raise ValueError(
+                f"Unsupported missing_merge_fallback '{fallback}'. Use one of: {allowed}."
+            )
+        return fallback
 
     # ------------------------------------------------------------------
     @staticmethod
@@ -362,6 +436,8 @@ class Binner(BaseEstimator, TransformerMixin):
         *,
         context: str,
     ) -> None:
+        if self.missing_policy == _MERGE_MISSING_POLICY:
+            raise NotImplementedError(_PYSPARK_MISSING_MERGE_UNIMPLEMENTED_MESSAGE)
         if self.missing_policy != _FORBID_MISSING_POLICY:
             return
         self._raise_forbidden_missing(
@@ -1176,7 +1252,7 @@ class Binner(BaseEstimator, TransformerMixin):
             labels = labels_raw.str.strip().str.lower()
             technical = labels.isin({"total", "totals", "special", "special codes", ""})
             technical |= labels.str.startswith("special")
-            if self.missing_policy != _SEPARATE_BIN_MISSING_POLICY:
+            if not self._uses_explicit_missing_bin():
                 technical |= labels.isin({"missing"})
                 technical |= labels.str.startswith("missing")
             mask &= ~technical
@@ -1189,6 +1265,20 @@ class Binner(BaseEstimator, TransformerMixin):
         return summary.loc[self._fitted_summary_mask(summary)].reset_index(drop=True)
 
     # ------------------------------------------------------------------
+    def _uses_explicit_missing_bin(self) -> bool:
+        return self.missing_policy in {
+            _SEPARATE_BIN_MISSING_POLICY,
+            _MERGE_MISSING_POLICY,
+        }
+
+    # ------------------------------------------------------------------
+    def _is_missing_merge_enabled(self) -> bool:
+        return (
+            self.missing_policy == _MERGE_MISSING_POLICY
+            and self.missing_merge_criterion == _NEAREST_EVENT_RATE_MISSING_MERGE_CRITERION
+        )
+
+    # ------------------------------------------------------------------
     def _refine_bins_for_policy(
         self,
         bin_summary: pd.DataFrame,
@@ -1198,7 +1288,7 @@ class Binner(BaseEstimator, TransformerMixin):
         time_col: str | None = None,
         check_stability: bool = False,
     ) -> pd.DataFrame:
-        if self.missing_policy != _SEPARATE_BIN_MISSING_POLICY:
+        if not self._uses_explicit_missing_bin():
             return refine_bins(
                 bin_summary,
                 min_er_delta=min_er_delta,
@@ -1421,6 +1511,625 @@ class Binner(BaseEstimator, TransformerMixin):
         self.missing_decision_log_ = pd.DataFrame(decision_records)
         self.missing_policy_ = self.missing_policy
         self.effective_missing_policy_ = self.missing_policy
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _row_number(row: pd.Series, field: str, default=np.nan) -> float:
+        value = pd.to_numeric(pd.Series([row.get(field)]), errors="coerce").iloc[0]
+        return float(value) if pd.notna(value) else default
+
+    # ------------------------------------------------------------------
+    def _candidate_row_from_profile(
+        self,
+        *,
+        variable: str,
+        missing_row: pd.Series,
+        candidate: pd.Series,
+        rank: int,
+        selected: bool = False,
+    ) -> dict[str, Any]:
+        missing_event_rate = self._row_number(missing_row, "event_rate")
+        candidate_event_rate = self._row_number(candidate, "event_rate")
+        distance = (
+            abs(missing_event_rate - candidate_event_rate)
+            if np.isfinite(missing_event_rate) and np.isfinite(candidate_event_rate)
+            else np.nan
+        )
+        return {
+            "variable": variable,
+            "criterion": self.missing_merge_criterion,
+            "candidate_rank": rank,
+            "candidate_bin_id": candidate.get("bin_id"),
+            "candidate_bin_label": candidate.get("bin_label"),
+            "candidate_bin_order": candidate.get("bin_order"),
+            "candidate_n": self._row_number(candidate, "n", default=0.0),
+            "candidate_events": self._row_number(candidate, "events", default=0.0),
+            "candidate_non_events": self._row_number(candidate, "non_events", default=0.0),
+            "candidate_event_rate": candidate_event_rate,
+            "missing_n": self._row_number(missing_row, "n", default=0.0),
+            "missing_events": self._row_number(missing_row, "events", default=0.0),
+            "missing_non_events": self._row_number(missing_row, "non_events", default=0.0),
+            "missing_event_rate": missing_event_rate,
+            "distance_event_rate": distance,
+            "distance_metric": "abs_event_rate_diff",
+            "selected": bool(selected),
+        }
+
+    # ------------------------------------------------------------------
+    def _build_missing_merge_audit_from_fit(
+        self,
+        X: pd.DataFrame,
+        y: pd.Series,
+        pre_profile: pd.DataFrame,
+        *,
+        backend: str,
+    ) -> None:
+        feature_columns = list(getattr(self, "feature_names_in_", X.columns))
+        counts = self._pandas_missing_counts(X, feature_columns)
+        profile_records = []
+        decision_records = []
+        candidate_records = []
+        merge_map: dict[str, Any] = {}
+        merge_metrics: dict[str, dict[str, Any]] = {}
+
+        for variable in feature_columns:
+            variable_profile = pre_profile.loc[pre_profile["variable"] == variable].copy()
+            n_missing = int(counts.get(str(variable), 0))
+            missing_detected = n_missing > 0
+            missing_rows = variable_profile.loc[
+                variable_profile.get("is_missing_bin", pd.Series(False, index=variable_profile.index))
+                .fillna(False)
+                .astype(bool)
+            ]
+
+            if missing_detected and not missing_rows.empty:
+                missing_row = missing_rows.iloc[0]
+                missing_n = self._row_number(missing_row, "n", default=float(n_missing))
+                missing_events = self._row_number(missing_row, "events", default=0.0)
+                missing_non_events = self._row_number(missing_row, "non_events", default=missing_n - missing_events)
+                missing_event_rate = self._row_number(missing_row, "event_rate")
+                missing_share = self._row_number(missing_row, "share")
+                profile_record_index = len(profile_records)
+                profile_records.append(
+                    {
+                        "variable": variable,
+                        "policy": self.missing_policy,
+                        "effective_policy": self.missing_policy,
+                        "n_missing_fit": int(missing_n),
+                        "share_missing_fit": missing_share,
+                        "events_missing_fit": missing_events,
+                        "event_rate_missing_fit": missing_event_rate,
+                        "is_missing_bin": True,
+                        "bin_label": missing_row.get("bin_label", "Missing"),
+                        "backend": backend,
+                        "context": "fit",
+                        "merge_criterion": self.missing_merge_criterion,
+                        "merged_into_bin_label": None,
+                        "merge_distance": None,
+                        "merge_status": None,
+                    }
+                )
+            else:
+                missing_row = pd.Series(dtype=object)
+                missing_n = float(n_missing)
+                missing_events = 0.0
+                missing_non_events = 0.0
+                missing_event_rate = np.nan
+                missing_share = np.nan
+                profile_record_index = None
+
+            base_decision = {
+                "variable": variable,
+                "policy_requested": self.missing_policy,
+                "effective_policy": self.missing_policy,
+                "merge_criterion": self.missing_merge_criterion,
+                "missing_merge_criterion": self.missing_merge_criterion,
+                "missing_merge_fallback": self.missing_merge_fallback,
+                "missing_detected": bool(missing_detected),
+                "n_missing_fit": n_missing,
+                "event_rate_missing_fit": missing_event_rate if np.isfinite(missing_event_rate) else None,
+                "training_only": True,
+                "backend": backend,
+                "fallback": self.missing_merge_fallback,
+                "fallback_used": False,
+                "selected_bin_label": None,
+                "selected_bin_order": None,
+                "selected_bin_event_rate": None,
+                "distance_metric": "abs_event_rate_diff",
+                "distance_value": None,
+                "distance": None,
+                "tie_break_rule": "distance_event_rate asc, candidate_n desc, bin_order asc, bin_label asc",
+                "tie_break_applied": False,
+                "tie_detected": False,
+                "candidate_count": 0,
+                "candidate_bins": [],
+                "metrics_before": None,
+                "metrics_after": None,
+            }
+
+            if not missing_detected:
+                decision_records.append(
+                    {
+                        **base_decision,
+                        "action": "no_missing_detected",
+                        "status": "no_missing_detected",
+                        "reason": "no_missing_detected",
+                        "notes": "No missing values were observed during fit; no merge destination was learned.",
+                    }
+                )
+                continue
+
+            if missing_rows.empty:
+                reason = "missing_profile_unavailable"
+                if self.missing_merge_fallback == _RAISE_MISSING_MERGE_FALLBACK:
+                    raise ValueError(
+                        f"missing_policy='merge' could not build a missing profile for variable "
+                        f"'{variable}'."
+                    )
+                if profile_record_index is not None:
+                    profile_records[profile_record_index]["merge_status"] = "kept_separate"
+                decision_records.append(
+                    {
+                        **base_decision,
+                        "action": "missing_kept_separate",
+                        "status": "kept_separate",
+                        "fallback_used": True,
+                        "reason": reason,
+                        "notes": (
+                            "Missing values were kept as a separate bin because the missing profile was unavailable."
+                        ),
+                    }
+                )
+                continue
+
+            regular = variable_profile.loc[
+                variable_profile.get("is_regular_bin", pd.Series(False, index=variable_profile.index))
+                .fillna(False)
+                .astype(bool)
+            ].copy()
+            if regular.empty:
+                reason = "no_regular_candidate_bins"
+                if self.missing_merge_fallback == _RAISE_MISSING_MERGE_FALLBACK:
+                    raise ValueError(
+                        f"missing_policy='merge' found missing values for variable '{variable}', "
+                        "but no regular candidate bin is available for nearest_event_rate merge."
+                    )
+                if profile_record_index is not None:
+                    profile_records[profile_record_index]["merge_status"] = "kept_separate"
+                decision_records.append(
+                    {
+                        **base_decision,
+                        "action": "missing_kept_separate",
+                        "status": "kept_separate",
+                        "fallback_used": True,
+                        "reason": reason,
+                        "notes": (
+                            "Missing values were kept as a separate bin because no regular candidate bin was available."
+                        ),
+                    }
+                )
+                continue
+
+            candidate_rows = []
+            for _, candidate in regular.iterrows():
+                record = self._candidate_row_from_profile(
+                    variable=variable,
+                    missing_row=missing_row,
+                    candidate=candidate,
+                    rank=0,
+                )
+                candidate_rows.append((record, candidate))
+
+            candidate_rows = [
+                (record, candidate)
+                for record, candidate in candidate_rows
+                if np.isfinite(float(record["distance_event_rate"]))
+            ]
+            if not candidate_rows:
+                reason = "criterion_not_available"
+                if self.missing_merge_fallback == _RAISE_MISSING_MERGE_FALLBACK:
+                    raise ValueError(
+                        f"missing_policy='merge' could not compute nearest_event_rate candidates "
+                        f"for variable '{variable}'."
+                    )
+                if profile_record_index is not None:
+                    profile_records[profile_record_index]["merge_status"] = "kept_separate"
+                decision_records.append(
+                    {
+                        **base_decision,
+                        "action": "missing_kept_separate",
+                        "status": "kept_separate",
+                        "fallback_used": True,
+                        "reason": reason,
+                        "notes": (
+                            "Missing values were kept as a separate bin because candidate distances were unavailable."
+                        ),
+                    }
+                )
+                continue
+
+            sorted_candidates = sorted(
+                candidate_rows,
+                key=lambda item: (
+                    float(item[0]["distance_event_rate"]),
+                    -float(item[0]["candidate_n"]),
+                    self._row_number(item[1], "bin_order", default=float("inf")),
+                    self._bin_label_key(item[1].get("bin_label")),
+                ),
+            )
+            best_distance = float(sorted_candidates[0][0]["distance_event_rate"])
+            tied = [
+                item
+                for item in sorted_candidates
+                if np.isclose(float(item[0]["distance_event_rate"]), best_distance)
+            ]
+            selected_record, selected_candidate = sorted_candidates[0]
+            selected_label = selected_candidate.get("bin_label")
+            selected_order = selected_candidate.get("bin_order")
+
+            candidate_bins_payload = []
+            for rank, (record, _candidate) in enumerate(sorted_candidates, start=1):
+                ranked_record = {
+                    **record,
+                    "candidate_rank": rank,
+                    "selected": rank == 1,
+                }
+                candidate_records.append(ranked_record)
+                candidate_bins_payload.append(
+                    {
+                        "candidate_rank": rank,
+                        "bin_label": ranked_record["candidate_bin_label"],
+                        "bin_order": ranked_record["candidate_bin_order"],
+                        "n": ranked_record["candidate_n"],
+                        "events": ranked_record["candidate_events"],
+                        "event_rate": ranked_record["candidate_event_rate"],
+                        "distance": ranked_record["distance_event_rate"],
+                        "selected": rank == 1,
+                    }
+                )
+
+            candidate_n = self._row_number(selected_candidate, "n", default=0.0)
+            candidate_events = self._row_number(selected_candidate, "events", default=0.0)
+            candidate_non_events = self._row_number(selected_candidate, "non_events", default=0.0)
+            selected_event_rate = self._row_number(selected_candidate, "event_rate")
+            post_n = missing_n + candidate_n
+            post_events = missing_events + candidate_events
+            post_non_events = missing_non_events + candidate_non_events
+            post_event_rate = post_events / post_n if post_n else np.nan
+            post_share = post_n / len(X) if len(X) else np.nan
+            metrics_before = {
+                "missing": {
+                    "n": missing_n,
+                    "events": missing_events,
+                    "non_events": missing_non_events,
+                    "event_rate": missing_event_rate,
+                    "share": missing_share,
+                },
+                "selected_bin": {
+                    "n": candidate_n,
+                    "events": candidate_events,
+                    "non_events": candidate_non_events,
+                    "event_rate": self._row_number(selected_candidate, "event_rate"),
+                    "share": self._row_number(selected_candidate, "share"),
+                },
+            }
+            metrics_after = {
+                "merged_bin": {
+                    "n": post_n,
+                    "events": post_events,
+                    "non_events": post_non_events,
+                    "event_rate": post_event_rate,
+                    "share": post_share,
+                }
+            }
+            merge_map[str(variable)] = selected_label
+            merge_metrics[str(variable)] = {
+                "selected_bin_label": selected_label,
+                "selected_bin_order": selected_order,
+                "post_n": post_n,
+                "post_events": post_events,
+                "post_non_events": post_non_events,
+                "post_event_rate": post_event_rate,
+            }
+            if profile_record_index is not None:
+                profile_records[profile_record_index]["merged_into_bin_label"] = selected_label
+                profile_records[profile_record_index]["merge_distance"] = best_distance
+                profile_records[profile_record_index]["merge_status"] = "merged"
+            decision_records.append(
+                {
+                    **base_decision,
+                    "action": "missing_merged",
+                    "status": "merged",
+                    "reason": None,
+                    "selected_bin_label": selected_label,
+                    "selected_bin_order": selected_order,
+                    "selected_bin_event_rate": selected_event_rate,
+                    "distance_value": best_distance,
+                    "distance": best_distance,
+                    "tie_break_applied": len(tied) > 1,
+                    "tie_detected": len(tied) > 1,
+                    "candidate_count": len(sorted_candidates),
+                    "candidate_bins": candidate_bins_payload,
+                    "metrics_before": metrics_before,
+                    "metrics_after": metrics_after,
+                    "notes": "Missing values were merged into the nearest event-rate regular bin using training data.",
+                }
+            )
+
+        self.missing_profile_ = pd.DataFrame(profile_records)
+        self.missing_decision_log_ = pd.DataFrame(decision_records)
+        self.missing_merge_candidates_ = pd.DataFrame(candidate_records)
+        self.missing_merge_map_ = merge_map
+        self._missing_merge_metrics_ = merge_metrics
+        self.missing_policy_ = self.missing_policy
+        self.effective_missing_policy_ = self.missing_policy
+        self.missing_merge_criterion_ = self.missing_merge_criterion
+        self.missing_merge_fallback_ = self.missing_merge_fallback
+
+    # ------------------------------------------------------------------
+    def _profile_row_for_bin(
+        self,
+        profile: pd.DataFrame | None,
+        variable: str,
+        bin_label: Any,
+    ) -> pd.Series | None:
+        if profile is None or profile.empty:
+            return None
+        required = {"variable", "bin_label"}
+        if not required.issubset(profile.columns):
+            return None
+        variable_mask = profile["variable"].astype(str) == str(variable)
+        label_mask = profile["bin_label"].map(self._bin_label_key) == self._bin_label_key(bin_label)
+        rows = profile.loc[variable_mask & label_mask]
+        if rows.empty:
+            return None
+        return rows.iloc[0]
+
+    # ------------------------------------------------------------------
+    def _apply_profile_metrics_to_summary_row(
+        self,
+        summary: pd.DataFrame,
+        mask: pd.Series,
+        profile_row: pd.Series,
+    ) -> None:
+        column_map = {
+            "count": "n",
+            "n": "n",
+            "event": "events",
+            "events": "events",
+            "non_event": "non_events",
+            "non_events": "non_events",
+            "event_rate": "event_rate",
+            "Event Rate": "event_rate",
+            "share": "share",
+            "count_pct": "share",
+            "Count (%)": "share",
+            "woe": "woe",
+            "WoE": "woe",
+            "iv_component": "iv_component",
+            "IV": "iv_component",
+        }
+        for summary_column, profile_column in column_map.items():
+            if summary_column not in summary.columns or profile_column not in profile_row.index:
+                continue
+            summary.loc[mask, summary_column] = profile_row[profile_column]
+
+    # ------------------------------------------------------------------
+    def _apply_missing_merge_to_bin_summary(self, merged_profile: pd.DataFrame | None = None) -> None:
+        merge_map = getattr(self, "missing_merge_map_", {}) or {}
+        merge_metrics = getattr(self, "_missing_merge_metrics_", {}) or {}
+        if not merge_map or self.bin_summary is None or self.bin_summary.empty:
+            return
+
+        summary = self.bin_summary.copy()
+        for derived_column in ("share", "woe", "iv_component"):
+            if derived_column not in summary.columns:
+                summary[derived_column] = np.nan
+
+        remove_mask = pd.Series(False, index=summary.index)
+        for variable, selected_label in merge_map.items():
+            variable_mask = summary["variable"].astype(str) == str(variable)
+            labels = summary["bin"].map(self._bin_label_key)
+            selected_mask = variable_mask & (labels == self._bin_label_key(selected_label))
+            if merged_profile is not None and not merged_profile.empty:
+                for row_index in summary.index[variable_mask]:
+                    profile_row = self._profile_row_for_bin(
+                        merged_profile,
+                        str(variable),
+                        summary.at[row_index, "bin"],
+                    )
+                    if profile_row is not None:
+                        self._apply_profile_metrics_to_summary_row(
+                            summary,
+                            pd.Series(summary.index == row_index, index=summary.index),
+                            profile_row,
+                        )
+            metrics = merge_metrics.get(str(variable), {})
+            if selected_mask.any() and metrics:
+                summary.loc[selected_mask, "count"] = metrics.get("post_n")
+                summary.loc[selected_mask, "event"] = metrics.get("post_events")
+                summary.loc[selected_mask, "non_event"] = metrics.get("post_non_events")
+                summary.loc[selected_mask, "event_rate"] = metrics.get("post_event_rate")
+            label_text = summary["bin"].astype(str).str.strip().str.lower()
+            remove_mask |= variable_mask & (label_text == "missing")
+            remove_mask |= variable_mask & label_text.str.startswith("missing")
+
+        self.bin_summary = summary.loc[~remove_mask].reset_index(drop=True)
+
+    # ------------------------------------------------------------------
+    def _transform_pandas_core(
+        self,
+        X: pd.DataFrame,
+        selected_columns: Sequence[str],
+        *,
+        return_woe: bool = False,
+    ) -> pd.DataFrame:
+        out = {}
+        for col in selected_columns:
+            binner = self._per_feature_binners[col]
+            sig = inspect.signature(binner.transform)
+            kwargs = {"return_woe": return_woe} if "return_woe" in sig.parameters else {}
+            transformed = binner.transform(X[[col]], **kwargs)
+            out[col] = transformed if isinstance(transformed, pd.Series) else transformed[col]
+        return pd.DataFrame(out, index=X.index)
+
+    # ------------------------------------------------------------------
+    def _route_missing_merge_pandas(
+        self,
+        transformed: pd.DataFrame,
+        X: pd.DataFrame,
+        selected_columns: Sequence[str],
+    ) -> pd.DataFrame:
+        if self.missing_policy != _MERGE_MISSING_POLICY:
+            return transformed
+
+        routed = transformed.copy()
+        merge_map = getattr(self, "missing_merge_map_", {}) or {}
+        transform_records = []
+        for column in selected_columns:
+            if column not in X.columns:
+                continue
+            missing_mask = X[column].isna()
+            if not bool(missing_mask.any()):
+                continue
+            n_missing = int(missing_mask.sum())
+            column_key = str(column)
+            if column_key in merge_map:
+                selected_label = merge_map[column_key]
+                routed.loc[missing_mask, column] = selected_label
+                transform_records.append(
+                    {
+                        "variable": column,
+                        "missing_detected": True,
+                        "n_missing_transform": n_missing,
+                        "action": "missing_routed_to_learned_merge",
+                        "selected_bin_label": selected_label,
+                        "fallback_used": False,
+                        "training_decision_used": True,
+                    }
+                )
+                continue
+            if self.missing_merge_fallback == _SEPARATE_BIN_MISSING_MERGE_FALLBACK:
+                routed.loc[missing_mask, column] = "Missing"
+                transform_records.append(
+                    {
+                        "variable": column,
+                        "missing_detected": True,
+                        "n_missing_transform": n_missing,
+                        "action": "missing_transform_fallback_separate_bin",
+                        "selected_bin_label": "Missing",
+                        "fallback_used": True,
+                        "training_decision_used": False,
+                    }
+                )
+                continue
+            transform_records.append(
+                {
+                    "variable": column,
+                    "missing_detected": True,
+                    "n_missing_transform": n_missing,
+                    "action": "missing_transform_fallback_raise",
+                    "selected_bin_label": None,
+                    "fallback_used": True,
+                    "training_decision_used": False,
+                }
+            )
+            self.missing_transform_fallback_log_ = pd.DataFrame(transform_records)
+            raise ValueError(
+                f"missing_policy='merge' detected missing values during transform for "
+                f"feature '{column}', but no missing merge decision was learned during fit."
+            )
+        self.missing_transform_fallback_log_ = pd.DataFrame(transform_records)
+        return routed
+
+    # ------------------------------------------------------------------
+    def _fitted_woe_lookup(self, variable: str) -> dict[str, float]:
+        profile = getattr(self, "fit_profile_", None)
+        if profile is None or profile.empty or "woe" not in profile.columns:
+            return {}
+        rows = profile.loc[profile["variable"].astype(str) == str(variable)]
+        lookup: dict[str, float] = {}
+        for _, row in rows.iterrows():
+            woe = pd.to_numeric(pd.Series([row.get("woe")]), errors="coerce").iloc[0]
+            if np.isfinite(float(woe)):
+                lookup[self._bin_label_key(row.get("bin_label"))] = float(woe)
+        return lookup
+
+    # ------------------------------------------------------------------
+    def _map_missing_merge_labels_to_woe(
+        self,
+        transformed: pd.DataFrame,
+        selected_columns: Sequence[str],
+    ) -> pd.DataFrame:
+        mapped = transformed.copy()
+        merge_map = getattr(self, "missing_merge_map_", {}) or {}
+        for column in selected_columns:
+            if column not in mapped.columns:
+                continue
+            labels = mapped[column]
+            label_keys = labels.map(self._bin_label_key)
+            if label_keys.map(lambda value: self._bin_flag(value, "missing")).any() and str(column) not in merge_map:
+                raise ValueError(
+                    f"missing_policy='merge' cannot return WoE for missing values in feature "
+                    f"'{column}' because no missing merge decision was learned during fit and "
+                    "fallback 'separate_bin' has no fitted WoE."
+                )
+            woe_lookup = self._fitted_woe_lookup(str(column))
+            if not woe_lookup:
+                raise ValueError(
+                    f"missing_policy='merge' cannot return WoE for feature '{column}' because no fitted "
+                    "WoE lookup is available."
+                )
+            unknown = sorted({key for key in label_keys if key not in woe_lookup})
+            if unknown:
+                formatted = ", ".join(map(str, unknown[:5]))
+                raise ValueError(
+                    f"missing_policy='merge' cannot return WoE for feature '{column}' because fitted "
+                    f"WoE is unavailable for transformed bin label(s): {formatted}."
+                )
+            mapped[column] = label_keys.map(woe_lookup).astype(float)
+        return mapped
+
+    # ------------------------------------------------------------------
+    def _missing_merge_destination_woe(self, variable: str, selected_label: Any) -> float:
+        woe_lookup = self._fitted_woe_lookup(variable)
+        selected_key = self._bin_label_key(selected_label)
+        if selected_key not in woe_lookup:
+            raise ValueError(
+                f"missing_policy='merge' cannot return WoE for missing values in feature "
+                f"'{variable}' because the learned destination bin has no fitted WoE."
+            )
+        return woe_lookup[selected_key]
+
+    # ------------------------------------------------------------------
+    def _finalize_fit_missing_audit(
+        self,
+        X_features: pd.DataFrame,
+        y: pd.Series,
+        *,
+        backend: str,
+    ) -> None:
+        if self._is_missing_merge_enabled():
+            pre_transformed = self._transform_pandas_core(
+                X_features,
+                list(getattr(self, "feature_names_in_", X_features.columns)),
+            )
+            pre_profile = self._build_profile_from_transformed(pre_transformed, y)
+            self._build_missing_merge_audit_from_fit(
+                X_features,
+                y,
+                pre_profile,
+                backend=backend,
+            )
+            merged_fit_profile = self._build_fit_profile(X_features, y)
+            self._apply_missing_merge_to_bin_summary(merged_profile=merged_fit_profile)
+            self._compute_iv_metrics()
+            self._refresh_min_n_bins_metadata()
+            self.fit_profile_ = merged_fit_profile
+            return
+
+        self.fit_profile_ = self._build_fit_profile(X_features, y)
+        self._build_missing_audit_from_fit(X_features, y, backend=backend)
 
     # ------------------------------------------------------------------
     @staticmethod
@@ -2362,8 +3071,14 @@ class Binner(BaseEstimator, TransformerMixin):
         self.source_profile_ = None
         self.missing_profile_ = pd.DataFrame()
         self.missing_decision_log_ = pd.DataFrame()
+        self.missing_merge_candidates_ = pd.DataFrame()
+        self.missing_merge_map_ = {}
+        self._missing_merge_metrics_ = {}
+        self.missing_transform_fallback_log_ = pd.DataFrame()
         self.missing_policy_ = self.missing_policy
         self.effective_missing_policy_ = self.missing_policy
+        self.missing_merge_criterion_ = self.missing_merge_criterion
+        self.missing_merge_fallback_ = self.missing_merge_fallback
         self.validation_settings_ = None
         self.sampling_metadata_ = self._pandas_fit_sampling_metadata(len(X))
         self.input_backend_ = "pandas"
@@ -2418,6 +3133,8 @@ class Binner(BaseEstimator, TransformerMixin):
                 monotonic=self.monotonic,
                 check_stability=self.check_stability,
                 missing_policy=self.missing_policy,
+                missing_merge_criterion=self.missing_merge_criterion,
+                missing_merge_fallback=self.missing_merge_fallback,
             )
             self._per_feature_binners = {}
             self.best_params_ = {}
@@ -2457,8 +3174,7 @@ class Binner(BaseEstimator, TransformerMixin):
             )
             self._compute_iv_metrics()
             self._refresh_min_n_bins_metadata()
-            self.fit_profile_ = self._build_fit_profile(X_features, y)
-            self._build_missing_audit_from_fit(X_features, y, backend="pandas")
+            self._finalize_fit_missing_audit(X_features, y, backend="pandas")
             self._refresh_reference_profile()
             if validate:
                 self.fit_validation_report_ = self._build_fit_validation_report()
@@ -2501,7 +3217,7 @@ class Binner(BaseEstimator, TransformerMixin):
 
             strat = CategoricalBinning(
                 max_bins=self.max_bins,
-                separate_missing=self.missing_policy == _SEPARATE_BIN_MISSING_POLICY,
+                separate_missing=self._uses_explicit_missing_bin(),
             )
             strat.fit(X_features[[col]], y)
 
@@ -2529,8 +3245,7 @@ class Binner(BaseEstimator, TransformerMixin):
         )
         self._compute_iv_metrics()
         self._refresh_min_n_bins_metadata()
-        self.fit_profile_ = self._build_fit_profile(X_features, y)
-        self._build_missing_audit_from_fit(X_features, y, backend="pandas")
+        self._finalize_fit_missing_audit(X_features, y, backend="pandas")
         self._refresh_reference_profile()
         if validate:
             self.fit_validation_report_ = self._build_fit_validation_report()
@@ -2581,15 +3296,15 @@ class Binner(BaseEstimator, TransformerMixin):
         X = self._coerce_force_numeric_columns(X, columns=selected_columns)
         self._check_missing_policy_pandas(X, selected_columns, context="transform")
 
-        out = {}
-        for col in selected_columns:
-            binner = self._per_feature_binners[col]
-            sig = inspect.signature(binner.transform)
-            kwargs = {"return_woe": return_woe} if "return_woe" in sig.parameters else {}
-            transformed = binner.transform(X[[col]], **kwargs)
-            out[col] = transformed if isinstance(transformed, pd.Series) else transformed[col]
-
-        transformed_df = pd.DataFrame(out, index=X.index)
+        core_return_woe = return_woe and self.missing_policy != _MERGE_MISSING_POLICY
+        transformed_df = self._transform_pandas_core(
+            X,
+            selected_columns,
+            return_woe=core_return_woe,
+        )
+        transformed_df = self._route_missing_merge_pandas(transformed_df, X, selected_columns)
+        if return_woe and self.missing_policy == _MERGE_MISSING_POLICY:
+            transformed_df = self._map_missing_merge_labels_to_woe(transformed_df, selected_columns)
         if validate:
             self._validate_transform_pandas(transformed_df, original_input, backend="pandas")
         if return_type == "dataframe":

--- a/riskbands/reporting.py
+++ b/riskbands/reporting.py
@@ -102,8 +102,13 @@ OPTIONAL_BUNDLE_PROFILE_FIELDS = (
     "data_schema",
     "missing_policy",
     "effective_missing_policy",
+    "missing_merge_criterion",
+    "missing_merge_fallback",
     "missing_profile",
     "missing_decision_log",
+    "missing_merge_candidates",
+    "missing_merge_map",
+    "missing_transform_fallback_log",
 )
 
 
@@ -574,6 +579,12 @@ def build_variable_audit_report(
             dataset_name,
             diagnostics.attrs.get("dataset") if diagnostics is not None else None,
         )
+        missing_decision_row = {}
+        missing_decision_log = getattr(binner, "missing_decision_log_", None)
+        if missing_decision_log is not None and not missing_decision_log.empty:
+            missing_match = missing_decision_log.loc[missing_decision_log["variable"] == variable]
+            if not missing_match.empty:
+                missing_decision_row = missing_match.iloc[0].to_dict()
 
         row = {
             "dataset": dataset_value,
@@ -650,6 +661,28 @@ def build_variable_audit_report(
                 objective_config.get("woe_shrinkage_strength"),
                 default=getattr(binner, "woe_shrinkage_strength", np.nan),
             ),
+            "missing_policy": getattr(binner, "missing_policy_", getattr(binner, "missing_policy", "standard")),
+            "effective_missing_policy": getattr(
+                binner,
+                "effective_missing_policy_",
+                getattr(binner, "missing_policy_", getattr(binner, "missing_policy", "standard")),
+            ),
+            "missing_merge_criterion": getattr(
+                binner,
+                "missing_merge_criterion_",
+                getattr(binner, "missing_merge_criterion", None),
+            ),
+            "missing_merge_fallback": getattr(
+                binner,
+                "missing_merge_fallback_",
+                getattr(binner, "missing_merge_fallback", None),
+            ),
+            "missing_merge_action": missing_decision_row.get("action"),
+            "missing_merge_status": missing_decision_row.get("status"),
+            "missing_merged_into": missing_decision_row.get("selected_bin_label"),
+            "missing_original_n": missing_decision_row.get("n_missing_fit"),
+            "missing_original_event_rate": missing_decision_row.get("event_rate_missing_fit"),
+            "missing_merge_distance": missing_decision_row.get("distance"),
         }
 
         for column in BASE_COMPONENT_COLUMNS:
@@ -932,6 +965,16 @@ def build_binner_metadata(
             "effective_missing_policy_",
             getattr(binner, "missing_policy_", getattr(binner, "missing_policy", "standard")),
         ),
+        "missing_merge_criterion": getattr(
+            binner,
+            "missing_merge_criterion_",
+            getattr(binner, "missing_merge_criterion", None),
+        ),
+        "missing_merge_fallback": getattr(
+            binner,
+            "missing_merge_fallback_",
+            getattr(binner, "missing_merge_fallback", None),
+        ),
         "objective_direction": objective_direction,
         "normalization_strategy": normalization_strategy,
         "woe_shrinkage_strength": (
@@ -983,7 +1026,7 @@ def _normalize_loaded_missing_policy(value: Any) -> str:
     text = str(value)
     if text == "legacy":
         return "standard"
-    if text in {"standard", "separate_bin", "forbid"}:
+    if text in {"standard", "separate_bin", "forbid", "merge"}:
         return text
     return text
 
@@ -1082,8 +1125,13 @@ def load_bundle(path: PathLike) -> dict[str, Any]:
         "validation_report": manifest.get("validation_report"),
         "missing_policy": manifest.get("missing_policy"),
         "effective_missing_policy": manifest.get("effective_missing_policy"),
+        "missing_merge_criterion": manifest.get("missing_merge_criterion"),
+        "missing_merge_fallback": manifest.get("missing_merge_fallback"),
         "missing_profile": manifest.get("missing_profile"),
         "missing_decision_log": manifest.get("missing_decision_log"),
+        "missing_merge_candidates": manifest.get("missing_merge_candidates"),
+        "missing_merge_map": manifest.get("missing_merge_map"),
+        "missing_transform_fallback_log": manifest.get("missing_transform_fallback_log"),
     }
 
 
@@ -1189,6 +1237,12 @@ def export_binner_bundle(binner: Binner, path: PathLike) -> Path:
     diagnostics_variable = _resolve_optional_table(binner, kind="variable")
     missing_profile = getattr(binner, "missing_profile_", pd.DataFrame())
     missing_decision_log = getattr(binner, "missing_decision_log_", pd.DataFrame())
+    missing_merge_candidates = getattr(binner, "missing_merge_candidates_", pd.DataFrame())
+    missing_transform_fallback_log = getattr(
+        binner,
+        "missing_transform_fallback_log_",
+        pd.DataFrame(),
+    )
 
     _write_csv(summary, target_dir / "summary.csv")
     _write_csv(score_details, target_dir / "score_details.csv")
@@ -1202,6 +1256,10 @@ def export_binner_bundle(binner: Binner, path: PathLike) -> Path:
         _write_csv(missing_profile, target_dir / "missing_profile.csv")
     if missing_decision_log is not None and not missing_decision_log.empty:
         _write_csv(missing_decision_log, target_dir / "missing_decision_log.csv")
+    if missing_merge_candidates is not None and not missing_merge_candidates.empty:
+        _write_csv(missing_merge_candidates, target_dir / "missing_merge_candidates.csv")
+    if missing_transform_fallback_log is not None and not missing_transform_fallback_log.empty:
+        _write_csv(missing_transform_fallback_log, target_dir / "missing_transform_fallback_log.csv")
     _write_csv(report, target_dir / "report.csv")
 
     feature_dir = target_dir / "feature_tables"
@@ -1257,6 +1315,16 @@ def export_binner_bundle(binner: Binner, path: PathLike) -> Path:
             "missing_decision_log_csv": (
                 "missing_decision_log.csv"
                 if missing_decision_log is not None and not missing_decision_log.empty
+                else None
+            ),
+            "missing_merge_candidates_csv": (
+                "missing_merge_candidates.csv"
+                if missing_merge_candidates is not None and not missing_merge_candidates.empty
+                else None
+            ),
+            "missing_transform_fallback_log_csv": (
+                "missing_transform_fallback_log.csv"
+                if missing_transform_fallback_log is not None and not missing_transform_fallback_log.empty
                 else None
             ),
             "feature_tables": feature_artifacts,
@@ -1333,6 +1401,12 @@ def _save_excel(binner: Binner, path: Path) -> None:
         missing_decision_log = getattr(binner, "missing_decision_log_", None)
         if missing_decision_log is not None and not missing_decision_log.empty:
             missing_decision_log.to_excel(writer, sheet_name="missing_decisions", index=False)
+        missing_merge_candidates = getattr(binner, "missing_merge_candidates_", None)
+        if missing_merge_candidates is not None and not missing_merge_candidates.empty:
+            missing_merge_candidates.to_excel(writer, sheet_name="missing_merge_candidates", index=False)
+        missing_transform_log = getattr(binner, "missing_transform_fallback_log_", None)
+        if missing_transform_log is not None and not missing_transform_log.empty:
+            missing_transform_log.to_excel(writer, sheet_name="missing_transform_log", index=False)
 
 
 # ------------------------------------------------------------------ #
@@ -1357,10 +1431,20 @@ def _save_json(binner: Binner, path: Path) -> None:
         info["missing_policy"] = _json_safe(binner.missing_policy_)
     if getattr(binner, "effective_missing_policy_", None) is not None:
         info["effective_missing_policy"] = _json_safe(binner.effective_missing_policy_)
+    if getattr(binner, "missing_merge_criterion_", None) is not None:
+        info["missing_merge_criterion"] = _json_safe(binner.missing_merge_criterion_)
+    if getattr(binner, "missing_merge_fallback_", None) is not None:
+        info["missing_merge_fallback"] = _json_safe(binner.missing_merge_fallback_)
     if getattr(binner, "missing_profile_", None) is not None:
         info["missing_profile"] = _json_safe(binner.missing_profile_)
     if getattr(binner, "missing_decision_log_", None) is not None:
         info["missing_decision_log"] = _json_safe(binner.missing_decision_log_)
+    if getattr(binner, "missing_merge_candidates_", None) is not None:
+        info["missing_merge_candidates"] = _json_safe(binner.missing_merge_candidates_)
+    if getattr(binner, "missing_merge_map_", None) is not None:
+        info["missing_merge_map"] = _json_safe(binner.missing_merge_map_)
+    if getattr(binner, "missing_transform_fallback_log_", None) is not None:
+        info["missing_transform_fallback_log"] = _json_safe(binner.missing_transform_fallback_log_)
     pivot = getattr(binner, "_pivot_", None)
     if pivot is not None:
         info["pivot_event_rate"] = _json_ready_records(pivot.reset_index())
@@ -1375,5 +1459,3 @@ def _save_json(binner: Binner, path: Path) -> None:
         info["variable_audit_report"] = _json_ready_records(audit)
     info["binnings_artifact"] = build_binnings_json_artifact(binner)
     path.write_text(json.dumps(_json_safe(info), indent=2, ensure_ascii=False), encoding="utf-8")
-
-

--- a/tests/test_missing_merge_audit_trail.py
+++ b/tests/test_missing_merge_audit_trail.py
@@ -1,0 +1,117 @@
+import json
+
+import numpy as np
+import pandas as pd
+
+from riskbands import RiskBands
+from tests.test_missing_merge_nearest_event_rate_pandas import fit_numeric_merge, selected_candidate
+
+
+def test_missing_merge_decision_log_contains_complete_decision():
+    binner, _ = fit_numeric_merge()
+    row = binner.missing_decision_log_.iloc[0]
+    candidate = selected_candidate(binner)
+
+    assert row["variable"] == "score"
+    assert row["policy_requested"] == "merge"
+    assert row["effective_policy"] == "merge"
+    assert row["missing_merge_criterion"] == "nearest_event_rate"
+    assert row["missing_merge_fallback"] == "separate_bin"
+    assert bool(row["missing_detected"]) is True
+    assert row["n_missing_fit"] > 0
+    assert row["event_rate_missing_fit"] == candidate["missing_event_rate"]
+    assert row["action"] == "missing_merged"
+    assert row["selected_bin_label"] == candidate["candidate_bin_label"]
+    assert row["selected_bin_order"] == candidate["candidate_bin_order"]
+    assert row["selected_bin_event_rate"] == candidate["candidate_event_rate"]
+    assert row["distance"] == candidate["distance_event_rate"]
+    assert row["distance_value"] == candidate["distance_event_rate"]
+    assert bool(row["training_only"]) is True
+    assert bool(row["fallback_used"]) is False
+    assert "training data" in row["notes"]
+
+
+def test_missing_merge_candidates_are_registered_and_mark_selected_bin():
+    binner, _ = fit_numeric_merge()
+    candidates = binner.missing_merge_candidates_
+
+    assert not candidates.empty
+    assert candidates["selected"].sum() == 1
+    assert set(
+        [
+            "candidate_bin_label",
+            "candidate_bin_order",
+            "candidate_event_rate",
+            "missing_event_rate",
+            "distance_event_rate",
+        ]
+    ).issubset(candidates.columns)
+    assert bool(candidates.sort_values("candidate_rank").iloc[0]["selected"]) is True
+
+
+def test_missing_profile_preserves_original_missing_after_merge():
+    binner, _ = fit_numeric_merge()
+    profile = binner.missing_profile_.iloc[0]
+    decision = binner.missing_decision_log_.iloc[0]
+
+    assert bool(profile["is_missing_bin"]) is True
+    assert profile["bin_label"] == "Missing"
+    assert profile["merge_criterion"] == "nearest_event_rate"
+    assert profile["merge_status"] == "merged"
+    assert profile["merged_into_bin_label"] == decision["selected_bin_label"]
+    assert profile["merge_distance"] == decision["distance"]
+
+
+def test_missing_merge_decision_log_records_candidate_bins_as_json_serializable_payload():
+    binner, _ = fit_numeric_merge()
+    records = binner.missing_decision_log_.to_dict("records")
+
+    payload = json.dumps(records)
+    decoded = json.loads(payload)
+
+    assert decoded[0]["candidate_bins"]
+    assert decoded[0]["candidate_bins"][0]["selected"] is True
+
+
+def test_missing_merge_tie_break_is_recorded():
+    rating = []
+    target = []
+    for category, n, events in [("A", 40, 10), ("B", 80, 60), ("C", 40, 4)]:
+        rating.extend([category] * n)
+        target.extend([1] * events + [0] * (n - events))
+    rating.extend([None] * 40)
+    target.extend([1] * 20 + [0] * 20)
+    df = pd.DataFrame({"rating": rating, "target": target})
+
+    binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        force_categorical=["rating"],
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    ).fit(df, y="target", column="rating")
+    row = binner.missing_decision_log_.iloc[0]
+
+    assert bool(row["tie_detected"]) is True
+    assert bool(row["tie_break_applied"]) is True
+    assert "candidate_n desc" in row["tie_break_rule"]
+
+
+def test_missing_merge_fallback_keeps_original_missing_profile_visible():
+    df = pd.DataFrame({"score": [np.nan] * 6, "target": [0, 1, 0, 1, 0, 1]})
+    binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        force_categorical=["score"],
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        missing_merge_fallback="separate_bin",
+    ).fit(df, y="target", column="score")
+    row = binner.missing_decision_log_.iloc[0]
+
+    assert row["action"] == "missing_kept_separate"
+    assert row["status"] == "kept_separate"
+    assert bool(row["fallback_used"]) is True
+    assert row["reason"] == "no_regular_candidate_bins"
+    assert binner.missing_profile_.iloc[0]["bin_label"] == "Missing"
+    assert binner.transform(pd.DataFrame({"score": [np.nan]})).iloc[0, 0] == "Missing"

--- a/tests/test_missing_merge_bundle_persistence.py
+++ b/tests/test_missing_merge_bundle_persistence.py
@@ -1,0 +1,137 @@
+import json
+
+import numpy as np
+import pandas as pd
+
+from riskbands import RiskBands
+from riskbands.reporting import load_bundle, load_bundle_metadata
+from tests.test_missing_merge_nearest_event_rate_pandas import (
+    fit_numeric_merge,
+    make_categorical_event_rate_frame,
+)
+
+
+def test_bundle_roundtrip_persists_merge_numeric_decision(tmp_path):
+    binner, _ = fit_numeric_merge()
+    bundle_dir = tmp_path / "bundle"
+
+    binner.export_bundle(bundle_dir)
+    loaded = load_bundle(bundle_dir)
+
+    assert loaded["missing_policy"] == "merge"
+    assert loaded["effective_missing_policy"] == "merge"
+    assert loaded["missing_merge_criterion"] == "nearest_event_rate"
+    assert loaded["missing_merge_fallback"] == "separate_bin"
+    assert loaded["missing_profile"][0]["bin_label"] == "Missing"
+    assert loaded["missing_profile"][0]["merge_status"] == "merged"
+    assert loaded["missing_decision_log"][0]["action"] == "missing_merged"
+    assert loaded["missing_decision_log"][0]["candidate_bins"]
+    assert loaded["missing_merge_candidates"]
+    assert loaded["missing_merge_map"] == binner.missing_merge_map_
+    assert (bundle_dir / "missing_profile.csv").exists()
+    assert (bundle_dir / "missing_decision_log.csv").exists()
+    assert (bundle_dir / "missing_merge_candidates.csv").exists()
+
+
+def test_bundle_roundtrip_persists_merge_categorical_decision(tmp_path):
+    df = make_categorical_event_rate_frame()
+    binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        force_categorical=["rating"],
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    ).fit(df, y="target", column="rating")
+
+    binner.export_bundle(tmp_path / "bundle")
+    loaded = load_bundle(tmp_path / "bundle")
+
+    assert loaded["missing_policy"] == "merge"
+    assert loaded["missing_decision_log"][0]["variable"] == "rating"
+    assert loaded["missing_decision_log"][0]["selected_bin_label"] == binner.missing_decision_log_.iloc[0][
+        "selected_bin_label"
+    ]
+    assert loaded["missing_merge_map"] == binner.missing_merge_map_
+
+
+def test_transform_after_bundle_export_still_uses_learned_merge_decision(tmp_path):
+    binner, _ = fit_numeric_merge()
+    learned_destination = binner.missing_decision_log_.iloc[0]["selected_bin_label"]
+    before = binner.transform(pd.DataFrame({"score": [np.nan, -5.0]}))
+
+    binner.export_bundle(tmp_path / "bundle")
+    loaded = load_bundle(tmp_path / "bundle")
+    after = binner.transform(pd.DataFrame({"score": [np.nan, -5.0]}))
+
+    assert before.equals(after)
+    assert after.loc[0, "score"] == learned_destination
+    assert loaded["missing_merge_map"]["score"] == learned_destination
+
+
+def test_bundle_roundtrip_persists_missing_merge_fallback_for_no_fit_missing(tmp_path):
+    df = pd.DataFrame({"score": [-5.0, -4.0, 0.0, 4.0, 5.0] * 8, "target": [0, 0, 1, 1, 1] * 8})
+    binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        missing_merge_fallback="raise",
+    ).fit(df, y="target", column="score")
+
+    binner.export_bundle(tmp_path / "bundle")
+    loaded = load_bundle(tmp_path / "bundle")
+
+    assert loaded["missing_policy"] == "merge"
+    assert loaded["missing_merge_fallback"] == "raise"
+    assert loaded["missing_merge_map"] == {}
+    assert loaded["missing_decision_log"][0]["action"] == "no_missing_detected"
+
+
+def test_old_bundle_without_missing_merge_fields_loads_with_none_values(tmp_path):
+    bundle_dir = tmp_path / "old_bundle"
+    bundle_dir.mkdir()
+    (bundle_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "artifact_type": "riskbands_audit_bundle",
+                "artifact_version": "1.0",
+                "metadata": {"missing_policy": "legacy"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = load_bundle_metadata(bundle_dir)
+
+    assert loaded["missing_policy"] == "standard"
+    assert loaded["effective_missing_policy"] == "standard"
+    assert loaded["metadata"]["missing_policy"] == "standard"
+    assert loaded["missing_merge_criterion"] is None
+    assert loaded["missing_merge_fallback"] is None
+    assert loaded["missing_merge_candidates"] is None
+    assert loaded["missing_merge_map"] is None
+
+
+def test_standard_separate_bin_and_forbid_bundle_fields_remain_compatible(tmp_path):
+    standard = RiskBands(missing_policy="standard", max_bins=2, min_event_rate_diff=0.0).fit(
+        pd.DataFrame({"score": [1.0, 2.0, np.nan, 4.0], "target": [0, 1, 0, 1]}),
+        y="target",
+        column="score",
+    )
+    separate = RiskBands(missing_policy="separate_bin", max_bins=2, min_event_rate_diff=0.0).fit(
+        pd.DataFrame({"score": [1.0, 2.0, np.nan, 4.0], "target": [0, 1, 0, 1]}),
+        y="target",
+        column="score",
+    )
+    forbid = RiskBands(missing_policy="forbid", max_bins=2, min_event_rate_diff=0.0).fit(
+        pd.DataFrame({"score": [1.0, 2.0, 3.0, 4.0], "target": [0, 1, 0, 1]}),
+        y="target",
+        column="score",
+    )
+
+    for name, binner in [("standard", standard), ("separate", separate), ("forbid", forbid)]:
+        binner.export_bundle(tmp_path / name)
+        loaded = load_bundle(tmp_path / name)
+        assert loaded["missing_policy"] == binner.missing_policy
+        assert loaded["missing_merge_criterion"] is None
+        assert loaded["missing_merge_candidates"] in (None, [])

--- a/tests/test_missing_merge_nearest_event_rate_pandas.py
+++ b/tests/test_missing_merge_nearest_event_rate_pandas.py
@@ -1,0 +1,246 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from riskbands import RiskBands
+from tests.test_missing_values_current_behavior import (
+    fit_categorical_missing_binner,
+    make_categorical_missing_frame,
+)
+
+
+def make_numeric_event_rate_frame(*, missing_events=20, missing_non_events=20):
+    score = []
+    target = []
+    for value, event_rate in [(-5.0, 0.05), (-3.0, 0.20), (0.0, 0.50), (3.0, 0.80), (5.0, 0.95)]:
+        n = 40
+        events = int(n * event_rate)
+        score.extend([value] * n)
+        target.extend([1] * events + [0] * (n - events))
+    score.extend([np.nan] * (missing_events + missing_non_events))
+    target.extend([1] * missing_events + [0] * missing_non_events)
+    return pd.DataFrame({"score": score, "target": target})
+
+
+def make_categorical_event_rate_frame():
+    rating = []
+    target = []
+    for category, event_rate in [("A", 0.10), ("B", 0.50), ("C", 0.90)]:
+        n = 40
+        events = int(n * event_rate)
+        rating.extend([category] * n)
+        target.extend([1] * events + [0] * (n - events))
+    rating.extend([None] * 40)
+    target.extend([1] * 20 + [0] * 20)
+    return pd.DataFrame({"rating": rating, "target": target})
+
+
+def fit_numeric_merge(df=None, **kwargs):
+    df = make_numeric_event_rate_frame() if df is None else df
+    binner = RiskBands(
+        max_bins=5,
+        min_event_rate_diff=0.0,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        **kwargs,
+    )
+    return binner.fit(df, y="target", column="score"), df
+
+
+def selected_candidate(binner):
+    selected = binner.missing_merge_candidates_.loc[binner.missing_merge_candidates_["selected"]]
+    assert len(selected) == 1
+    return selected.iloc[0]
+
+
+def row_for_label(df, label_column, label):
+    key = str(label)
+    rows = df.loc[df[label_column].astype(str) == key]
+    assert len(rows) == 1
+    return rows.iloc[0]
+
+
+def test_numeric_nearest_event_rate_merges_missing_into_expected_bin():
+    binner, df = fit_numeric_merge()
+    decision = binner.missing_decision_log_.iloc[0]
+    candidate = selected_candidate(binner)
+
+    transformed = binner.transform(pd.DataFrame({"score": [np.nan, -5.0, 5.0]}))
+
+    assert decision["action"] == "missing_merged"
+    assert decision["status"] == "merged"
+    assert decision["merge_criterion"] == "nearest_event_rate"
+    assert decision["selected_bin_label"] == candidate["candidate_bin_label"]
+    assert candidate["distance_event_rate"] == pytest.approx(0.0)
+    assert transformed.loc[0, "score"] == decision["selected_bin_label"]
+    assert transformed.loc[0, "score"] != "Missing"
+    assert "Missing" not in set(binner.bin_summary["bin"].astype(str))
+    assert binner.missing_profile_.iloc[0]["bin_label"] == "Missing"
+    assert int(binner.missing_profile_.iloc[0]["n_missing_fit"]) == int(df["score"].isna().sum())
+
+
+def test_numeric_merge_return_woe_routes_missing_to_selected_bin_woe():
+    binner, _ = fit_numeric_merge()
+    decision = binner.missing_decision_log_.iloc[0]
+    selected_label = decision["selected_bin_label"]
+    profile_row = row_for_label(binner.fit_profile_, "bin_label", selected_label)
+
+    transformed = binner.transform(pd.DataFrame({"score": [np.nan, -5.0, 5.0]}), return_woe=True)
+
+    assert pd.api.types.is_numeric_dtype(transformed["score"])
+    assert not isinstance(transformed.loc[0, "score"], str)
+    assert transformed.loc[0, "score"] == pytest.approx(profile_row["woe"])
+
+
+def test_bin_summary_selected_bin_matches_fit_profile_after_missing_merge():
+    binner, _ = fit_numeric_merge()
+    decision = binner.missing_decision_log_.iloc[0]
+    selected_label = decision["selected_bin_label"]
+    metrics_before = decision["metrics_before"]
+    summary_row = row_for_label(binner.bin_summary, "bin", selected_label)
+    profile_row = row_for_label(binner.fit_profile_, "bin_label", selected_label)
+    expected_n = metrics_before["selected_bin"]["n"] + metrics_before["missing"]["n"]
+    expected_events = metrics_before["selected_bin"]["events"] + metrics_before["missing"]["events"]
+    expected_non_events = (
+        metrics_before["selected_bin"]["non_events"]
+        + metrics_before["missing"]["non_events"]
+    )
+
+    assert "Missing" not in set(binner.bin_summary["bin"].astype(str))
+    assert summary_row["count"] == pytest.approx(expected_n)
+    assert summary_row["event"] == pytest.approx(expected_events)
+    assert summary_row["non_event"] == pytest.approx(expected_non_events)
+    assert summary_row["event_rate"] == pytest.approx(expected_events / expected_n)
+    assert summary_row["count"] == pytest.approx(profile_row["n"])
+    assert summary_row["event"] == pytest.approx(profile_row["events"])
+    assert summary_row["non_event"] == pytest.approx(profile_row["non_events"])
+    assert summary_row["event_rate"] == pytest.approx(profile_row["event_rate"])
+    if "share" in binner.bin_summary.columns:
+        assert summary_row["share"] == pytest.approx(profile_row["share"])
+    if "woe" in binner.bin_summary.columns:
+        assert summary_row["woe"] == pytest.approx(profile_row["woe"])
+    if "iv_component" in binner.bin_summary.columns:
+        assert summary_row["iv_component"] == pytest.approx(profile_row["iv_component"])
+
+
+def test_categorical_nearest_event_rate_merges_missing_into_expected_bin():
+    df = make_categorical_event_rate_frame()
+    binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        force_categorical=["rating"],
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    ).fit(df, y="target", column="rating")
+    decision = binner.missing_decision_log_.iloc[0]
+    candidate = selected_candidate(binner)
+
+    transformed = binner.transform(pd.DataFrame({"rating": [None, "A", "Z"]}))
+
+    assert decision["action"] == "missing_merged"
+    assert decision["selected_bin_label"] == candidate["candidate_bin_label"]
+    assert candidate["candidate_event_rate"] == pytest.approx(0.5)
+    assert transformed.loc[0, "rating"] == decision["selected_bin_label"]
+    assert transformed.loc[0, "rating"] != "Missing"
+    assert binner.missing_profile_.iloc[0]["bin_label"] == "Missing"
+
+
+def test_nearest_event_rate_tie_break_prefers_larger_candidate_n():
+    rating = []
+    target = []
+    for category, n, events in [("A", 40, 10), ("B", 80, 60), ("C", 40, 4)]:
+        rating.extend([category] * n)
+        target.extend([1] * events + [0] * (n - events))
+    rating.extend([None] * 40)
+    target.extend([1] * 20 + [0] * 20)
+    df = pd.DataFrame({"rating": rating, "target": target})
+
+    binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        force_categorical=["rating"],
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    ).fit(df, y="target", column="rating")
+
+    decision = binner.missing_decision_log_.iloc[0]
+    candidates = binner.missing_merge_candidates_
+    min_distance = candidates["distance_event_rate"].min()
+    tied = candidates.loc[np.isclose(candidates["distance_event_rate"], min_distance)]
+    candidate = selected_candidate(binner)
+
+    assert bool(decision["tie_detected"]) is True
+    assert len(tied) >= 2
+    assert candidate["candidate_n"] == tied["candidate_n"].max()
+
+
+@pytest.mark.parametrize(
+    ("missing_events", "missing_non_events", "expected_rate"),
+    [
+        (0, 40, 0.0),
+        (40, 0, 1.0),
+    ],
+)
+def test_nearest_event_rate_handles_zero_or_all_missing_events(
+    missing_events,
+    missing_non_events,
+    expected_rate,
+):
+    df = make_numeric_event_rate_frame(
+        missing_events=missing_events,
+        missing_non_events=missing_non_events,
+    )
+    binner, _ = fit_numeric_merge(df)
+    candidate = selected_candidate(binner)
+
+    assert binner.missing_profile_.iloc[0]["event_rate_missing_fit"] == pytest.approx(expected_rate)
+    assert candidate["missing_event_rate"] == pytest.approx(expected_rate)
+    assert binner.missing_decision_log_.iloc[0]["action"] == "missing_merged"
+
+
+def test_no_missing_in_fit_transform_missing_uses_separate_bin_fallback():
+    df = pd.DataFrame({"score": [-5.0, -4.0, 0.0, 3.0, 5.0] * 10, "target": [0, 0, 1, 1, 1] * 10})
+    binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        missing_merge_fallback="separate_bin",
+    ).fit(df, y="target", column="score")
+
+    transformed = binner.transform(pd.DataFrame({"score": [np.nan, -5.0]}))
+
+    assert binner.missing_merge_map_ == {}
+    assert binner.missing_decision_log_.iloc[0]["action"] == "no_missing_detected"
+    assert transformed.loc[0, "score"] == "Missing"
+
+
+def test_no_missing_in_fit_transform_missing_raise_fallback_errors():
+    df = pd.DataFrame({"score": [-5.0, -4.0, 0.0, 3.0, 5.0] * 10, "target": [0, 0, 1, 1, 1] * 10})
+    binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        missing_merge_fallback="raise",
+    ).fit(df, y="target", column="score")
+
+    with pytest.raises(ValueError, match="no missing merge decision was learned"):
+        binner.transform(pd.DataFrame({"score": [np.nan, -5.0]}))
+
+
+def test_standard_and_separate_bin_current_behaviors_remain_distinct():
+    standard, df = fit_categorical_missing_binner()
+    separate = RiskBands(
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        force_categorical=["grade"],
+        missing_policy="separate_bin",
+    ).fit(make_categorical_missing_frame(), y="target", column="grade")
+
+    standard_transformed = standard.transform(df[["grade"]])
+    separate_transformed = separate.transform(df[["grade"]])
+
+    assert standard.fit_profile_.loc[standard.fit_profile_["is_missing_bin"]].empty
+    assert set(separate_transformed.loc[df["grade"].isna(), "grade"]) == {"Missing"}
+    assert set(standard_transformed.loc[df["grade"].isna(), "grade"]) != {"Missing"}

--- a/tests/test_missing_merge_policy_parameter.py
+++ b/tests/test_missing_merge_policy_parameter.py
@@ -1,0 +1,113 @@
+import pytest
+
+from riskbands import Binner, RiskBands
+
+
+def test_missing_merge_defaults_do_not_change_standard_policy():
+    binner = RiskBands()
+
+    assert binner.missing_policy == "standard"
+    assert binner.missing_policy_ == "standard"
+    assert binner.missing_merge_criterion is None
+    assert binner.missing_merge_criterion_ is None
+    assert binner.missing_merge_fallback == "separate_bin"
+    assert binner.missing_merge_fallback_ == "separate_bin"
+    assert binner.get_params()["missing_policy"] == "standard"
+    assert binner.get_params()["missing_merge_criterion"] is None
+    assert binner.get_params()["missing_merge_fallback"] == "separate_bin"
+
+
+def test_missing_merge_nearest_event_rate_is_accepted():
+    binner = RiskBands(
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    )
+
+    assert binner.missing_policy == "merge"
+    assert binner.missing_policy_ == "merge"
+    assert binner.effective_missing_policy_ == "merge"
+    assert binner.missing_merge_criterion == "nearest_event_rate"
+    assert binner.missing_merge_criterion_ == "nearest_event_rate"
+    assert binner.missing_merge_fallback == "separate_bin"
+
+
+def test_missing_merge_accepts_raise_fallback():
+    binner = Binner(
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        missing_merge_fallback="raise",
+    )
+
+    assert binner.missing_merge_fallback == "raise"
+    assert binner.missing_merge_fallback_ == "raise"
+
+
+def test_missing_policy_merge_requires_criterion():
+    with pytest.raises(ValueError, match="missing_merge_criterion.*required"):
+        RiskBands(missing_policy="merge")
+
+
+def test_missing_merge_rejects_invalid_criterion():
+    with pytest.raises(ValueError, match="Unsupported missing_merge_criterion"):
+        RiskBands(
+            missing_policy="merge",
+            missing_merge_criterion="nearest_woe",
+        )
+
+
+def test_missing_merge_rejects_invalid_fallback():
+    with pytest.raises(ValueError, match="Unsupported missing_merge_fallback"):
+        RiskBands(
+            missing_policy="merge",
+            missing_merge_criterion="nearest_event_rate",
+            missing_merge_fallback="standard",
+        )
+
+
+@pytest.mark.parametrize("policy", ["standard", "separate_bin", "forbid"])
+def test_missing_merge_criterion_is_rejected_without_merge_policy(policy):
+    with pytest.raises(ValueError, match="missing_merge_criterion.*missing_policy='merge'"):
+        RiskBands(
+            missing_policy=policy,
+            missing_merge_criterion="nearest_event_rate",
+        )
+
+
+def test_legacy_alias_remains_standard_without_merge_params():
+    binner = RiskBands(missing_policy="legacy")
+
+    assert binner.missing_policy == "standard"
+    assert binner.missing_policy_ == "standard"
+    assert binner.missing_merge_criterion is None
+
+
+def test_legacy_alias_rejects_merge_criterion():
+    with pytest.raises(ValueError, match="missing_merge_criterion.*missing_policy='merge'"):
+        RiskBands(
+            missing_policy="legacy",
+            missing_merge_criterion="nearest_event_rate",
+        )
+
+
+def test_set_params_validates_missing_merge_contract():
+    binner = RiskBands()
+
+    binner.set_params(
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        missing_merge_fallback="raise",
+    )
+
+    assert binner.missing_policy == "merge"
+    assert binner.missing_merge_criterion == "nearest_event_rate"
+    assert binner.missing_merge_fallback == "raise"
+
+
+def test_set_params_rejects_incompatible_criterion():
+    binner = RiskBands(
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    )
+
+    with pytest.raises(ValueError, match="missing_merge_criterion.*missing_policy='merge'"):
+        binner.set_params(missing_policy="standard")

--- a/tests/test_missing_merge_pyspark_boundary.py
+++ b/tests/test_missing_merge_pyspark_boundary.py
@@ -1,0 +1,70 @@
+import pandas as pd
+import pytest
+
+from riskbands import RiskBands
+from tests.test_missing_values_current_behavior import make_numeric_missing_frame
+
+pytestmark = pytest.mark.spark
+pytest_plugins = ["tests.test_missing_values_pyspark_current_behavior"]
+
+SPARK_MERGE_MESSAGE = 'missing_policy="merge" with PySpark is not implemented in this release'
+
+
+def _numeric_spark_frame(spark_session, rows):
+    from pyspark.sql import types as T
+
+    schema = T.StructType(
+        [
+            T.StructField("score", T.DoubleType(), True),
+            T.StructField("target", T.IntegerType(), True),
+        ]
+    )
+    return spark_session.createDataFrame(rows, schema=schema)
+
+
+def test_merge_spark_fit_fails_explicitly(spark_session):
+    sdf = _numeric_spark_frame(spark_session, [(1.0, 0), (None, 1), (3.0, 0), (4.0, 1)])
+
+    with pytest.raises(NotImplementedError, match=SPARK_MERGE_MESSAGE):
+        RiskBands(
+            missing_policy="merge",
+            missing_merge_criterion="nearest_event_rate",
+        ).fit(sdf, y="target", column="score")
+
+
+def test_merge_pandas_fit_spark_transform_fails_explicitly(spark_session):
+    binner = RiskBands(
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        min_event_rate_diff=0.0,
+    ).fit(make_numeric_missing_frame(), y="target", column="score")
+    sdf = _numeric_spark_frame(spark_session, [(1.0, 0), (None, 1)])
+
+    with pytest.raises(NotImplementedError, match=SPARK_MERGE_MESSAGE):
+        binner.transform(sdf, column="score")
+
+
+def test_separate_bin_spark_transform_still_works(spark_session):
+    binner = RiskBands(
+        missing_policy="separate_bin",
+        min_event_rate_diff=0.0,
+    ).fit(make_numeric_missing_frame(), y="target", column="score")
+    sdf = _numeric_spark_frame(spark_session, [(1.0, 0), (None, 1), (float("nan"), 0)])
+
+    transformed = binner.transform(sdf, column="score")
+    observed = transformed.toPandas()["score"].tolist()
+
+    assert transformed.__class__.__module__.startswith("pyspark")
+    assert observed.count("Missing") == 2
+
+
+def test_forbid_spark_transform_still_enforces_missing_policy(spark_session):
+    fit_df = pd.DataFrame({"score": [1.0, 2.0, 3.0, 4.0] * 4, "target": [0, 0, 1, 1] * 4})
+    binner = RiskBands(
+        missing_policy="forbid",
+        min_event_rate_diff=0.0,
+    ).fit(fit_df, y="target", column="score")
+    sdf = _numeric_spark_frame(spark_session, [(1.0, 0), (None, 1)])
+
+    with pytest.raises(ValueError, match="missing_policy='forbid'.*pyspark.*score=1"):
+        binner.transform(sdf, column="score")

--- a/tests/test_missing_merge_reporting.py
+++ b/tests/test_missing_merge_reporting.py
@@ -1,0 +1,73 @@
+import json
+
+import pandas as pd
+
+from riskbands import RiskBands
+from tests.test_missing_merge_nearest_event_rate_pandas import fit_numeric_merge
+from tests.test_missing_values_current_behavior import make_numeric_missing_frame
+
+
+def test_report_exposes_missing_merge_summary_fields():
+    binner, _ = fit_numeric_merge()
+
+    report = binner.report()
+    row = report.iloc[0]
+
+    assert row["missing_policy"] == "merge"
+    assert row["effective_missing_policy"] == "merge"
+    assert row["missing_merge_criterion"] == "nearest_event_rate"
+    assert row["missing_merge_fallback"] == "separate_bin"
+    assert row["missing_merge_action"] == "missing_merged"
+    assert row["missing_merge_status"] == "merged"
+    assert row["missing_merged_into"] == binner.missing_decision_log_.iloc[0]["selected_bin_label"]
+    assert row["missing_original_n"] == binner.missing_decision_log_.iloc[0]["n_missing_fit"]
+
+
+def test_save_report_json_contains_missing_merge_fields(tmp_path):
+    binner, _ = fit_numeric_merge()
+    path = tmp_path / "report.json"
+
+    binner.save_report(path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+
+    assert payload["missing_policy"] == "merge"
+    assert payload["effective_missing_policy"] == "merge"
+    assert payload["missing_merge_criterion"] == "nearest_event_rate"
+    assert payload["missing_merge_fallback"] == "separate_bin"
+    assert payload["missing_profile"][0]["bin_label"] == "Missing"
+    assert payload["missing_decision_log"][0]["action"] == "missing_merged"
+    assert payload["missing_merge_candidates"][0]["selected"] is True
+    assert payload["missing_merge_map"]
+
+
+def test_missing_merge_reporting_does_not_revert_standard_objective_name():
+    binner, _ = fit_numeric_merge()
+
+    report = binner.report()
+
+    assert "legacy" not in set(report["score_strategy"].astype(str))
+    assert "legacy" not in set(report["objective_source"].astype(str))
+    assert report.iloc[0]["objective_source"] == "derived_standard_objective"
+
+
+def test_standard_separate_bin_and_forbid_reporting_do_not_regress():
+    standard = RiskBands(missing_policy="standard", min_event_rate_diff=0.0).fit(
+        make_numeric_missing_frame(),
+        y="target",
+        column="score",
+    )
+    separate = RiskBands(missing_policy="separate_bin", min_event_rate_diff=0.0).fit(
+        make_numeric_missing_frame(),
+        y="target",
+        column="score",
+    )
+    forbid = RiskBands(missing_policy="forbid", min_event_rate_diff=0.0).fit(
+        pd.DataFrame({"score": [-5.0, -1.0, 1.0, 5.0], "target": [0, 0, 1, 1]}),
+        y="target",
+        column="score",
+    )
+
+    assert standard.report().iloc[0]["missing_policy"] == "standard"
+    assert separate.report().iloc[0]["missing_policy"] == "separate_bin"
+    assert forbid.report().iloc[0]["missing_policy"] == "forbid"
+    assert standard.save_report is not None

--- a/tests/test_missing_merge_transform_no_leakage.py
+++ b/tests/test_missing_merge_transform_no_leakage.py
@@ -1,0 +1,125 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from riskbands import RiskBands
+from tests.test_missing_merge_nearest_event_rate_pandas import fit_numeric_merge
+
+
+def make_no_missing_numeric_frame():
+    return pd.DataFrame(
+        {
+            "score": [-5.0, -4.0, -3.0, 0.0, 3.0, 4.0, 5.0] * 8,
+            "target": [0, 0, 0, 1, 1, 1, 1] * 8,
+        }
+    )
+
+
+def test_transform_target_values_do_not_change_learned_missing_destination():
+    binner, _ = fit_numeric_merge()
+    learned_destination = binner.missing_decision_log_.iloc[0]["selected_bin_label"]
+    decision_before = binner.missing_decision_log_.copy(deep=True)
+    app = pd.DataFrame(
+        {
+            "score": [np.nan, np.nan, -5.0, 5.0],
+            "target": [1, 1, 1, 1],
+        }
+    )
+
+    transformed = binner.transform(app, column="score", validate=True)
+
+    assert set(transformed.loc[[0, 1], "score"]) == {learned_destination}
+    assert binner.missing_decision_log_.equals(decision_before)
+    assert binner.missing_transform_fallback_log_.iloc[0]["action"] == "missing_routed_to_learned_merge"
+    assert bool(binner.missing_transform_fallback_log_.iloc[0]["training_decision_used"]) is True
+
+
+def test_transform_without_target_uses_learned_missing_destination():
+    binner, _ = fit_numeric_merge()
+    learned_destination = binner.missing_decision_log_.iloc[0]["selected_bin_label"]
+
+    transformed = binner.transform(pd.DataFrame({"score": [np.nan, -5.0, 5.0]}))
+
+    assert transformed.loc[0, "score"] == learned_destination
+
+
+def test_repeated_transform_is_deterministic():
+    binner, _ = fit_numeric_merge()
+    app = pd.DataFrame({"score": [np.nan, -5.0, 0.0, 5.0, np.nan]})
+
+    first = binner.transform(app)
+    second = binner.transform(app)
+
+    assert first.equals(second)
+
+
+def test_transform_missing_not_seen_in_fit_uses_separate_bin_fallback_and_logs_it():
+    df = make_no_missing_numeric_frame()
+    binner = RiskBands(
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        missing_merge_fallback="separate_bin",
+    ).fit(df, y="target", column="score")
+
+    transformed = binner.transform(pd.DataFrame({"score": [np.nan, -5.0]}))
+    log = binner.missing_transform_fallback_log_.iloc[0]
+
+    assert transformed.loc[0, "score"] == "Missing"
+    assert log["action"] == "missing_transform_fallback_separate_bin"
+    assert bool(log["fallback_used"]) is True
+    assert bool(log["training_decision_used"]) is False
+
+
+def test_transform_missing_not_seen_in_fit_return_woe_errors_for_separate_fallback():
+    df = make_no_missing_numeric_frame()
+    binner = RiskBands(
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        missing_merge_fallback="separate_bin",
+    ).fit(df, y="target", column="score")
+
+    with pytest.raises(ValueError, match="fallback 'separate_bin' has no fitted WoE"):
+        binner.transform(pd.DataFrame({"score": [np.nan, -5.0]}), return_woe=True)
+
+    log = binner.missing_transform_fallback_log_.iloc[0]
+    assert log["action"] == "missing_transform_fallback_separate_bin"
+    assert bool(log["fallback_used"]) is True
+    assert bool(log["training_decision_used"]) is False
+
+
+def test_transform_missing_not_seen_in_fit_raise_fallback_errors_and_logs_it():
+    df = make_no_missing_numeric_frame()
+    binner = RiskBands(
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        missing_merge_fallback="raise",
+    ).fit(df, y="target", column="score")
+
+    with pytest.raises(ValueError, match="no missing merge decision was learned"):
+        binner.transform(pd.DataFrame({"score": [np.nan, -5.0]}))
+
+    log = binner.missing_transform_fallback_log_.iloc[0]
+    assert log["action"] == "missing_transform_fallback_raise"
+    assert bool(log["fallback_used"]) is True
+
+
+def test_transform_application_distribution_cannot_retarget_missing_merge():
+    binner, _ = fit_numeric_merge()
+    learned_destination = binner.missing_decision_log_.iloc[0]["selected_bin_label"]
+    adversarial_app = pd.DataFrame(
+        {
+            "score": [np.nan] * 20 + [-5.0] * 20 + [5.0] * 20,
+            "target": [0] * 20 + [0] * 20 + [1] * 20,
+        }
+    )
+
+    transformed = binner.transform(adversarial_app, column="score", validate=True)
+
+    assert set(transformed.loc[adversarial_app["score"].isna(), "score"]) == {learned_destination}
+    assert binner.missing_decision_log_.iloc[0]["selected_bin_label"] == learned_destination


### PR DESCRIPTION
Adds missing_policy='merge' with missing_merge_criterion='nearest_event_rate', including fallback behavior, audit trail, bundle/reporting persistence, no-leakage transform behavior, return_woe support, and regression coverage for existing missing policies. PySpark merge remains explicitly unsupported in this sprint.