### PR TITLE
Add nearest WOE missing merge policy

### DIFF
--- a/docs/missing_merge_nearest_event_rate_design.md
+++ b/docs/missing_merge_nearest_event_rate_design.md
@@ -6,7 +6,7 @@ version.
 
 ## Implemented API
 
-The E1 API adds a narrow merge mode:
+The E1 API added the first narrow merge mode:
 
 ```python
 RiskBands(
@@ -16,10 +16,20 @@ RiskBands(
 )
 ```
 
-Supported values in this sprint:
+Sprint E2 adds the second supported criterion:
+
+```python
+RiskBands(
+    missing_policy="merge",
+    missing_merge_criterion="nearest_woe",
+    missing_merge_fallback="separate_bin",
+)
+```
+
+Supported values after E2:
 
 - `missing_policy`: `standard`, `separate_bin`, `forbid`, `merge`.
-- `missing_merge_criterion`: `nearest_event_rate` only.
+- `missing_merge_criterion`: `nearest_event_rate` or `nearest_woe`.
 - `missing_merge_fallback`: `separate_bin` or `raise`.
 
 `legacy` remains a compatibility alias for `standard`. The default
@@ -93,9 +103,19 @@ missing_policy="merge" with PySpark is not implemented in this release. Use pand
 Existing Spark behavior for `standard`, `separate_bin`, and `forbid` remains in
 scope and is covered by Spark regression tests.
 
+## Relationship To Nearest WOE
+
+`nearest_event_rate` selects the regular candidate bin with the smallest
+absolute event-rate difference from the missing group. `nearest_woe` uses the
+same pre-merge fit profile, but selects by absolute WOE difference. Both
+criteria preserve the same fit-only decision, transform routing, fallback,
+bundle, and reporting contract.
+
+The detailed E2 design is documented in
+[`docs/missing_merge_nearest_woe_design.md`](missing_merge_nearest_woe_design.md).
+
 ## Limitations
 
-- No `nearest_woe` criterion.
 - No `temporal_stable` criterion.
 - No `monotonic_neighbor` criterion.
 - No custom criterion.
@@ -104,9 +124,6 @@ scope and is covered by Spark regression tests.
 - No use of transform/OOT target data to choose a merge destination.
 
 ## Future Work
-
-Sprint E2 can add `nearest_woe` if the WOE definition and smoothing rules are
-made explicit for low-count or zero-event bins.
 
 Later sprints can consider:
 

--- a/docs/missing_merge_nearest_woe_design.md
+++ b/docs/missing_merge_nearest_woe_design.md
@@ -1,0 +1,115 @@
+# Missing Merge Nearest WOE Design
+
+This internal note documents the Sprint E2 implementation of
+`missing_policy="merge"` with `missing_merge_criterion="nearest_woe"`. It is
+not a release note and does not imply package publication.
+
+## API
+
+The supported merge criteria are:
+
+```python
+RiskBands(
+    missing_policy="merge",
+    missing_merge_criterion="nearest_event_rate",
+)
+
+RiskBands(
+    missing_policy="merge",
+    missing_merge_criterion="nearest_woe",
+)
+```
+
+`missing_merge_fallback` remains `separate_bin` by default and also accepts
+`raise`. The default `missing_policy` remains `standard`. `legacy` remains a
+compatibility alias for `standard` and cannot be combined with merge criteria.
+
+## Fit Semantics
+
+During pandas fit, `nearest_woe` follows the same auditable flow introduced for
+`nearest_event_rate`:
+
+1. Keep missing values visible as a pre-merge `Missing` group.
+2. Build the pre-merge fit profile with the existing WOE calculation.
+3. Read the missing group's WOE from that profile.
+4. Read each regular candidate bin's WOE from that profile.
+5. Exclude candidates with non-finite WOE.
+6. Select the candidate with the smallest `abs(missing_woe - candidate_woe)`.
+7. Break ties by larger candidate `n`, lower `bin_order`, then label.
+8. Persist the learned destination and full candidate audit payload.
+
+No transform or application data participates in the decision.
+
+## Event Rate Versus WOE
+
+`nearest_event_rate` selects by absolute event-rate distance. `nearest_woe`
+selects by absolute WOE distance. These can choose different bins because WOE
+uses smoothed event and non-event distributions from the fit profile rather
+than raw event-rate differences.
+
+The WOE values are not recalculated in a separate implementation. They come
+from the same profile used elsewhere by RiskBands, including the existing 0.5
+smoothing for zero-event or all-event groups.
+
+## Audit Trail
+
+`missing_decision_log_` records:
+
+- `merge_criterion="nearest_woe"`
+- `missing_woe`
+- `selected_bin_woe`
+- `distance_woe`
+- `distance_metric="abs_woe_diff"`
+- `candidate_bins` with bin label, `n`, event rate, WOE, distance, and selected
+  flag
+- tie-break and fallback metadata
+
+`missing_merge_candidates_` stores the tabular candidate payload, and
+`missing_profile_` keeps the original missing group visible even after the final
+`bin_summary` removes the standalone `Missing` row for merged variables.
+
+## Transform And Return WOE
+
+Transform uses only the fit-time `missing_merge_map_`. It does not inspect
+target values, application event rates, application WOE, or OOT distributions.
+
+With `return_woe=True`, missing values are first routed to the learned
+destination label and then mapped to the final fitted WOE for that destination
+bin. If no decision was learned because no missing values appeared during fit,
+`separate_bin` keeps the transform label as `Missing`; requesting WOE for that
+fallback raises because there is no fitted WOE for a new transform-only missing
+bin. With fallback `raise`, transform fails when new missing values appear.
+
+## Bundle And Reporting
+
+Bundle export persists:
+
+- `missing_policy`
+- `effective_missing_policy`
+- `missing_merge_criterion`
+- `missing_merge_fallback`
+- `missing_profile`
+- `missing_decision_log`
+- `missing_merge_candidates`
+- `missing_merge_map`
+
+Reports expose the selected criterion, destination bin, generic merge distance,
+distance metric, event-rate distance, and WOE distance.
+
+## PySpark Boundary
+
+PySpark merge remains intentionally unsupported in E2. Fit or transform with
+`missing_policy="merge"` raises a clear `NotImplementedError` for both
+`nearest_event_rate` and `nearest_woe`. Existing PySpark behavior for
+`separate_bin` and `forbid` remains covered by regression tests.
+
+## Out Of Scope
+
+E2 does not implement:
+
+- `temporal_stable`
+- `monotonic_neighbor`
+- custom criteria
+- advanced thresholds
+- full PySpark merge routing
+- publication, tags, or automatic pushes

