### PR TITLE
Fix missing merge review feedback

### DIFF
--- a/riskbands/binning_engine.py
+++ b/riskbands/binning_engine.py
@@ -160,9 +160,19 @@ class Binner(BaseEstimator, TransformerMixin):
         if "missing_policy" in params:
             params["missing_policy"] = self._normalize_missing_policy(params["missing_policy"])
         prospective_missing_policy = params.get("missing_policy", self.missing_policy)
-        if "missing_merge_criterion" in params or "missing_policy" in params:
+        if "missing_merge_criterion" in params:
             params["missing_merge_criterion"] = self._normalize_missing_merge_criterion(
-                params.get("missing_merge_criterion", self.missing_merge_criterion),
+                params["missing_merge_criterion"],
+                missing_policy=prospective_missing_policy,
+            )
+        elif "missing_policy" in params:
+            inherited_criterion = (
+                self.missing_merge_criterion
+                if prospective_missing_policy == _MERGE_MISSING_POLICY
+                else None
+            )
+            params["missing_merge_criterion"] = self._normalize_missing_merge_criterion(
+                inherited_criterion,
                 missing_policy=prospective_missing_policy,
             )
         if "missing_merge_fallback" in params:
@@ -1957,6 +1967,59 @@ class Binner(BaseEstimator, TransformerMixin):
         self.bin_summary = summary.loc[~remove_mask].reset_index(drop=True)
 
     # ------------------------------------------------------------------
+    def _collect_missing_merge_audit_from_child_binners(self) -> bool:
+        if not hasattr(self, "_per_feature_binners") or not self._per_feature_binners:
+            return False
+
+        feature_columns = list(getattr(self, "feature_names_in_", list(self._per_feature_binners)))
+        profile_frames = []
+        decision_frames = []
+        candidate_frames = []
+        merge_map: dict[str, Any] = {}
+        merge_metrics: dict[str, dict[str, Any]] = {}
+
+        for variable in feature_columns:
+            child = self._per_feature_binners.get(variable)
+            if not isinstance(child, Binner) or not child._is_missing_merge_enabled():
+                return False
+            if not hasattr(child, "missing_decision_log_"):
+                return False
+
+            profile = getattr(child, "missing_profile_", pd.DataFrame())
+            if isinstance(profile, pd.DataFrame) and not profile.empty:
+                profile_frames.append(profile.copy(deep=True))
+
+            decision_log = getattr(child, "missing_decision_log_", pd.DataFrame())
+            if isinstance(decision_log, pd.DataFrame) and not decision_log.empty:
+                decision_frames.append(decision_log.copy(deep=True))
+
+            candidates = getattr(child, "missing_merge_candidates_", pd.DataFrame())
+            if isinstance(candidates, pd.DataFrame) and not candidates.empty:
+                candidate_frames.append(candidates.copy(deep=True))
+
+            for key, value in (getattr(child, "missing_merge_map_", {}) or {}).items():
+                merge_map[str(key)] = value
+            for key, value in (getattr(child, "_missing_merge_metrics_", {}) or {}).items():
+                merge_metrics[str(key)] = dict(value) if isinstance(value, dict) else value
+
+        self.missing_profile_ = (
+            pd.concat(profile_frames, ignore_index=True) if profile_frames else pd.DataFrame()
+        )
+        self.missing_decision_log_ = (
+            pd.concat(decision_frames, ignore_index=True) if decision_frames else pd.DataFrame()
+        )
+        self.missing_merge_candidates_ = (
+            pd.concat(candidate_frames, ignore_index=True) if candidate_frames else pd.DataFrame()
+        )
+        self.missing_merge_map_ = merge_map
+        self._missing_merge_metrics_ = merge_metrics
+        self.missing_policy_ = self.missing_policy
+        self.effective_missing_policy_ = self.missing_policy
+        self.missing_merge_criterion_ = self.missing_merge_criterion
+        self.missing_merge_fallback_ = self.missing_merge_fallback
+        return True
+
+    # ------------------------------------------------------------------
     def _transform_pandas_core(
         self,
         X: pd.DataFrame,
@@ -2110,17 +2173,18 @@ class Binner(BaseEstimator, TransformerMixin):
         backend: str,
     ) -> None:
         if self._is_missing_merge_enabled():
-            pre_transformed = self._transform_pandas_core(
-                X_features,
-                list(getattr(self, "feature_names_in_", X_features.columns)),
-            )
-            pre_profile = self._build_profile_from_transformed(pre_transformed, y)
-            self._build_missing_merge_audit_from_fit(
-                X_features,
-                y,
-                pre_profile,
-                backend=backend,
-            )
+            if not self._collect_missing_merge_audit_from_child_binners():
+                pre_transformed = self._transform_pandas_core(
+                    X_features,
+                    list(getattr(self, "feature_names_in_", X_features.columns)),
+                )
+                pre_profile = self._build_profile_from_transformed(pre_transformed, y)
+                self._build_missing_merge_audit_from_fit(
+                    X_features,
+                    y,
+                    pre_profile,
+                    backend=backend,
+                )
             merged_fit_profile = self._build_fit_profile(X_features, y)
             self._apply_missing_merge_to_bin_summary(merged_profile=merged_fit_profile)
             self._compute_iv_metrics()