--- a/riskbands/binning_engine.py
+++ b/riskbands/binning_engine.py
@@ -33,8 +33,10 @@ _VALID_MISSING_POLICIES = {
     _MERGE_MISSING_POLICY,
 }
 _NEAREST_EVENT_RATE_MISSING_MERGE_CRITERION = "nearest_event_rate"
+_NEAREST_WOE_MISSING_MERGE_CRITERION = "nearest_woe"
 _VALID_MISSING_MERGE_CRITERIA = {
     _NEAREST_EVENT_RATE_MISSING_MERGE_CRITERION,
+    _NEAREST_WOE_MISSING_MERGE_CRITERION,
 }
 _SEPARATE_BIN_MISSING_MERGE_FALLBACK = "separate_bin"
 _RAISE_MISSING_MERGE_FALLBACK = "raise"
@@ -226,7 +228,7 @@ class Binner(BaseEstimator, TransformerMixin):
             if missing_policy == _MERGE_MISSING_POLICY:
                 raise ValueError(
                     "`missing_merge_criterion` is required when missing_policy='merge'. "
-                    "Use 'nearest_event_rate'."
+                    "Use 'nearest_event_rate' or 'nearest_woe'."
                 )
             return None
         criterion = str(value)
@@ -1285,7 +1287,7 @@ class Binner(BaseEstimator, TransformerMixin):
     def _is_missing_merge_enabled(self) -> bool:
         return (
             self.missing_policy == _MERGE_MISSING_POLICY
-            and self.missing_merge_criterion == _NEAREST_EVENT_RATE_MISSING_MERGE_CRITERION
+            and self.missing_merge_criterion in _VALID_MISSING_MERGE_CRITERIA
         )
 
     # ------------------------------------------------------------------
@@ -1540,14 +1542,32 @@ class Binner(BaseEstimator, TransformerMixin):
     ) -> dict[str, Any]:
         missing_event_rate = self._row_number(missing_row, "event_rate")
         candidate_event_rate = self._row_number(candidate, "event_rate")
-        distance = (
+        distance_event_rate = (
             abs(missing_event_rate - candidate_event_rate)
             if np.isfinite(missing_event_rate) and np.isfinite(candidate_event_rate)
             else np.nan
         )
+        missing_woe = self._row_number(missing_row, "woe")
+        candidate_woe = self._row_number(candidate, "woe")
+        distance_woe = (
+            abs(missing_woe - candidate_woe)
+            if np.isfinite(missing_woe) and np.isfinite(candidate_woe)
+            else np.nan
+        )
+        criterion = self.missing_merge_criterion
+        distance = (
+            distance_woe
+            if criterion == _NEAREST_WOE_MISSING_MERGE_CRITERION
+            else distance_event_rate
+        )
+        distance_metric = (
+            "abs_woe_diff"
+            if criterion == _NEAREST_WOE_MISSING_MERGE_CRITERION
+            else "abs_event_rate_diff"
+        )
         return {
             "variable": variable,
-            "criterion": self.missing_merge_criterion,
+            "criterion": criterion,
             "candidate_rank": rank,
             "candidate_bin_id": candidate.get("bin_id"),
             "candidate_bin_label": candidate.get("bin_label"),
@@ -1556,12 +1576,16 @@ class Binner(BaseEstimator, TransformerMixin):
             "candidate_events": self._row_number(candidate, "events", default=0.0),
             "candidate_non_events": self._row_number(candidate, "non_events", default=0.0),
             "candidate_event_rate": candidate_event_rate,
+            "candidate_woe": candidate_woe,
             "missing_n": self._row_number(missing_row, "n", default=0.0),
             "missing_events": self._row_number(missing_row, "events", default=0.0),
             "missing_non_events": self._row_number(missing_row, "non_events", default=0.0),
             "missing_event_rate": missing_event_rate,
-            "distance_event_rate": distance,
-            "distance_metric": "abs_event_rate_diff",
+            "missing_woe": missing_woe,
+            "distance_event_rate": distance_event_rate,
+            "distance_woe": distance_woe,
+            "distance": distance,
+            "distance_metric": distance_metric,
             "selected": bool(selected),
         }
 
@@ -1583,6 +1607,17 @@ class Binner(BaseEstimator, TransformerMixin):
         merge_metrics: dict[str, dict[str, Any]] = {}
 
         for variable in feature_columns:
+            criterion = self.missing_merge_criterion
+            distance_field = (
+                "distance_woe"
+                if criterion == _NEAREST_WOE_MISSING_MERGE_CRITERION
+                else "distance_event_rate"
+            )
+            distance_metric = (
+                "abs_woe_diff"
+                if criterion == _NEAREST_WOE_MISSING_MERGE_CRITERION
+                else "abs_event_rate_diff"
+            )
             variable_profile = pre_profile.loc[pre_profile["variable"] == variable].copy()
             n_missing = int(counts.get(str(variable), 0))
             missing_detected = n_missing > 0
@@ -1598,6 +1633,7 @@ class Binner(BaseEstimator, TransformerMixin):
                 missing_events = self._row_number(missing_row, "events", default=0.0)
                 missing_non_events = self._row_number(missing_row, "non_events", default=missing_n - missing_events)
                 missing_event_rate = self._row_number(missing_row, "event_rate")
+                missing_woe = self._row_number(missing_row, "woe")
                 missing_share = self._row_number(missing_row, "share")
                 profile_record_index = len(profile_records)
                 profile_records.append(
@@ -1609,6 +1645,7 @@ class Binner(BaseEstimator, TransformerMixin):
                         "share_missing_fit": missing_share,
                         "events_missing_fit": missing_events,
                         "event_rate_missing_fit": missing_event_rate,
+                        "woe_missing_fit": missing_woe if np.isfinite(missing_woe) else None,
                         "is_missing_bin": True,
                         "bin_label": missing_row.get("bin_label", "Missing"),
                         "backend": backend,
@@ -1625,6 +1662,7 @@ class Binner(BaseEstimator, TransformerMixin):
                 missing_events = 0.0
                 missing_non_events = 0.0
                 missing_event_rate = np.nan
+                missing_woe = np.nan
                 missing_share = np.nan
                 profile_record_index = None
 
@@ -1638,6 +1676,8 @@ class Binner(BaseEstimator, TransformerMixin):
                 "missing_detected": bool(missing_detected),
                 "n_missing_fit": n_missing,
                 "event_rate_missing_fit": missing_event_rate if np.isfinite(missing_event_rate) else None,
+                "woe_missing_fit": missing_woe if np.isfinite(missing_woe) else None,
+                "missing_woe": missing_woe if np.isfinite(missing_woe) else None,
                 "training_only": True,
                 "backend": backend,
                 "fallback": self.missing_merge_fallback,
@@ -1645,10 +1685,13 @@ class Binner(BaseEstimator, TransformerMixin):
                 "selected_bin_label": None,
                 "selected_bin_order": None,
                 "selected_bin_event_rate": None,
-                "distance_metric": "abs_event_rate_diff",
+                "selected_bin_woe": None,
+                "distance_metric": distance_metric,
                 "distance_value": None,
                 "distance": None,
-                "tie_break_rule": "distance_event_rate asc, candidate_n desc, bin_order asc, bin_label asc",
+                "distance_event_rate": None,
+                "distance_woe": None,
+                "tie_break_rule": f"{distance_field} asc, candidate_n desc, bin_order asc, bin_label asc",
                 "tie_break_applied": False,
                 "tie_detected": False,
                 "candidate_count": 0,
@@ -1692,6 +1735,29 @@ class Binner(BaseEstimator, TransformerMixin):
                 )
                 continue
 
+            if criterion == _NEAREST_WOE_MISSING_MERGE_CRITERION and not np.isfinite(missing_woe):
+                reason = "missing_woe_not_finite"
+                if self.missing_merge_fallback == _RAISE_MISSING_MERGE_FALLBACK:
+                    raise ValueError(
+                        f"missing_policy='merge' could not compute nearest_woe for variable "
+                        f"'{variable}' because the missing WoE is not finite."
+                    )
+                if profile_record_index is not None:
+                    profile_records[profile_record_index]["merge_status"] = "kept_separate"
+                decision_records.append(
+                    {
+                        **base_decision,
+                        "action": "missing_kept_separate",
+                        "status": "kept_separate",
+                        "fallback_used": True,
+                        "reason": reason,
+                        "notes": (
+                            "Missing values were kept as a separate bin because the missing WoE was unavailable."
+                        ),
+                    }
+                )
+                continue
+
             regular = variable_profile.loc[
                 variable_profile.get("is_regular_bin", pd.Series(False, index=variable_profile.index))
                 .fillna(False)
@@ -1702,7 +1768,7 @@ class Binner(BaseEstimator, TransformerMixin):
                 if self.missing_merge_fallback == _RAISE_MISSING_MERGE_FALLBACK:
                     raise ValueError(
                         f"missing_policy='merge' found missing values for variable '{variable}', "
-                        "but no regular candidate bin is available for nearest_event_rate merge."
+                        f"but no regular candidate bin is available for {criterion} merge."
                     )
                 if profile_record_index is not None:
                     profile_records[profile_record_index]["merge_status"] = "kept_separate"
@@ -1733,13 +1799,17 @@ class Binner(BaseEstimator, TransformerMixin):
             candidate_rows = [
                 (record, candidate)
                 for record, candidate in candidate_rows
-                if np.isfinite(float(record["distance_event_rate"]))
+                if np.isfinite(float(record[distance_field]))
             ]
             if not candidate_rows:
-                reason = "criterion_not_available"
+                reason = (
+                    "no_finite_candidate_woe"
+                    if criterion == _NEAREST_WOE_MISSING_MERGE_CRITERION
+                    else "criterion_not_available"
+                )
                 if self.missing_merge_fallback == _RAISE_MISSING_MERGE_FALLBACK:
                     raise ValueError(
-                        f"missing_policy='merge' could not compute nearest_event_rate candidates "
+                        f"missing_policy='merge' could not compute {criterion} candidates "
                         f"for variable '{variable}'."
                     )
                 if profile_record_index is not None:
@@ -1761,17 +1831,17 @@ class Binner(BaseEstimator, TransformerMixin):
             sorted_candidates = sorted(
                 candidate_rows,
                 key=lambda item: (
-                    float(item[0]["distance_event_rate"]),
+                    float(item[0][distance_field]),
                     -float(item[0]["candidate_n"]),
                     self._row_number(item[1], "bin_order", default=float("inf")),
                     self._bin_label_key(item[1].get("bin_label")),
                 ),
             )
-            best_distance = float(sorted_candidates[0][0]["distance_event_rate"])
+            best_distance = float(sorted_candidates[0][0][distance_field])
             tied = [
                 item
                 for item in sorted_candidates
-                if np.isclose(float(item[0]["distance_event_rate"]), best_distance)
+                if np.isclose(float(item[0][distance_field]), best_distance)
             ]
             selected_record, selected_candidate = sorted_candidates[0]
             selected_label = selected_candidate.get("bin_label")
@@ -1793,7 +1863,11 @@ class Binner(BaseEstimator, TransformerMixin):
                         "n": ranked_record["candidate_n"],
                         "events": ranked_record["candidate_events"],
                         "event_rate": ranked_record["candidate_event_rate"],
-                        "distance": ranked_record["distance_event_rate"],
+                        "woe": ranked_record["candidate_woe"],
+                        "distance": ranked_record[distance_field],
+                        "distance_event_rate": ranked_record["distance_event_rate"],
+                        "distance_woe": ranked_record["distance_woe"],
+                        "distance_metric": ranked_record["distance_metric"],
                         "selected": rank == 1,
                     }
                 )