--- a/tests/test_missing_merge_nearest_event_rate_pandas.py
+++ b/tests/test_missing_merge_nearest_event_rate_pandas.py
@@ -92,6 +92,43 @@ def test_numeric_merge_return_woe_routes_missing_to_selected_bin_woe():
     assert transformed.loc[0, "score"] == pytest.approx(profile_row["woe"])
 
 
+def test_optuna_merge_preserves_child_missing_audit_artifacts():
+    df = make_numeric_event_rate_frame(missing_events=10, missing_non_events=10)
+    binner = RiskBands(
+        max_bins=5,
+        min_event_rate_diff=0.0,
+        use_optuna=True,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        strategy_kwargs={"n_trials": 2, "sampler_seed": 123},
+    ).fit(df, y="target", column="score")
+    child = binner._per_feature_binners["score"]
+    decision = binner.missing_decision_log_.iloc[0]
+    child_decision = child.missing_decision_log_.iloc[0]
+    selected_label = decision["selected_bin_label"]
+    profile_row = row_for_label(binner.missing_profile_, "bin_label", "Missing")
+
+    transformed = binner.transform(pd.DataFrame({"score": [np.nan, -5.0]}))
+    transformed_woe = binner.transform(pd.DataFrame({"score": [np.nan, -5.0]}), return_woe=True)
+    fit_profile_row = row_for_label(binner.fit_profile_, "bin_label", selected_label)
+    summary_row = row_for_label(binner.bin_summary, "bin", selected_label)
+
+    assert decision["action"] == "missing_merged"
+    assert selected_label == child_decision["selected_bin_label"]
+    assert profile_row["merged_into_bin_label"] == selected_label
+    assert int(profile_row["n_missing_fit"]) == int(df["score"].isna().sum())
+    assert binner.missing_merge_map_["score"] == selected_label
+    assert not binner.missing_merge_candidates_.empty
+    assert transformed.loc[0, "score"] == selected_label
+    assert transformed.loc[0, "score"] != "Missing"
+    assert pd.api.types.is_numeric_dtype(transformed_woe["score"])
+    assert not isinstance(transformed_woe.loc[0, "score"], str)
+    assert transformed_woe.loc[0, "score"] == pytest.approx(fit_profile_row["woe"])
+    assert "Missing" not in set(binner.bin_summary["bin"].astype(str))
+    assert summary_row["count"] == pytest.approx(fit_profile_row["n"])
+    assert summary_row["event_rate"] == pytest.approx(fit_profile_row["event_rate"])
+
+
 def test_bin_summary_selected_bin_matches_fit_profile_after_missing_merge():
     binner, _ = fit_numeric_merge()
     decision = binner.missing_decision_log_.iloc[0]

--- a/tests/test_missing_merge_policy_parameter.py
+++ b/tests/test_missing_merge_policy_parameter.py
@@ -103,11 +103,33 @@ def test_set_params_validates_missing_merge_contract():
     assert binner.missing_merge_fallback == "raise"
 
 
-def test_set_params_rejects_incompatible_criterion():
+def test_set_params_clears_merge_criterion_when_leaving_merge_policy():
     binner = RiskBands(
         missing_policy="merge",
         missing_merge_criterion="nearest_event_rate",
     )
 
+    binner.set_params(missing_policy="standard")
+
+    assert binner.missing_policy == "standard"
+    assert binner.missing_policy_ == "standard"
+    assert binner.missing_merge_criterion is None
+    assert binner.missing_merge_criterion_ is None
+    assert binner.missing_merge_fallback == "separate_bin"
+
     with pytest.raises(ValueError, match="missing_merge_criterion.*missing_policy='merge'"):
-        binner.set_params(missing_policy="standard")
+        binner.set_params(
+            missing_policy="standard",
+            missing_merge_criterion="nearest_event_rate",
+        )
+
+    with pytest.raises(ValueError, match="missing_merge_criterion.*required"):
+        binner.set_params(missing_policy="merge")
+
+    binner.set_params(
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    )
+
+    assert binner.missing_policy == "merge"
+    assert binner.missing_merge_criterion == "nearest_event_rate"


### PR DESCRIPTION
Fixes Codex Review feedback from the nearest event rate missing merge policy. Preserves merge audit artifacts from child binners in the Optuna path and clears stale missing_merge_criterion when leaving missing_policy='merge'. Includes targeted regression coverage and preserves existing missing policy behavior.