@@ -1802,6 +1876,7 @@ class Binner(BaseEstimator, TransformerMixin):
             candidate_events = self._row_number(selected_candidate, "events", default=0.0)
             candidate_non_events = self._row_number(selected_candidate, "non_events", default=0.0)
             selected_event_rate = self._row_number(selected_candidate, "event_rate")
+            selected_woe = self._row_number(selected_candidate, "woe")
             post_n = missing_n + candidate_n
             post_events = missing_events + candidate_events
             post_non_events = missing_non_events + candidate_non_events
@@ -1813,6 +1888,7 @@ class Binner(BaseEstimator, TransformerMixin):
                     "events": missing_events,
                     "non_events": missing_non_events,
                     "event_rate": missing_event_rate,
+                    "woe": missing_woe if np.isfinite(missing_woe) else None,
                     "share": missing_share,
                 },
                 "selected_bin": {
@@ -1820,6 +1896,7 @@ class Binner(BaseEstimator, TransformerMixin):
                     "events": candidate_events,
                     "non_events": candidate_non_events,
                     "event_rate": self._row_number(selected_candidate, "event_rate"),
+                    "woe": selected_woe if np.isfinite(selected_woe) else None,
                     "share": self._row_number(selected_candidate, "share"),
                 },
             }
@@ -1840,6 +1917,11 @@ class Binner(BaseEstimator, TransformerMixin):
                 "post_events": post_events,
                 "post_non_events": post_non_events,
                 "post_event_rate": post_event_rate,
+                "missing_woe": missing_woe if np.isfinite(missing_woe) else None,
+                "selected_bin_woe": selected_woe if np.isfinite(selected_woe) else None,
+                "distance_woe": selected_record.get("distance_woe"),
+                "distance_event_rate": selected_record.get("distance_event_rate"),
+                "distance_metric": distance_metric,
             }
             if profile_record_index is not None:
                 profile_records[profile_record_index]["merged_into_bin_label"] = selected_label
@@ -1854,15 +1936,21 @@ class Binner(BaseEstimator, TransformerMixin):
                     "selected_bin_label": selected_label,
                     "selected_bin_order": selected_order,
                     "selected_bin_event_rate": selected_event_rate,
+                    "selected_bin_woe": selected_woe if np.isfinite(selected_woe) else None,
                     "distance_value": best_distance,
                     "distance": best_distance,
+                    "distance_event_rate": selected_record.get("distance_event_rate"),
+                    "distance_woe": selected_record.get("distance_woe"),
                     "tie_break_applied": len(tied) > 1,
                     "tie_detected": len(tied) > 1,
                     "candidate_count": len(sorted_candidates),
                     "candidate_bins": candidate_bins_payload,
                     "metrics_before": metrics_before,
                     "metrics_after": metrics_after,
-                    "notes": "Missing values were merged into the nearest event-rate regular bin using training data.",
+                    "notes": (
+                        f"Missing values were merged into the nearest {criterion} regular bin "
+                        "using training data."
+                    ),
                 }
             )
 

--- a/riskbands/reporting.py
+++ b/riskbands/reporting.py
@@ -682,7 +682,15 @@ def build_variable_audit_report(
             "missing_merged_into": missing_decision_row.get("selected_bin_label"),
             "missing_original_n": missing_decision_row.get("n_missing_fit"),
             "missing_original_event_rate": missing_decision_row.get("event_rate_missing_fit"),
+            "missing_original_woe": missing_decision_row.get(
+                "missing_woe",
+                missing_decision_row.get("woe_missing_fit"),
+            ),
+            "missing_selected_bin_woe": missing_decision_row.get("selected_bin_woe"),
+            "missing_merge_distance_metric": missing_decision_row.get("distance_metric"),
             "missing_merge_distance": missing_decision_row.get("distance"),
+            "missing_merge_distance_event_rate": missing_decision_row.get("distance_event_rate"),
+            "missing_merge_distance_woe": missing_decision_row.get("distance_woe"),
         }
 
         for column in BASE_COMPONENT_COLUMNS:

--- a/tests/test_missing_merge_audit_trail.py
+++ b/tests/test_missing_merge_audit_trail.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from riskbands import RiskBands
 from tests.test_missing_merge_nearest_event_rate_pandas import fit_numeric_merge, selected_candidate
+from tests.test_missing_merge_nearest_woe_pandas import fit_numeric_woe_merge, selected_woe_candidate
 
 
 def test_missing_merge_decision_log_contains_complete_decision():
@@ -47,6 +48,33 @@ def test_missing_merge_candidates_are_registered_and_mark_selected_bin():
         ]
     ).issubset(candidates.columns)
     assert bool(candidates.sort_values("candidate_rank").iloc[0]["selected"]) is True
+
+
+def test_nearest_woe_decision_log_contains_woe_distance_fields():
+    binner, _ = fit_numeric_woe_merge()
+    row = binner.missing_decision_log_.iloc[0]
+    candidate = selected_woe_candidate(binner)
+
+    assert row["missing_merge_criterion"] == "nearest_woe"
+    assert row["distance_metric"] == "abs_woe_diff"
+    assert row["missing_woe"] == candidate["missing_woe"]
+    assert row["selected_bin_woe"] == candidate["candidate_woe"]
+    assert row["distance_woe"] == candidate["distance_woe"]
+    assert row["distance"] == candidate["distance_woe"]
+    assert row["candidate_bins"][0]["woe"] == candidate["candidate_woe"]
+    assert row["candidate_bins"][0]["distance_metric"] == "abs_woe_diff"
+
+
+def test_nearest_woe_candidates_are_json_serializable():
+    binner, _ = fit_numeric_woe_merge()
+    records = binner.missing_decision_log_.to_dict("records")
+
+    payload = json.dumps(records)
+    decoded = json.loads(payload)
+
+    assert decoded[0]["candidate_bins"]
+    assert "woe" in decoded[0]["candidate_bins"][0]
+    assert "distance_woe" in decoded[0]["candidate_bins"][0]
 
 
 def test_missing_profile_preserves_original_missing_after_merge():

--- a/tests/test_missing_merge_bundle_persistence.py
+++ b/tests/test_missing_merge_bundle_persistence.py
@@ -9,6 +9,7 @@ from tests.test_missing_merge_nearest_event_rate_pandas import (
     fit_numeric_merge,
     make_categorical_event_rate_frame,
 )
+from tests.test_missing_merge_nearest_woe_pandas import fit_numeric_woe_merge
 
 
 def test_bundle_roundtrip_persists_merge_numeric_decision(tmp_path):
@@ -31,6 +32,27 @@ def test_bundle_roundtrip_persists_merge_numeric_decision(tmp_path):
     assert (bundle_dir / "missing_profile.csv").exists()
     assert (bundle_dir / "missing_decision_log.csv").exists()
     assert (bundle_dir / "missing_merge_candidates.csv").exists()
+
+
+def test_bundle_roundtrip_persists_nearest_woe_decision(tmp_path):
+    binner, _ = fit_numeric_woe_merge()
+    bundle_dir = tmp_path / "bundle"
+
+    binner.export_bundle(bundle_dir)
+    loaded = load_bundle(bundle_dir)
+
+    assert loaded["missing_policy"] == "merge"
+    assert loaded["effective_missing_policy"] == "merge"
+    assert loaded["missing_merge_criterion"] == "nearest_woe"
+    assert loaded["missing_decision_log"][0]["distance_metric"] == "abs_woe_diff"
+    assert loaded["missing_decision_log"][0]["distance_woe"] == binner.missing_decision_log_.iloc[0][
+        "distance_woe"
+    ]
+    assert loaded["missing_decision_log"][0]["selected_bin_woe"] == binner.missing_decision_log_.iloc[0][
+        "selected_bin_woe"
+    ]
+    assert loaded["missing_merge_candidates"][0]["candidate_woe"] is not None
+    assert loaded["missing_merge_map"] == binner.missing_merge_map_
 
 
 def test_bundle_roundtrip_persists_merge_categorical_decision(tmp_path):

--- a/tests/test_missing_merge_nearest_woe_pandas.py
+++ b/tests/test_missing_merge_nearest_woe_pandas.py
@@ -1,0 +1,266 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from riskbands import RiskBands
+from tests.test_missing_merge_nearest_event_rate_pandas import (
+    make_numeric_event_rate_frame,
+    row_for_label,
+)
+
+
+def make_categorical_woe_difference_frame():
+    rating = []
+    target = []
+    for category, n, events in [
+        ("A", 100, 10),
+        ("B", 100, 35),
+        ("C", 100, 80),
+    ]:
+        rating.extend([category] * n)
+        target.extend([1] * events + [0] * (n - events))
+    rating.extend([None] * 100)
+    target.extend([1] * 20 + [0] * 80)
+    return pd.DataFrame({"rating": rating, "target": target})
+
+
+def fit_numeric_woe_merge(df=None, **kwargs):
+    df = make_numeric_event_rate_frame() if df is None else df
+    binner = RiskBands(
+        max_bins=5,
+        min_event_rate_diff=0.0,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_woe",
+        **kwargs,
+    )
+    return binner.fit(df, y="target", column="score"), df
+
+
+def fit_categorical_woe_merge(df=None, **kwargs):
+    df = make_categorical_woe_difference_frame() if df is None else df
+    binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        force_categorical=["rating"],
+        missing_policy="merge",
+        missing_merge_criterion="nearest_woe",
+        **kwargs,
+    )
+    return binner.fit(df, y="target", column="rating"), df
+
+
+def selected_woe_candidate(binner):
+    selected = binner.missing_merge_candidates_.loc[binner.missing_merge_candidates_["selected"]]
+    assert len(selected) == 1
+    return selected.iloc[0]
+
+
+def assert_selected_by_min_woe_distance(binner):
+    candidates = binner.missing_merge_candidates_
+    selected = selected_woe_candidate(binner)
+    decision = binner.missing_decision_log_.iloc[0]
+
+    assert decision["missing_merge_criterion"] == "nearest_woe"
+    assert decision["distance_metric"] == "abs_woe_diff"
+    assert selected["distance_woe"] == pytest.approx(candidates["distance_woe"].min())
+    assert decision["distance"] == pytest.approx(selected["distance_woe"])
+    assert decision["distance_woe"] == pytest.approx(selected["distance_woe"])
+    assert decision["selected_bin_woe"] == pytest.approx(selected["candidate_woe"])
+    assert decision["missing_woe"] == pytest.approx(selected["missing_woe"])
+
+
+def test_numeric_nearest_woe_merges_missing_into_expected_bin():
+    binner, _ = fit_numeric_woe_merge()
+    decision = binner.missing_decision_log_.iloc[0]
+    selected = selected_woe_candidate(binner)
+
+    transformed = binner.transform(pd.DataFrame({"score": [np.nan, -5.0, 5.0]}))
+
+    assert decision["action"] == "missing_merged"
+    assert decision["status"] == "merged"
+    assert_selected_by_min_woe_distance(binner)
+    assert transformed.loc[0, "score"] == selected["candidate_bin_label"]
+    assert transformed.loc[0, "score"] != "Missing"
+    assert "Missing" not in set(binner.bin_summary["bin"].astype(str))
+    assert binner.missing_profile_.iloc[0]["woe_missing_fit"] == pytest.approx(selected["missing_woe"])
+
+
+def test_categorical_nearest_woe_merges_missing_into_expected_bin():
+    binner, _ = fit_categorical_woe_merge()
+    decision = binner.missing_decision_log_.iloc[0]
+    selected = selected_woe_candidate(binner)
+
+    transformed = binner.transform(pd.DataFrame({"rating": [None, "A", "Z"]}))
+
+    assert decision["action"] == "missing_merged"
+    assert_selected_by_min_woe_distance(binner)
+    assert transformed.loc[0, "rating"] == selected["candidate_bin_label"]
+    assert transformed.loc[0, "rating"] != "Missing"
+
+
+def test_nearest_event_rate_and_nearest_woe_can_choose_different_bins():
+    df = make_categorical_woe_difference_frame()
+    event_rate_binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        force_categorical=["rating"],
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    ).fit(df, y="target", column="rating")
+    woe_binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        force_categorical=["rating"],
+        missing_policy="merge",
+        missing_merge_criterion="nearest_woe",
+    ).fit(df, y="target", column="rating")
+
+    event_rate_decision = event_rate_binner.missing_decision_log_.iloc[0]
+    woe_decision = woe_binner.missing_decision_log_.iloc[0]
+
+    assert event_rate_decision["selected_bin_label"] != woe_decision["selected_bin_label"]
+    assert event_rate_decision["distance_metric"] == "abs_event_rate_diff"
+    assert woe_decision["distance_metric"] == "abs_woe_diff"
+
+
+def test_numeric_merge_return_woe_routes_missing_to_selected_bin_woe():
+    binner, _ = fit_numeric_woe_merge()
+    decision = binner.missing_decision_log_.iloc[0]
+    selected_label = decision["selected_bin_label"]
+    profile_row = row_for_label(binner.fit_profile_, "bin_label", selected_label)
+
+    transformed = binner.transform(pd.DataFrame({"score": [np.nan, -5.0, 5.0]}), return_woe=True)
+
+    assert pd.api.types.is_numeric_dtype(transformed["score"])
+    assert not isinstance(transformed.loc[0, "score"], str)
+    assert transformed.loc[0, "score"] == pytest.approx(profile_row["woe"])
+
+
+def _manual_woe_profile(*, missing_woe=0.0, candidate_woes=(1.0, -1.0)):
+    return pd.DataFrame(
+        [
+            {
+                "variable": "score",
+                "bin_id": "missing",
+                "bin_label": "Missing",
+                "bin_order": 2,
+                "n": 10,
+                "events": 5,
+                "non_events": 5,
+                "event_rate": 0.5,
+                "share": 0.25,
+                "woe": missing_woe,
+                "is_missing_bin": True,
+                "is_special_bin": False,
+                "is_regular_bin": False,
+            },
+            {
+                "variable": "score",
+                "bin_id": "A",
+                "bin_label": "A",
+                "bin_order": 0,
+                "n": 10,
+                "events": 2,
+                "non_events": 8,
+                "event_rate": 0.2,
+                "share": 0.25,
+                "woe": candidate_woes[0],
+                "is_missing_bin": False,
+                "is_special_bin": False,
+                "is_regular_bin": True,
+            },
+            {
+                "variable": "score",
+                "bin_id": "B",
+                "bin_label": "B",
+                "bin_order": 1,
+                "n": 20,
+                "events": 16,
+                "non_events": 4,
+                "event_rate": 0.8,
+                "share": 0.50,
+                "woe": candidate_woes[1],
+                "is_missing_bin": False,
+                "is_special_bin": False,
+                "is_regular_bin": True,
+            },
+        ]
+    )
+
+
+def _build_manual_woe_audit(pre_profile, *, fallback="separate_bin"):
+    binner = RiskBands(
+        missing_policy="merge",
+        missing_merge_criterion="nearest_woe",
+        missing_merge_fallback=fallback,
+    )
+    binner.feature_names_in_ = ["score"]
+    X = pd.DataFrame({"score": [np.nan] * 10 + [0.0] * 10 + [1.0] * 20})
+    y = pd.Series([0, 1] * 20, name="target")
+    binner._build_missing_merge_audit_from_fit(X, y, pre_profile, backend="pandas")
+    return binner
+
+
+def test_nearest_woe_tie_break_prefers_larger_candidate_n():
+    binner = _build_manual_woe_audit(_manual_woe_profile())
+    decision = binner.missing_decision_log_.iloc[0]
+    selected = selected_woe_candidate(binner)
+
+    assert bool(decision["tie_detected"]) is True
+    assert bool(decision["tie_break_applied"]) is True
+    assert selected["candidate_bin_label"] == "B"
+    assert selected["candidate_n"] == 20
+    assert "candidate_n desc" in decision["tie_break_rule"]
+
+
+def test_nearest_woe_missing_non_finite_uses_separate_fallback():
+    binner = _build_manual_woe_audit(_manual_woe_profile(missing_woe=np.nan))
+    decision = binner.missing_decision_log_.iloc[0]
+
+    assert decision["action"] == "missing_kept_separate"
+    assert decision["status"] == "kept_separate"
+    assert bool(decision["fallback_used"]) is True
+    assert decision["reason"] == "missing_woe_not_finite"
+
+
+def test_nearest_woe_no_finite_candidate_uses_separate_fallback():
+    binner = _build_manual_woe_audit(_manual_woe_profile(candidate_woes=(np.nan, np.nan)))
+    decision = binner.missing_decision_log_.iloc[0]
+
+    assert decision["action"] == "missing_kept_separate"
+    assert decision["status"] == "kept_separate"
+    assert bool(decision["fallback_used"]) is True
+    assert decision["reason"] == "no_finite_candidate_woe"
+
+
+def test_nearest_woe_no_finite_candidate_raise_fallback_errors():
+    with pytest.raises(ValueError, match="nearest_woe candidates"):
+        _build_manual_woe_audit(
+            _manual_woe_profile(candidate_woes=(np.nan, np.nan)),
+            fallback="raise",
+        )
+
+
+def test_standard_separate_bin_and_forbid_stay_intact_with_nearest_woe_available():
+    standard = RiskBands(missing_policy="standard", min_event_rate_diff=0.0).fit(
+        pd.DataFrame({"score": [1.0, 2.0, np.nan, 4.0], "target": [0, 1, 0, 1]}),
+        y="target",
+        column="score",
+    )
+    separate = RiskBands(missing_policy="separate_bin", min_event_rate_diff=0.0).fit(
+        pd.DataFrame({"score": [1.0, 2.0, np.nan, 4.0], "target": [0, 1, 0, 1]}),
+        y="target",
+        column="score",
+    )
+    forbid = RiskBands(missing_policy="forbid", min_event_rate_diff=0.0).fit(
+        pd.DataFrame({"score": [1.0, 2.0, 3.0, 4.0], "target": [0, 1, 0, 1]}),
+        y="target",
+        column="score",
+    )
+
+    assert standard.missing_policy_ == "standard"
+    assert separate.missing_policy_ == "separate_bin"
+    assert forbid.missing_policy_ == "forbid"
+    assert standard.missing_merge_criterion_ is None
+    assert separate.missing_merge_criterion_ is None
+    assert forbid.missing_merge_criterion_ is None

--- a/tests/test_missing_merge_policy_parameter.py
+++ b/tests/test_missing_merge_policy_parameter.py
@@ -31,6 +31,20 @@ def test_missing_merge_nearest_event_rate_is_accepted():
     assert binner.missing_merge_fallback == "separate_bin"
 
 
+def test_missing_merge_nearest_woe_is_accepted():
+    binner = RiskBands(
+        missing_policy="merge",
+        missing_merge_criterion="nearest_woe",
+    )
+
+    assert binner.missing_policy == "merge"
+    assert binner.missing_policy_ == "merge"
+    assert binner.effective_missing_policy_ == "merge"
+    assert binner.missing_merge_criterion == "nearest_woe"
+    assert binner.missing_merge_criterion_ == "nearest_woe"
+    assert binner.missing_merge_fallback == "separate_bin"
+
+
 def test_missing_merge_accepts_raise_fallback():
     binner = Binner(
         missing_policy="merge",
@@ -51,7 +65,7 @@ def test_missing_merge_rejects_invalid_criterion():
     with pytest.raises(ValueError, match="Unsupported missing_merge_criterion"):
         RiskBands(
             missing_policy="merge",
-            missing_merge_criterion="nearest_woe",
+            missing_merge_criterion="temporal_stable",
         )
 
 
@@ -70,6 +84,14 @@ def test_missing_merge_criterion_is_rejected_without_merge_policy(policy):
         RiskBands(
             missing_policy=policy,
             missing_merge_criterion="nearest_event_rate",
+        )
+
+
+def test_missing_merge_nearest_woe_is_rejected_without_merge_policy():
+    with pytest.raises(ValueError, match="missing_merge_criterion.*missing_policy='merge'"):
+        RiskBands(
+            missing_policy="standard",
+            missing_merge_criterion="nearest_woe",
         )
 
 

--- a/tests/test_missing_merge_pyspark_boundary.py
+++ b/tests/test_missing_merge_pyspark_boundary.py
@@ -32,10 +32,32 @@ def test_merge_spark_fit_fails_explicitly(spark_session):
         ).fit(sdf, y="target", column="score")
 
 
+def test_merge_nearest_woe_spark_fit_fails_explicitly(spark_session):
+    sdf = _numeric_spark_frame(spark_session, [(1.0, 0), (None, 1), (3.0, 0), (4.0, 1)])
+
+    with pytest.raises(NotImplementedError, match=SPARK_MERGE_MESSAGE):
+        RiskBands(
+            missing_policy="merge",
+            missing_merge_criterion="nearest_woe",
+        ).fit(sdf, y="target", column="score")
+
+
 def test_merge_pandas_fit_spark_transform_fails_explicitly(spark_session):
     binner = RiskBands(
         missing_policy="merge",
         missing_merge_criterion="nearest_event_rate",
+        min_event_rate_diff=0.0,
+    ).fit(make_numeric_missing_frame(), y="target", column="score")
+    sdf = _numeric_spark_frame(spark_session, [(1.0, 0), (None, 1)])
+
+    with pytest.raises(NotImplementedError, match=SPARK_MERGE_MESSAGE):
+        binner.transform(sdf, column="score")
+
+
+def test_merge_nearest_woe_pandas_fit_spark_transform_fails_explicitly(spark_session):
+    binner = RiskBands(
+        missing_policy="merge",
+        missing_merge_criterion="nearest_woe",
         min_event_rate_diff=0.0,
     ).fit(make_numeric_missing_frame(), y="target", column="score")
     sdf = _numeric_spark_frame(spark_session, [(1.0, 0), (None, 1)])

--- a/tests/test_missing_merge_reporting.py
+++ b/tests/test_missing_merge_reporting.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 from riskbands import RiskBands
 from tests.test_missing_merge_nearest_event_rate_pandas import fit_numeric_merge
+from tests.test_missing_merge_nearest_woe_pandas import fit_numeric_woe_merge
 from tests.test_missing_values_current_behavior import make_numeric_missing_frame
 
 
@@ -38,6 +39,33 @@ def test_save_report_json_contains_missing_merge_fields(tmp_path):
     assert payload["missing_decision_log"][0]["action"] == "missing_merged"
     assert payload["missing_merge_candidates"][0]["selected"] is True
     assert payload["missing_merge_map"]
+
+
+def test_report_exposes_nearest_woe_distance_fields():
+    binner, _ = fit_numeric_woe_merge()
+
+    report = binner.report()
+    row = report.iloc[0]
+
+    assert row["missing_policy"] == "merge"
+    assert row["missing_merge_criterion"] == "nearest_woe"
+    assert row["missing_merge_distance_metric"] == "abs_woe_diff"
+    assert row["missing_merge_distance_woe"] == binner.missing_decision_log_.iloc[0]["distance_woe"]
+    assert row["missing_original_woe"] == binner.missing_decision_log_.iloc[0]["missing_woe"]
+    assert row["missing_selected_bin_woe"] == binner.missing_decision_log_.iloc[0]["selected_bin_woe"]
+
+
+def test_save_report_json_contains_nearest_woe_fields(tmp_path):
+    binner, _ = fit_numeric_woe_merge()
+    path = tmp_path / "report.json"
+
+    binner.save_report(path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+
+    assert payload["missing_merge_criterion"] == "nearest_woe"
+    assert payload["missing_decision_log"][0]["distance_metric"] == "abs_woe_diff"
+    assert payload["missing_decision_log"][0]["distance_woe"] is not None
+    assert payload["missing_merge_candidates"][0]["distance_woe"] is not None
 
 
 def test_missing_merge_reporting_does_not_revert_standard_objective_name():

--- a/tests/test_missing_merge_transform_no_leakage.py
+++ b/tests/test_missing_merge_transform_no_leakage.py
@@ -3,7 +3,8 @@ import pandas as pd
 import pytest
 
 from riskbands import RiskBands
-from tests.test_missing_merge_nearest_event_rate_pandas import fit_numeric_merge
+from tests.test_missing_merge_nearest_event_rate_pandas import fit_numeric_merge, row_for_label
+from tests.test_missing_merge_nearest_woe_pandas import fit_numeric_woe_merge
 
 
 def make_no_missing_numeric_frame():
@@ -41,6 +42,26 @@ def test_transform_without_target_uses_learned_missing_destination():
     transformed = binner.transform(pd.DataFrame({"score": [np.nan, -5.0, 5.0]}))
 
     assert transformed.loc[0, "score"] == learned_destination
+
+
+def test_nearest_woe_transform_without_target_uses_learned_missing_destination():
+    binner, _ = fit_numeric_woe_merge()
+    learned_destination = binner.missing_decision_log_.iloc[0]["selected_bin_label"]
+
+    transformed = binner.transform(pd.DataFrame({"score": [np.nan, -5.0, 5.0]}))
+
+    assert transformed.loc[0, "score"] == learned_destination
+
+
+def test_nearest_woe_return_woe_uses_final_selected_bin_value():
+    binner, _ = fit_numeric_woe_merge()
+    learned_destination = binner.missing_decision_log_.iloc[0]["selected_bin_label"]
+    profile_row = row_for_label(binner.fit_profile_, "bin_label", learned_destination)
+
+    transformed = binner.transform(pd.DataFrame({"score": [np.nan, -5.0]}), return_woe=True)
+
+    assert pd.api.types.is_numeric_dtype(transformed["score"])
+    assert transformed.loc[0, "score"] == pytest.approx(profile_row["woe"])
 
 
 def test_repeated_transform_is_deterministic():
@@ -123,3 +144,20 @@ def test_transform_application_distribution_cannot_retarget_missing_merge():
 
     assert set(transformed.loc[adversarial_app["score"].isna(), "score"]) == {learned_destination}
     assert binner.missing_decision_log_.iloc[0]["selected_bin_label"] == learned_destination
+
+
+def test_nearest_woe_application_distribution_cannot_retarget_missing_merge():
+    binner, _ = fit_numeric_woe_merge()
+    learned_destination = binner.missing_decision_log_.iloc[0]["selected_bin_label"]
+    decision_before = binner.missing_decision_log_.copy(deep=True)
+    adversarial_app = pd.DataFrame(
+        {
+            "score": [np.nan] * 20 + [-5.0] * 20 + [5.0] * 20,
+            "target": [1] * 20 + [0] * 20 + [1] * 20,
+        }
+    )
+
+    transformed = binner.transform(adversarial_app, column="score", validate=True)
+
+    assert set(transformed.loc[adversarial_app["score"].isna(), "score"]) == {learned_destination}
+    assert binner.missing_decision_log_.equals(decision_before)


### PR DESCRIPTION
Adds missing_merge_criterion='nearest_woe' for missing_policy='merge', preserving nearest_event_rate and existing missing policies. Includes audit trail fields for WOE distance, bundle/reporting persistence, no-leakage transform behavior, return_woe coverage, and PySpark boundary regression tests. This does not implement temporal_stable, monotonic_neighbor, or PySpark merge.