### PR TITLE
Prepare RiskBands v2.3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,10 +187,25 @@ no binning:
   categorico.
 - `forbid` falha em `fit` ou `transform` quando houver missing nas features
   selecionadas.
+- `merge` e opt-in para unir o grupo missing a um bin regular aprendido no
+  `fit`, preservando a trilha auditavel.
+
+Com `missing_policy="merge"`, escolha explicitamente o criterio:
+
+- `missing_merge_criterion="nearest_event_rate"` escolhe o bin regular com
+  menor distancia absoluta de event rate em relacao ao grupo missing no fit.
+- `missing_merge_criterion="nearest_woe"` escolhe o bin regular com menor
+  distancia absoluta de WoE em relacao ao grupo missing no fit.
+
+`missing_merge_fallback="separate_bin"` mantem missing novo de transform como
+`Missing` quando nao houve decisao aprendida no fit. `missing_merge_fallback="raise"`
+falha nesse caso.
 
 Bundles novos persistem `missing_policy`, `effective_missing_policy`,
-`missing_profile` e `missing_decision_log`. Bundles antigos sem esses campos
-carregam como `standard`.
+`missing_profile`, `missing_decision_log`, `missing_merge_criterion`,
+`missing_merge_fallback`, `missing_merge_candidates` e `missing_merge_map`
+quando esses campos existem. Bundles antigos sem esses campos carregam como
+`standard`, com campos de merge ausentes como `None`.
 
 Guia dedicado:
 [docs/missing_policy_user_guide.md](docs/missing_policy_user_guide.md) ou
@@ -214,28 +229,60 @@ print(binner.missing_profile_)
 print(binner.missing_decision_log_)
 ```
 
+Exemplo de merge auditavel:
+
+```python
+binner = RiskBands(
+    max_bins=4,
+    missing_policy="merge",
+    missing_merge_criterion="nearest_event_rate",
+    missing_merge_fallback="separate_bin",
+)
+
+binner.fit(df, y="target", column="score")
+df_binned = binner.transform(df[["score"]])
+
+print(binner.missing_profile_)
+print(binner.missing_decision_log_)
+print(binner.missing_merge_candidates_)
+```
+
+Troque o criterio para `missing_merge_criterion="nearest_woe"` quando a
+similaridade por WoE for mais alinhada a revisao do scorecard. Em ambos os
+casos, a decisao e aprendida somente no `fit`; `transform(...)` nao recalcula
+destino usando a base de aplicacao.
+
 Exemplos executaveis:
 
 - `python examples/missing_policy/missing_policy_pandas_demo.py`
 - `python examples/missing_policy/missing_policy_pyspark_demo.py`
 
-## Destaques da versao 2.2.0
+## Destaques da versao 2.3.0
 
-A versao 2.2.0 consolida a politica auditavel de missing values:
+A versao 2.3.0 prepara a release de merge auditavel de missing values:
 
 - `missing_policy="standard"` permanece como default compativel.
 - `missing_policy="separate_bin"` cria bin explicito `Missing` quando essa escolha
   for intencional.
 - `missing_policy="forbid"` falha quando missing values devem ser tratados antes
   do binning.
+- `missing_policy="merge"` permite unir o grupo missing a um bin regular usando
+  `nearest_event_rate` ou `nearest_woe`.
+- `missing_merge_fallback` controla o comportamento quando missing aparece no
+  transform sem uma decisao aprendida no fit.
+- `missing_profile_`, `missing_decision_log_`, `missing_merge_candidates_` e
+  `missing_merge_map_` preservam a auditoria do merge.
+- `return_woe=True` em pandas usa o WoE do bin de destino aprendido.
+- bundles e reporting persistem criterio, fallback, candidatos e mapa de merge.
 - `standard` e o nome canonico do score historico; `legacy` segue como alias
   compativel.
 - pandas e PySpark seguem suportados, com PySpark opcional via
   `riskbands[spark]` e restrito a `pyspark>=3.5,<4`.
 - bundles antigos seguem carregando como `standard` quando nao possuem os novos
-  campos de missing policy.
+  campos de missing policy ou missing merge.
 
-Fora do escopo desta versao: merge policies, imputacao inteligente opaca e um
+Fora do escopo desta versao: `temporal_stable`, `monotonic_neighbor`, PySpark
+merge completo, criterios adicionais de merge, imputacao inteligente opaca e um
 backend Spark distribuido completo para fitting.
 
 ## Export auditavel e supply chain

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,47 +4,56 @@
 
 - Project: `RiskBands`
 - Distribution: `riskbands`
-- Repository version: `2.2.0`
-- Planned release tag: `v2.2.0`
+- Repository version: `2.3.0`
+- Planned release tag: `v2.3.0`
 - Default branch: `main`
-- Preparation branch: `release/v2.2.0-prep`
-- Status: prepared for v2.2.0 publication after local validation.
+- Preparation branch: `release/v2.3.0-prep`
+- Status: prepared for v2.3.0 publication review after local validation.
 
-No PyPI upload, TestPyPI upload, tag creation, or push is performed by Sprint C.
+No PyPI upload, TestPyPI upload, tag creation, or push is performed by Sprint E3.
 
-## 2.2.0 Release Notes
+## 2.3.0 Release Notes
 
 Type: compatible minor release preparation.
 
+Positioning: RiskBands v2.3.0 - auditable missing merge policies.
+
 ### Added
 
-- `missing_policy="standard"` as the default missing-value policy, preserving the Sprint A baseline behavior.
-- `missing_policy="separate_bin"` as an opt-in policy that creates explicit `Missing` bins, including categorical missing values.
-- `missing_policy="forbid"` for governance flows that must fail when selected features contain missing values.
-- pandas and PySpark support for the missing-policy contract.
-- Persistence of `missing_policy`, `effective_missing_policy`, `missing_profile`, and `missing_decision_log` in fitted objects and bundles.
+- `missing_policy="merge"` for pandas flows that need to route a missing group into a learned regular bin while preserving audit evidence.
+- `missing_merge_criterion="nearest_event_rate"` to select the regular candidate bin with the closest fit-time event rate.
+- `missing_merge_criterion="nearest_woe"` to select the regular candidate bin with the closest fit-time WoE.
+- `missing_merge_fallback="separate_bin"` and `missing_merge_fallback="raise"` for transform-time missing values when no fit-time merge decision was learned.
+- `missing_merge_candidates_`, `missing_merge_map_`, and richer `missing_decision_log_` fields for reviewable merge decisions.
+- Bundle and report persistence for merge criterion, fallback, candidates, selected destination, distances, and merge map.
 
 ### Changed
 
-- `standard` is the canonical name for the historical maximize-oriented score strategy.
-- `legacy` remains accepted only as a compatibility alias for `standard`.
-- New metadata and bundle fields use the canonical `standard` naming where applicable.
+- Release documentation now describes merge as an opt-in policy alongside `standard`, `separate_bin`, and `forbid`.
+- README, technical docs, and docs-site pages explain when to use `nearest_event_rate` versus `nearest_woe`.
+- pandas examples include `separate_bin`, merge with both criteria, fallback behavior, audit fields, and bundle roundtrip.
 
 ### Compatibility
 
+- `missing_policy="standard"` remains the default.
+- `missing_policy="separate_bin"` and `missing_policy="forbid"` remain supported.
+- `score_strategy="standard"` remains canonical; `score_strategy="legacy"` remains a compatibility alias.
 - Existing `from riskbands import Binner` and `Binner(...)` usage is preserved.
 - `RiskBands` remains the preferred public estimator name and aliases `Binner`.
-- Bundles created before the missing-policy metadata existed continue to load as `standard`.
+- Bundles created before missing-merge metadata existed continue to load with missing-merge fields as `None`.
 - The base installation does not install PySpark.
 - PySpark support remains optional through `riskbands[spark]`.
 - The Spark extra remains constrained to `pyspark>=3.5,<4`.
 
 ### Explicitly Out Of Scope
 
-- No merge policies are included in this target. `merge_nearest_woe`, `merge_nearest_event_rate`, and similar policies remain future work.
+- No `temporal_stable` missing-merge criterion is included.
+- No `monotonic_neighbor` missing-merge criterion is included.
+- No additional merge criteria beyond `nearest_event_rate` and `nearest_woe` are included.
 - No opaque intelligent imputation is added.
-- No new full distributed Spark fitting backend is added.
-- No default change away from `missing_policy="standard"` is included.
+- No full PySpark implementation for `missing_policy="merge"` is added.
+- No PySpark 4.x support is promised.
+- No regulatory compliance guarantee is made.
 
 ## Workflows In Use
 
@@ -56,69 +65,61 @@ Type: compatible minor release preparation.
 
 ## Release Sequence
 
-1. Prepare versioned files and release notes for `2.2.0`.
+1. Prepare versioned files and release notes for `2.3.0`.
 2. Run the complete local validation suite.
 3. Confirm docs-site build.
 4. Confirm package build, `twine check`, smoke base install, and smoke `[spark]` install.
-5. Confirm no tag, push, PyPI upload, or TestPyPI upload was performed during Sprint C.
+5. Confirm no tag, push, PyPI upload, or TestPyPI upload was performed during Sprint E3.
 6. Commit the final release-prep changes after review.
-7. Create the annotated git tag `v2.2.0` manually only after review approval.
-8. Push `main` and the tag manually.
-9. Confirm `release-validation.yml` is green for the pushed tag.
-10. Optionally run `publish-testpypi.yml` on the reviewed tag.
-11. Run `publish-pypi.yml` on the same stable tag only after release validation and optional TestPyPI smoke checks are green.
-12. Confirm `docs-deploy.yml` is green after the push to `main`.
+7. Open a PR from `release/v2.3.0-prep` to `main`.
+8. Create the annotated git tag `v2.3.0` manually only after review approval and merge.
+9. Push `main` and the tag manually.
+10. Confirm `release-validation.yml` is green for the pushed tag.
+11. Optionally run `publish-testpypi.yml` on the reviewed tag.
+12. Run `publish-pypi.yml` on the same stable tag only after release validation and optional TestPyPI smoke checks are green.
+13. Confirm `docs-deploy.yml` is green after the push to `main`.
 
 Do not replace an artifact that already exists on a package index. If a defect is found after PyPI publication, yank the affected version and prepare a new version.
 
 ## Local Validation
 
-Use a clean project virtual environment rather than a globally shared Python environment.
+Use the repository virtual environment or another clean Python environment.
 
 Recommended command sequence:
 
 ```powershell
-python -m pip install --upgrade pip setuptools wheel
-python -m pip install -e .[dev]
-python -m pip check
-python -m ruff check riskbands tests
-python -m bandit -q -r riskbands
-python -m pytest -q --cov=riskbands --cov-report=term-missing --basetemp .pytest_tmp/v220-final
-python -m pytest -m spark --basetemp .pytest_tmp/v220-spark
-python -m pip_audit
+.\.venv-v210-spark\Scripts\python.exe -m pip check
+.\.venv-v210-spark\Scripts\python.exe -m ruff check riskbands tests
+.\.venv-v210-spark\Scripts\python.exe -m bandit -q -r riskbands
+.\.venv-v210-spark\Scripts\python.exe -m pytest --basetemp .pytest_tmp\v230-full-core
+.\.venv-v210-spark\Scripts\python.exe -m pytest -m spark --basetemp .pytest_tmp\v230-full-spark
+.\.venv-v210-spark\Scripts\python.exe -m pip_audit
+npm --prefix docs-site run build
 Remove-Item -Recurse -Force dist, build, *.egg-info -ErrorAction SilentlyContinue
-python -m build
-python -m twine check dist/*
+.\.venv-v210-spark\Scripts\python.exe -m build
+.\.venv-v210-spark\Scripts\python.exe -m twine check dist/*
 ```
 
 Wheel smoke test, base install:
 
 ```powershell
-python -m venv .pytest_tmp\v220-smoke-base
-.\.pytest_tmp\v220-smoke-base\Scripts\python.exe -m pip install --upgrade pip
-.\.pytest_tmp\v220-smoke-base\Scripts\python.exe -m pip install dist/riskbands-2.2.0-py3-none-any.whl
-.\.pytest_tmp\v220-smoke-base\Scripts\python.exe .\scripts\smoke_test_installed_package.py --expected-version 2.2.0
-.\.pytest_tmp\v220-smoke-base\Scripts\python.exe -c "import importlib.util, riskbands; from riskbands import RiskBands, Binner; print('version:', riskbands.__version__); print('RiskBands is Binner:', RiskBands is Binner); print('pyspark_installed:', importlib.util.find_spec('pyspark') is not None); assert riskbands.__version__ == '2.2.0'; assert RiskBands is Binner; assert importlib.util.find_spec('pyspark') is None"
+python -m venv .pytest_tmp\v230-smoke-base
+.\.pytest_tmp\v230-smoke-base\Scripts\python.exe -m pip install --upgrade pip
+.\.pytest_tmp\v230-smoke-base\Scripts\python.exe -m pip install dist/riskbands-2.3.0-py3-none-any.whl
+.\.pytest_tmp\v230-smoke-base\Scripts\python.exe .\scripts\smoke_test_installed_package.py --expected-version 2.3.0 --expect-no-pyspark
+.\.pytest_tmp\v230-smoke-base\Scripts\python.exe -c "import importlib.util, riskbands; from riskbands import RiskBands, Binner; print('version:', riskbands.__version__); print('RiskBands is Binner:', RiskBands is Binner); print('pyspark_installed:', importlib.util.find_spec('pyspark') is not None); assert riskbands.__version__ == '2.3.0'; assert RiskBands is Binner; assert importlib.util.find_spec('pyspark') is None"
+.\.pytest_tmp\v230-smoke-base\Scripts\python.exe -m pip check
 ```
 
 Wheel smoke test with the `spark` extra:
 
 ```powershell
-python -m venv .pytest_tmp\v220-smoke-spark
-.\.pytest_tmp\v220-smoke-spark\Scripts\python.exe -m pip install --upgrade pip
-.\.pytest_tmp\v220-smoke-spark\Scripts\python.exe -m pip install "dist/riskbands-2.2.0-py3-none-any.whl[spark]"
-.\.pytest_tmp\v220-smoke-spark\Scripts\python.exe .\scripts\smoke_test_installed_package.py --expected-version 2.2.0
-.\.pytest_tmp\v220-smoke-spark\Scripts\python.exe -c "import pyspark; print('pyspark:', pyspark.__version__); assert int(pyspark.__version__.split('.')[0]) == 3"
-```
-
-Sdist smoke test:
-
-```powershell
-python -m venv .pytest_tmp\v220-smoke-sdist
-.\.pytest_tmp\v220-smoke-sdist\Scripts\python.exe -m pip install --upgrade pip
-.\.pytest_tmp\v220-smoke-sdist\Scripts\python.exe -m pip install dist/riskbands-2.2.0.tar.gz
-.\.pytest_tmp\v220-smoke-sdist\Scripts\python.exe .\scripts\smoke_test_installed_package.py --expected-version 2.2.0
-.\.pytest_tmp\v220-smoke-sdist\Scripts\python.exe -c "import importlib.util; print('pyspark_installed:', importlib.util.find_spec('pyspark') is not None); assert importlib.util.find_spec('pyspark') is None"
+python -m venv .pytest_tmp\v230-smoke-spark
+.\.pytest_tmp\v230-smoke-spark\Scripts\python.exe -m pip install --upgrade pip
+.\.pytest_tmp\v230-smoke-spark\Scripts\python.exe -m pip install "dist/riskbands-2.3.0-py3-none-any.whl[spark]"
+.\.pytest_tmp\v230-smoke-spark\Scripts\python.exe .\scripts\smoke_test_installed_package.py --expected-version 2.3.0 --check-spark --expect-pyspark-major 3
+.\.pytest_tmp\v230-smoke-spark\Scripts\python.exe -c "import pyspark; print('pyspark:', pyspark.__version__); assert int(pyspark.__version__.split('.')[0]) == 3"
+.\.pytest_tmp\v230-smoke-spark\Scripts\python.exe -m pip check
 ```
 
 Docs-site validation:
@@ -134,9 +135,9 @@ Both publication workflows require:
 
 - the workflow to run against a git tag, not a branch;
 - the tag name to match `v<pyproject version>`;
-- the package version to be stable, such as `2.2.0`.
+- the package version to be stable, such as `2.3.0`.
 
-For this target, the planned tag is `v2.2.0`. Do not create the tag during Sprint C.
+For this target, the planned tag is `v2.3.0`. Do not create the tag during Sprint E3.
 
 ## TestPyPI
 
@@ -145,17 +146,17 @@ For this target, the planned tag is `v2.2.0`. Do not create the tag during Sprin
 After a successful TestPyPI upload, smoke test with:
 
 ```powershell
-python -m venv .pytest_tmp\v220-testpypi
-.\.pytest_tmp\v220-testpypi\Scripts\python.exe -m pip install --upgrade pip
-.\.pytest_tmp\v220-testpypi\Scripts\python.exe -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ riskbands==2.2.0
-.\.pytest_tmp\v220-testpypi\Scripts\python.exe .\scripts\smoke_test_installed_package.py --expected-version 2.2.0 --expect-no-pyspark
-.\.pytest_tmp\v220-testpypi\Scripts\python.exe -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ "riskbands[spark]==2.2.0"
-.\.pytest_tmp\v220-testpypi\Scripts\python.exe .\scripts\smoke_test_installed_package.py --expected-version 2.2.0 --check-spark --expect-pyspark-major 3
+python -m venv .pytest_tmp\v230-testpypi
+.\.pytest_tmp\v230-testpypi\Scripts\python.exe -m pip install --upgrade pip
+.\.pytest_tmp\v230-testpypi\Scripts\python.exe -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ riskbands==2.3.0
+.\.pytest_tmp\v230-testpypi\Scripts\python.exe .\scripts\smoke_test_installed_package.py --expected-version 2.3.0 --expect-no-pyspark
+.\.pytest_tmp\v230-testpypi\Scripts\python.exe -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ "riskbands[spark]==2.3.0"
+.\.pytest_tmp\v230-testpypi\Scripts\python.exe .\scripts\smoke_test_installed_package.py --expected-version 2.3.0 --check-spark --expect-pyspark-major 3
 ```
 
 ## PyPI
 
-Run `publish-pypi.yml` manually on `v2.2.0` only after:
+Run `publish-pypi.yml` manually on `v2.3.0` only after:
 
 - local validation is complete and green;
 - `release-validation.yml` is green on the pushed tag;

--- a/docs-site/src/content/docs/en/index.md
+++ b/docs-site/src/content/docs/en/index.md
@@ -27,7 +27,7 @@ features:
     description: Learn how to interpret `summary()`, `report()`, `score_details()`, `diagnostics()`, and `binning_table()`.
     link: ./technical/outputs/
   - title: Auditable missing values
-    description: Use `standard`, `separate_bin`, or `forbid` without opaque imputation and with a persisted audit trail in bundles.
+    description: Use `standard`, `separate_bin`, `forbid`, or `merge` without opaque imputation and with a persisted audit trail in bundles.
     link: ./technical/missing-policy/
   - title: API overview
     description: See the public surface for onboarding, audit, temporal reading, exports, and public plots.

--- a/docs-site/src/content/docs/en/reference/release-notes.md
+++ b/docs-site/src/content/docs/en/reference/release-notes.md
@@ -3,6 +3,28 @@ title: "Release Notes"
 description: "High-level release milestones for the public package and the official documentation."
 ---
 
+## v2.3.0
+
+Type: compatible minor release.
+
+Main points:
+
+- `missing_policy="merge"` adds auditable missing-value merge for pandas workflows
+- `missing_merge_criterion="nearest_event_rate"` selects the closest regular bin by fit-time event-rate distance
+- `missing_merge_criterion="nearest_woe"` selects the closest regular bin by fit-time WoE distance
+- `missing_merge_fallback` supports `separate_bin` and `raise`
+- `missing_profile_`, `missing_decision_log_`, `missing_merge_candidates_`, and `missing_merge_map_` preserve the audit trail
+- `return_woe=True` routes merged missing values to the learned destination bin before mapping WoE
+- bundle and reporting exports persist merge criterion, fallback, candidates, decision log, and merge map
+- `standard`, `separate_bin`, `forbid`, `legacy` alias compatibility, and `RiskBands is Binner` are preserved
+- pt-BR/en docs and examples describe both merge criteria
+
+Notes:
+
+- `missing_policy="standard"` remains the default
+- PySpark merge is not implemented; PySpark raises an explicit boundary for `missing_policy="merge"`
+- no `temporal_stable`, `monotonic_neighbor`, custom merge criteria, opaque imputation, or PySpark 4.x support is added
+
 ## Documentation update after v2.2.0
 
 Type: docs-only preparation.
@@ -17,9 +39,9 @@ Main points:
 - keeps PySpark documented as optional through `riskbands[spark]`
 - does not change core behavior, package version, publish status, tag, or release artifacts
 
-Notes:
+Historical notes:
 
-- merge policies remain future work
+- at that documentation point, merge policies remained future work
 - no opaque intelligent imputation is added
 - i18n is handled as a later docs-site sprint, without changing package release status
 

--- a/docs-site/src/content/docs/en/technical/api-overview.md
+++ b/docs-site/src/content/docs/en/technical/api-overview.md
@@ -25,34 +25,8 @@ from riskbands.temporal_stability import (
 )
 ```
 
-## What became friendlier
-
-Without aggressive changes to the core, the public `Binner` API became closer
-to familiar sklearn and pandas patterns:
-
-- `fit(df, y="target", column="score")`
-- `fit(df["score"], y=df["target"])`
-- `transform(df)` or `transform(df["score"])`
-- `fit_transform(...)`
-- `summary()`
-- `score_details()`
-- `score_table()`
-- `report()`
-- `audit_table()`
-- `diagnostics()`
-- `binning_table()`
-- `feature_binning_table()`
-- `plot_bad_rate_over_time()`
-- `plot_bad_rate_heatmap()`
-- `plot_bin_share_over_time()`
-- `plot_score_components()`
-- `export_binnings_json()`
-- `export_bundle()`
-
-Friendlier configuration aliases were also added:
-
-- `max_n_bins` as an alias for `max_bins`
-- `monotonic_trend` as an alias for `monotonic`
+`RiskBands` is the preferred name. `Binner` remains available for
+compatibility, and `RiskBands is Binner` remains true.
 
 ## Core blocks
 
@@ -65,7 +39,7 @@ Friendlier configuration aliases were also added:
 | `diagnostics()` | Detailed temporal reading | Opens stability by bin or by variable |
 | `export_binnings_json()` | Single JSON artifact | Makes versioning and governance easier |
 | `export_bundle()` | Complete audit package | Generates JSON, CSV, and feature-level tables |
-| `BinComparator` | Champion/challenger comparison | Remains central when the problem is choosing between multiple candidates |
+| `BinComparator` | Champion/challenger comparison | Helps choose between multiple candidates |
 
 ## Recommended single-candidate flow
 
@@ -91,13 +65,11 @@ binner.export_bundle("artifacts/run_2026_04_14")
 
 ## Score strategies
 
-Today the API exposes two explicit strategies:
+The API exposes two explicit strategies:
 
-- `standard`
-  Keeps the historical maximization-oriented score. `legacy` remains accepted
-  only as a compatibility alias.
-- `stable`
-  Introduces the temporal-robustness-oriented minimization objective.
+- `standard`: the historical maximization-oriented score. `legacy` remains
+  accepted only as a compatibility alias.
+- `stable`: the temporal-robustness-oriented minimization objective.
 
 ## Missing values
 
@@ -106,15 +78,21 @@ Today the API exposes two explicit strategies:
 - `standard`: compatible default with the current behavior
 - `separate_bin`: opt-in explicit `Missing` bin
 - `forbid`: error during `fit` or `transform` if selected features contain missing values
+- `merge`: opt-in pandas routing from the missing group to the closest regular bin learned during `fit`
 
-`separate_bin` does not perform opaque imputation; it makes missing values
-explicit and auditable. Merge policies are not part of the public contract yet.
+`merge` requires `missing_merge_criterion="nearest_event_rate"` or
+`missing_merge_criterion="nearest_woe"`. The first uses absolute event-rate
+distance; the second uses absolute WoE distance. `missing_merge_fallback`
+accepts `separate_bin` or `raise` for missing values that appear during
+`transform` without a fit-time decision.
 
-Dedicated guide: [Missing policy](../missing-policy/).
+These policies do not perform opaque imputation. In merge mode, `transform(...)`
+uses only the decision learned during `fit` and does not learn a new rule from
+application data.
 
-After `fit`, inspect `missing_profile_` and `missing_decision_log_` to see
-volume, share, event rate, and the decision taken per variable. These fields
-are also persisted by `export_bundle(...)`.
+After `fit`, inspect `missing_profile_`, `missing_decision_log_`,
+`missing_merge_candidates_`, and `missing_merge_map_` to review volume, share,
+event rate, criterion, candidates, distances, and learned destination.
 
 Example:
 
@@ -123,20 +101,14 @@ binner = RiskBands(
     strategy="supervised",
     check_stability=True,
     time_col="month",
-    missing_policy="separate_bin",
+    missing_policy="merge",
+    missing_merge_criterion="nearest_woe",
+    missing_merge_fallback="separate_bin",
     score_strategy="stable",
-    score_weights={
-        "temporal_variance_weight": 0.22,
-        "window_drift_weight": 0.18,
-        "rank_inversion_weight": 0.20,
-        "separation_weight": 0.20,
-        "entropy_weight": 0.08,
-        "psi_weight": 0.12,
-    },
-    normalization_strategy="absolute",
-    woe_shrinkage_strength=40.0,
 )
 ```
+
+Dedicated guide: [Missing policy](../missing-policy/).
 
 ## What to inspect next
 

--- a/docs-site/src/content/docs/en/technical/examples.md
+++ b/docs-site/src/content/docs/en/technical/examples.md
@@ -24,22 +24,11 @@ This material shows:
 
 ### Temporal stability quickstart
 
-This is the shortest entry point to the temporal layer, now with score table,
-audit table, and auditable export.
-
 - [Quickstart script](https://github.com/joaaomaia/RiskBands/blob/main/examples/temporal_stability/temporal_stability_example.py)
 - [Quickstart notebook](https://github.com/joaaomaia/RiskBands/blob/main/examples/temporal_stability/temporal_stability_example.ipynb)
 
-This flow already shows:
-
-- `score_table()`
-- `audit_table()`
-- `export_binnings_json(...)`
-- `export_bundle(...)`
-- `plot_bad_rate_over_time(...)`
-- `plot_bad_rate_heatmap(...)`
-- `plot_bin_share_over_time(...)`
-- `plot_score_components(...)`
+This flow shows `score_table()`, `audit_table()`, JSON/bundle export, and public
+plots for temporal reading.
 
 ### Missing policy with pandas and PySpark
 
@@ -54,33 +43,29 @@ They show:
 - `missing_policy="standard"`
 - `missing_policy="separate_bin"`
 - `missing_policy="forbid"`
+- `missing_policy="merge"` with `nearest_event_rate`
+- `missing_policy="merge"` with `nearest_woe`
 - `missing_profile_`
 - `missing_decision_log_`
-- bundle fields for missing policy
+- `missing_merge_candidates_`
+- bundle fields for missing policy and missing merge
 - optional guard for PySpark
 
 ### PD vintage champion/challenger
-
-This is the most direct credit example for comparing candidates.
 
 - [Champion/challenger script](https://github.com/joaaomaia/RiskBands/blob/main/examples/pd_vintage_champion_challenger/pd_vintage_champion_challenger.py)
 - [Champion/challenger notebook](https://github.com/joaaomaia/RiskBands/blob/main/examples/pd_vintage_champion_challenger/pd_vintage_champion_challenger.ipynb)
 
 ### PD vintage benchmark
 
-This is the strongest methodology showcase in the project today.
-
 - [Benchmark script](https://github.com/joaaomaia/RiskBands/blob/main/examples/pd_vintage_benchmark/pd_vintage_benchmark.py)
 - [Benchmark notebook](https://github.com/joaaomaia/RiskBands/blob/main/examples/pd_vintage_benchmark/pd_vintage_benchmark.ipynb)
 
-Use this material when the main question is:
-
-> why can a candidate with stronger aggregate IV still be the wrong choice for credit when time enters the decision?
+Use this material when the main question is why a candidate with stronger
+aggregate IV can still be the wrong choice for credit when time enters the
+decision.
 
 ### `stable` score demo
-
-This is the minimal example for seeing the change between the legacy score and
-the current recommended temporal strategy.
 
 - [Demo script](https://github.com/joaaomaia/RiskBands/blob/main/examples/stable_score/stable_score_demo.py)
 

--- a/docs-site/src/content/docs/en/technical/missing-policy.md
+++ b/docs-site/src/content/docs/en/technical/missing-policy.md
@@ -1,6 +1,6 @@
 ---
 title: "Missing policy"
-description: "How to use standard, separate_bin, and forbid to handle missing values with an auditable trail in RiskBands."
+description: "How to use standard, separate_bin, forbid, and merge to handle missing values with an auditable trail in RiskBands."
 ---
 
 ## Core idea
@@ -25,9 +25,40 @@ binner = RiskBands(missing_policy="separate_bin")
 | `standard` | Preserves the current compatible behavior. | Reproducing existing flows and compatibility. |
 | `separate_bin` | Creates an explicit `Missing` bin for missing values in selected features. | Auditable analysis of missing values as their own group. |
 | `forbid` | Fails during `fit` or `transform` when missing values are found. | Governance that requires upstream treatment before binning. |
+| `merge` | Learns a regular destination bin for the missing group during `fit`. | When missing should remain audited but be routed to the closest bin. |
 
 `legacy` may appear in old metadata for compatibility, but it is not a new
 recommendation. The current canonical name is `standard`.
+
+## Auditable merge
+
+`missing_policy="merge"` is opt-in and requires an explicit criterion:
+
+```python
+binner = RiskBands(
+    missing_policy="merge",
+    missing_merge_criterion="nearest_event_rate",
+    missing_merge_fallback="separate_bin",
+)
+```
+
+```python
+binner = RiskBands(
+    missing_policy="merge",
+    missing_merge_criterion="nearest_woe",
+    missing_merge_fallback="raise",
+)
+```
+
+`nearest_event_rate` selects the regular bin with the smallest absolute event-rate
+distance from the missing group during fit. `nearest_woe` uses the smallest
+absolute WoE distance from the same fit profile.
+
+Merge is not opaque imputation. The decision is stored in
+`missing_decision_log_`, candidates are stored in `missing_merge_candidates_`,
+and the learned routing map is stored in `missing_merge_map_`. `transform(...)`
+uses only the fit-time decision; it does not learn a new rule from application
+data.
 
 ## pandas example
 
@@ -120,6 +151,10 @@ the action taken per variable.
 - `effective_missing_policy`
 - `missing_profile`
 - `missing_decision_log`
+- `missing_merge_criterion`
+- `missing_merge_fallback`
+- `missing_merge_candidates`
+- `missing_merge_map`
 
 ```python
 from riskbands.reporting import load_bundle
@@ -135,13 +170,13 @@ Old bundles without these fields continue to load as `standard`.
 
 ## What is not implemented
 
-This page documents the current contract. It does not announce new features.
+This page documents the current contract. There are not yet:
 
-There are not yet:
-
-- auditable merge policies to merge the missing bin into another bin;
+- `temporal_stable` as a merge criterion;
+- `monotonic_neighbor` as a merge criterion;
+- merge criteria beyond `nearest_event_rate` and `nearest_woe`;
+- complete PySpark merge support;
 - intelligent imputation inside RiskBands;
-- automatic behavioral similarity for missing values;
 - fully distributed statistical fitting in Spark.
 
 RiskBands helps make the decision defensible and auditable, but it does not

--- a/docs-site/src/content/docs/en/technical/outputs.md
+++ b/docs-site/src/content/docs/en/technical/outputs.md
@@ -5,8 +5,7 @@ description: "How to interpret the main Binner outputs after fit, with a focus o
 
 ## What appears after `fit`
 
-After fitting a `Binner`, the public API exposes friendlier artifacts for
-inspection:
+After fitting a `Binner`, the public API exposes friendly artifacts:
 
 - `binning_table()`
 - `feature_binning_table()` and `get_binning_table()`
@@ -36,54 +35,19 @@ Useful post-fit attributes are also available, such as:
 - `score_`
 - `comparison_score_`
 
-## `binning_table()`
+## Main tables
 
-Use it when you want to see final cuts or bins directly.
+`binning_table()` shows final cuts or bins. `score_table()` is the short table
+for explaining the objective, weights, normalized components, and raw
+components. `audit_table()` combines cuts, IV, temporal score, penalties,
+coverage, rare bins, reversals, and summarized rationale.
 
-Questions it helps answer:
+## Temporal diagnostics
 
-- how many bins were kept?
-- which intervals or groups were formed?
-- what is the bin order?
+Use `diagnostics(kind="bin")` to open detail by bin and period. Use
+`diagnostics(kind="variable")` for the aggregated temporal summary by variable.
 
-## `score_table()`
-
-This is the shortest notebook table when the central question is:
-
-- why did this score come out this way?
-- which weights entered?
-- which components mattered most?
-- which normalization is active?
-
-It exposes:
-
-- `objective_score`
-- `objective_preference_score`
-- `weight_profile`
-- `normalized_component_profile`
-- `raw_component_profile`
-- detailed `objective_weight_*`, `objective_norm_*`, and `objective_raw_*` columns
-
-## `audit_table()`
-
-This is the most useful table for auditable review and model risk.
-
-It combines in a single view:
-
-- cuts
-- IV and temporal score
-- score and penalties
-- coverage, rare bins, and reversals
-- summarized rationale
-
-## `diagnostics()`
-
-Use `diagnostics(kind="bin")` when you want to open detail by bin and period.
-
-Use `diagnostics(kind="variable")` when you want the aggregated temporal
-summary by variable.
-
-It is the best entry point to investigate:
+This is the best entry point to investigate:
 
 - coverage
 - event-rate volatility
@@ -92,65 +56,44 @@ It is the best entry point to investigate:
 - ranking reversals
 - monotonicity breaks
 
-## `metadata_`
+## Metadata
 
-Post-fit metadata is now more auditable.
-
-It includes:
-
-- `riskbands` version
-- `strategy`
-- `score_strategy`
-- `normalization_strategy`
-- `woe_shrinkage_strength`
-- provided weights and effective weights
-- `target_name`
-- `time_col`
-- fitted features
+`metadata_` includes the `riskbands` version, strategy, `score_strategy`,
+`normalization_strategy`, `woe_shrinkage_strength`, weights, `target_name`,
+`time_col`, and fitted features.
 
 ## Auditable export
 
-### `export_binnings_json(path)`
+`export_binnings_json(path)` generates a single JSON with metadata, score
+weights, bins by feature, summary, score details, and feature-level audit.
 
-Generates a single JSON with:
+`export_bundle(path)` generates readable JSON, CSVs, feature-level tables, and
+optional Parquet when an engine is available.
 
-- general fit metadata
-- score weights
-- bins by feature
-- summary, score details, and audit by feature
+Bundles also persist the missing-values trail when available:
+`missing_policy`, `effective_missing_policy`, `missing_profile`,
+`missing_decision_log`, `missing_merge_criterion`, `missing_merge_fallback`,
+`missing_merge_candidates`, and `missing_merge_map`.
 
-### `export_bundle(path)`
+These fields record the missing-values treatment decision. They do not
+represent opaque imputation.
 
-Generates an audit package with:
+Use `missing_profile_` to review missing volume, share, and event rate by
+variable. Use `missing_decision_log_` to see whether the action was to preserve
+`standard`, create a `Missing` bin with `separate_bin`, block with `forbid`, or
+route missing values with `merge`. For merge, use `missing_merge_candidates_`
+to review candidates and distances and `missing_merge_map_` to see the learned
+destination.
 
-- readable JSON
-- CSVs ready for notebooks or governance
-- feature-level tables
-- optional Parquet when an engine is available
+Dedicated guide: [Missing policy](../missing-policy/).
 
 ## Fast score reading
-
-A simple rule:
 
 - `standard`: higher raw score is better
 - `stable`: lower raw score is better
 
-If you want a consolidated scale for comparison across strategies, also look
-at `objective_preference_score`.
-
-Bundles also persist the missing-values trail when available:
-`missing_policy`, `effective_missing_policy`, `missing_profile`, and
-`missing_decision_log`.
-
-These fields record the missing-values treatment decision. They do not
-represent opaque imputation or merge policies.
-
-Use `missing_profile_` to review missing volume, share, and event rate by
-variable. Use `missing_decision_log_` to see whether the action was to preserve
-`standard` behavior, create a `Missing` bin with `separate_bin`, or block the
-flow with `forbid`.
-
-Dedicated guide: [Missing policy](../missing-policy/).
+For a consolidated scale across strategies, also look at
+`objective_preference_score`.
 
 ## Example
 

--- a/docs-site/src/content/docs/en/technical/quickstart.md
+++ b/docs-site/src/content/docs/en/technical/quickstart.md
@@ -63,74 +63,42 @@ need to audit missing values explicitly, use `missing_policy="separate_bin"`.
 When missing values must be blocked before binning, use
 `missing_policy="forbid"`.
 
-These policies do not perform opaque imputation and do not include merge
-policies.
+When missing should remain audited but be routed to a regular bin, use
+`missing_policy="merge"` with `missing_merge_criterion="nearest_event_rate"` or
+`missing_merge_criterion="nearest_woe"`.
+
+These policies do not perform opaque imputation. In merge mode, the rule is
+learned during `fit` and reused during `transform`, without retargeting from
+application data.
 
 For complete pandas and PySpark examples, see
 [Missing policy](../missing-policy/).
-
-## Why this flow is friendlier
-
-It follows familiar conventions:
-
-- `fit(...)`
-- `transform(...)`
-- `fit_transform(...)`
-- pandas `DataFrame` and `Series` as the first option
-- short tables for notebooks before opening full detail
-
-It also avoids requiring you to assemble pivots, bundles, or internal
-dictionaries at the beginning.
 
 ## What to look at first
 
 ### `summary()`
 
-This is the best first stop after fitting.
-
-Use it when you want to answer quickly:
-
-- how many bins were kept?
-- what was the IV?
-- which score strategy is active?
-- are there relevant temporal warnings?
+The best first stop after fitting: bins, IV, score strategy, and temporal
+warnings.
 
 ### `score_table()`
 
-This is the shortest reading for explaining the objective.
-
-It helps inspect:
-
-- final score
-- comparison score
-- objective direction
-- weights used
-- the most relevant components and penalties
+Short reading for final score, comparison score, objective direction, weights,
+and the most relevant components.
 
 ### `audit_table()`
 
-This is the consolidated view for auditable review.
-
-It combines:
-
-- final cuts
-- score
-- coverage
-- rare bins
-- reversals
-- summarized rationale
+Consolidated view for auditable review: final cuts, score, coverage, rare bins,
+reversals, and summarized rationale.
 
 ## When to use `stable`
 
-For a new user, `stable` is usually the best public strategy to start with
-when:
+For a new user, `stable` is usually the best public strategy to start with when
+a temporal column exists, stability matters, and you want to balance separation
+and robustness.
 
-- a temporal column exists
-- stability really matters
-- you want to balance separation and robustness
-
-If you need to reproduce a more historical behavior or compare against the
-previous approach, use `standard`.
+If you need to reproduce a historical behavior or compare against the previous
+approach, use `standard`.
 
 ## Next steps
 

--- a/docs-site/src/content/docs/index.md
+++ b/docs-site/src/content/docs/index.md
@@ -27,7 +27,7 @@ features:
     description: Veja como interpretar `summary()`, `report()`, `score_details()`, `diagnostics()` e `binning_table()`.
     link: ./technical/outputs/
   - title: Missing values auditaveis
-    description: Use `standard`, `separate_bin` ou `forbid` sem imputacao opaca e com trilha persistida nos bundles.
+    description: Use `standard`, `separate_bin`, `forbid` ou `merge` sem imputacao opaca e com trilha persistida nos bundles.
     link: ./technical/missing-policy/
   - title: Optuna sem acoplamento
     description: Descubra quando vale ligar a busca externa e como ela se encaixa no mesmo objective do fluxo sem Optuna.

--- a/docs-site/src/content/docs/reference/release-notes.md
+++ b/docs-site/src/content/docs/reference/release-notes.md
@@ -3,6 +3,28 @@ title: "Release Notes"
 description: "Marcos de release em alto nível para o pacote público e para a documentação oficial."
 ---
 
+## v2.3.0
+
+Type: compatible minor release.
+
+Main points:
+
+- `missing_policy="merge"` adds auditable missing-value merge for pandas workflows
+- `missing_merge_criterion="nearest_event_rate"` selects the closest regular bin by fit-time event-rate distance
+- `missing_merge_criterion="nearest_woe"` selects the closest regular bin by fit-time WoE distance
+- `missing_merge_fallback` supports `separate_bin` and `raise`
+- `missing_profile_`, `missing_decision_log_`, `missing_merge_candidates_`, and `missing_merge_map_` preserve the audit trail
+- `return_woe=True` routes merged missing values to the learned destination bin before mapping WoE
+- bundle and reporting exports persist merge criterion, fallback, candidates, decision log, and merge map
+- `standard`, `separate_bin`, `forbid`, `legacy` alias compatibility, and `RiskBands is Binner` are preserved
+- docs pt-BR/en and examples describe both merge criteria
+
+Notes:
+
+- `missing_policy="standard"` remains the default
+- PySpark merge is not implemented; PySpark raises an explicit boundary for `missing_policy="merge"`
+- no `temporal_stable`, `monotonic_neighbor`, custom merge criteria, opaque imputation, or PySpark 4.x support is added
+
 ## Documentation update after v2.2.0
 
 Type: docs-only preparation.
@@ -17,9 +39,9 @@ Main points:
 - keeps PySpark documented as optional through `riskbands[spark]`
 - does not change core behavior, package version, publish status, tag, or release artifacts
 
-Notes:
+Historical notes:
 
-- merge policies remain future work
+- at that documentation point, merge policies remained future work
 - no opaque intelligent imputation is added
 - i18n is not part of this docs-only preparation
 

--- a/docs-site/src/content/docs/technical/api-overview.md
+++ b/docs-site/src/content/docs/technical/api-overview.md
@@ -1,20 +1,20 @@
 ---
-title: "Visão geral da API"
-description: "Mapa da superfície pública do RiskBands, com foco em onboarding, auditoria e leitura temporal amigável."
+title: "Visao geral da API"
+description: "Mapa da superficie publica do RiskBands, com foco em onboarding, auditoria e leitura temporal amigavel."
 ---
 
 ## Porta de entrada recomendada
 
-Na maior parte dos casos, o fluxo ideal para um usuário novo é:
+Na maior parte dos casos, o fluxo ideal para um usuario novo e:
 
 1. instanciar `RiskBands`
 2. rodar `fit(...)`
 3. inspecionar `summary()`, `score_table()` e `audit_table()`
 4. aplicar `transform(...)`
-5. exportar os artefatos auditáveis
-6. usar os plots públicos para leitura temporal
+5. exportar os artefatos auditaveis
+6. usar os plots publicos para leitura temporal
 
-## Superfície pública principal
+## Superficie publica principal
 
 ```python
 from riskbands import RiskBands, Binner, BinComparator
@@ -25,48 +25,23 @@ from riskbands.temporal_stability import (
 )
 ```
 
-## O que ficou mais amigável
-
-Sem mexer agressivamente no core, a API pública do `Binner` ficou mais próxima de padrões familiares de sklearn e pandas:
-
-- `fit(df, y="target", column="score")`
-- `fit(df["score"], y=df["target"])`
-- `transform(df)` ou `transform(df["score"])`
-- `fit_transform(...)`
-- `summary()`
-- `score_details()`
-- `score_table()`
-- `report()`
-- `audit_table()`
-- `diagnostics()`
-- `binning_table()`
-- `feature_binning_table()`
-- `plot_bad_rate_over_time()`
-- `plot_bad_rate_heatmap()`
-- `plot_bin_share_over_time()`
-- `plot_score_components()`
-- `export_binnings_json()`
-- `export_bundle()`
-
-Também foram adicionados aliases mais amigáveis para configuração:
-
-- `max_n_bins` como alias de `max_bins`
-- `monotonic_trend` como alias de `monotonic`
+`RiskBands` e o nome preferido. `Binner` segue disponivel para compatibilidade,
+e `RiskBands is Binner` continua verdadeiro.
 
 ## Blocos centrais
 
 | Componente | Papel no fluxo | Por que importa |
 | --- | --- | --- |
 | `RiskBands` / `Binner` | Porta de entrada principal | Ajusta, transforma, resume, exporta e plota sem exigir estruturas internas |
-| `summary()` | Resumo curto pós-fit | Ajuda a entender rapidamente bins, IV e score |
-| `score_table()` | Explicação curta do objective | Expõe score final, pesos e componentes mais relevantes |
-| `audit_table()` | Revisão auditável consolidada | Junta cuts, score, penalidades, cobertura e rationale |
-| `diagnostics()` | Leitura temporal detalhada | Abre estabilidade por bin ou por variável |
-| `export_binnings_json()` | Artefato único em JSON | Facilita versionamento e governança |
+| `summary()` | Resumo curto pos-fit | Ajuda a entender bins, IV e score |
+| `score_table()` | Explicacao curta do objective | Expoe score final, pesos e componentes mais relevantes |
+| `audit_table()` | Revisao auditavel consolidada | Junta cuts, score, penalidades, cobertura e rationale |
+| `diagnostics()` | Leitura temporal detalhada | Abre estabilidade por bin ou por variavel |
+| `export_binnings_json()` | Artefato unico em JSON | Facilita versionamento e governanca |
 | `export_bundle()` | Pacote completo de auditoria | Gera JSON, CSV e tabelas por feature |
-| `BinComparator` | Comparação champion/challenger | Continua sendo a peça central quando o problema é escolher entre múltiplos candidatos |
+| `BinComparator` | Comparacao champion/challenger | Ajuda a escolher entre multiplos candidatos |
 
-## Fluxo recomendado para candidato único
+## Fluxo recomendado para candidato unico
 
 ```python
 binner = RiskBands(
@@ -88,31 +63,36 @@ binner.export_binnings_json("artifacts/riskbands_binnings.json")
 binner.export_bundle("artifacts/run_2026_04_14")
 ```
 
-## Estratégias de score
+## Estrategias de score
 
-Hoje a API expõe duas estratégias explícitas:
+A API expoe duas estrategias explicitas:
 
-- `standard`
-  Mantém o score histórico orientado a maximização. `legacy` segue aceito apenas como alias compatível.
-- `stable`
-  Introduz o objective orientado a robustez temporal e minimização.
+- `standard`: score historico orientado a maximizacao. `legacy` segue aceito
+  apenas como alias compativel.
+- `stable`: objective orientado a robustez temporal e minimizacao.
 
 ## Missing values
 
 `missing_policy` aceita:
 
-- `standard`: default compatível com o comportamento atual
-- `separate_bin`: opt-in para bin explícito `Missing`
-- `forbid`: erro em `fit` ou `transform` se houver missing nas features selecionadas
+- `standard`: default compativel com o comportamento atual
+- `separate_bin`: opt-in para bin explicito `Missing`
+- `forbid`: erro em `fit` ou `transform` quando ha missing nas features selecionadas
+- `merge`: opt-in pandas para rotear missing ao bin regular mais proximo aprendido no `fit`
 
-`separate_bin` nao faz imputacao opaca; ele torna o missing explicito e
-auditavel. Merge policies ainda nao fazem parte do contrato publico.
+`merge` exige `missing_merge_criterion="nearest_event_rate"` ou
+`missing_merge_criterion="nearest_woe"`. O primeiro usa distancia absoluta de
+taxa de evento; o segundo usa distancia absoluta de WoE. `missing_merge_fallback`
+aceita `separate_bin` ou `raise` para missing que aparece no `transform` sem
+decisao aprendida no `fit`.
 
-Guia dedicado: [Missing policy](../missing-policy/).
+Essas politicas nao fazem imputacao opaca. Em merge, `transform(...)` usa
+somente a decisao aprendida no `fit` e nao aprende regra nova com a base de
+aplicacao.
 
-Depois do `fit`, inspecione `missing_profile_` e `missing_decision_log_` para
-ver volume, share, event rate e decisao tomada por variavel. Esses campos tambem
-sao persistidos em `export_bundle(...)`.
+Depois do `fit`, inspecione `missing_profile_`, `missing_decision_log_`,
+`missing_merge_candidates_` e `missing_merge_map_` para revisar volume, share,
+event rate, criterio, candidatos, distancias e destino aprendido.
 
 Exemplo:
 
@@ -121,33 +101,27 @@ binner = RiskBands(
     strategy="supervised",
     check_stability=True,
     time_col="month",
-    missing_policy="separate_bin",
+    missing_policy="merge",
+    missing_merge_criterion="nearest_woe",
+    missing_merge_fallback="separate_bin",
     score_strategy="stable",
-    score_weights={
-        "temporal_variance_weight": 0.22,
-        "window_drift_weight": 0.18,
-        "rank_inversion_weight": 0.20,
-        "separation_weight": 0.20,
-        "entropy_weight": 0.08,
-        "psi_weight": 0.12,
-    },
-    normalization_strategy="absolute",
-    woe_shrinkage_strength=40.0,
 )
 ```
 
+Guia dedicado: [Missing policy](../missing-policy/).
+
 ## O que olhar em seguida
 
-Depois do primeiro `fit`, o trio mais útil costuma ser:
+Depois do primeiro `fit`, o trio mais util costuma ser:
 
 - `summary()` para uma leitura curta
 - `score_table()` para entender o score e os pesos
-- `audit_table()` para abrir a revisão auditável
+- `audit_table()` para abrir a revisao auditavel
 
-## Próximos passos
+## Proximos passos
 
 - [Quickstart](../quickstart/)
 - [Auditoria e plots](../audit-and-plots/)
-- [Outputs e diagnóstico](../outputs/)
+- [Outputs e diagnostico](../outputs/)
 - [Missing policy](../missing-policy/)
 - [Exemplos](../examples/)

--- a/docs-site/src/content/docs/technical/examples.md
+++ b/docs-site/src/content/docs/technical/examples.md
@@ -1,15 +1,16 @@
 ---
 title: "Exemplos"
-description: "Scripts e notebooks para quickstart, benchmark, auditoria e demonstração da API amigável do RiskBands."
+description: "Scripts e notebooks para quickstart, benchmark, auditoria e demonstracao da API amigavel do RiskBands."
 ---
 
 ## Comece por aqui
 
 ### Notebook de ergonomia da API
 
-É a porta de entrada recomendada para quem quer aprender o RiskBands com um fluxo mais familiar de pandas e sklearn.
+Porta de entrada recomendada para aprender o RiskBands com um fluxo familiar de
+pandas e sklearn.
 
-- [Notebook sintético com Plotly](https://github.com/joaaomaia/RiskBands/blob/main/examples/riskbands_synthetic_plotly_comparative_demo.ipynb)
+- [Notebook sintetico com Plotly](https://github.com/joaaomaia/RiskBands/blob/main/examples/riskbands_synthetic_plotly_comparative_demo.ipynb)
 
 Esse material mostra:
 
@@ -19,25 +20,15 @@ Esse material mostra:
 - `binning_table()`
 - `score_details()`
 - `diagnostics()`
-- comparação entre `standard` e `stable`
+- comparacao entre `standard` e `stable`
 
 ### Quickstart de estabilidade temporal
-
-É a porta de entrada mais curta para a camada temporal, agora já com tabela de score, auditoria e export auditável.
 
 - [Script do quickstart](https://github.com/joaaomaia/RiskBands/blob/main/examples/temporal_stability/temporal_stability_example.py)
 - [Notebook do quickstart](https://github.com/joaaomaia/RiskBands/blob/main/examples/temporal_stability/temporal_stability_example.ipynb)
 
-Esse fluxo já mostra:
-
-- `score_table()`
-- `audit_table()`
-- `export_binnings_json(...)`
-- `export_bundle(...)`
-- `plot_bad_rate_over_time(...)`
-- `plot_bad_rate_heatmap(...)`
-- `plot_bin_share_over_time(...)`
-- `plot_score_components(...)`
+Esse fluxo mostra `score_table()`, `audit_table()`, export JSON/bundle e plots
+publicos para leitura temporal.
 
 ### Missing policy pandas e PySpark
 
@@ -52,50 +43,47 @@ Eles mostram:
 - `missing_policy="standard"`
 - `missing_policy="separate_bin"`
 - `missing_policy="forbid"`
+- `missing_policy="merge"` com `nearest_event_rate`
+- `missing_policy="merge"` com `nearest_woe`
 - `missing_profile_`
 - `missing_decision_log_`
-- bundle com campos de missing policy
+- `missing_merge_candidates_`
+- bundle com campos de missing policy e missing merge
 - guarda opcional para PySpark
 
 ### PD vintage champion challenger
-
-É o exemplo de crédito mais direto para comparação entre candidatos.
 
 - [Script champion challenger](https://github.com/joaaomaia/RiskBands/blob/main/examples/pd_vintage_champion_challenger/pd_vintage_champion_challenger.py)
 - [Notebook champion challenger](https://github.com/joaaomaia/RiskBands/blob/main/examples/pd_vintage_champion_challenger/pd_vintage_champion_challenger.ipynb)
 
 ### Benchmark PD vintage
 
-É a vitrine metodológica mais forte do projeto hoje.
-
 - [Script do benchmark](https://github.com/joaaomaia/RiskBands/blob/main/examples/pd_vintage_benchmark/pd_vintage_benchmark.py)
 - [Notebook do benchmark](https://github.com/joaaomaia/RiskBands/blob/main/examples/pd_vintage_benchmark/pd_vintage_benchmark.ipynb)
 
-Use este material quando a pergunta principal for:
-
-> por que um candidato com IV agregado mais forte ainda pode ser a escolha errada para crédito quando o tempo entra na decisão?
+Use este material quando a pergunta principal for por que um candidato com IV
+agregado mais forte ainda pode ser a escolha errada para credito quando o tempo
+entra na decisao.
 
 ### Demo do score `stable`
-
-É o exemplo mínimo para enxergar a mudança entre o score legado e a estratégia temporal recomendada no estado atual do projeto.
 
 - [Script da demo](https://github.com/joaaomaia/RiskBands/blob/main/examples/stable_score/stable_score_demo.py)
 
 ## Ordem de leitura sugerida
 
-### Se você quer começar pela API
+### Se voce quer comecar pela API
 
-1. Notebook sintético com Plotly
+1. Notebook sintetico com Plotly
 2. Quickstart
 3. Auditoria e plots
-4. Visão geral da API
+4. Visao geral da API
 5. Missing policy
 6. PD vintage champion challenger
 7. Benchmark PD vintage
 
-### Se você quer começar pela tese metodológica
+### Se voce quer comecar pela tese metodologica
 
 1. Por que RiskBands
-2. Por que não usar apenas OptimalBinning
+2. Por que nao usar apenas OptimalBinning
 3. Benchmark PD vintage
-4. Como ler os gráficos
+4. Como ler os graficos

--- a/docs-site/src/content/docs/technical/missing-policy.md
+++ b/docs-site/src/content/docs/technical/missing-policy.md
@@ -1,6 +1,6 @@
 ---
 title: "Missing policy"
-description: "Como usar standard, separate_bin e forbid para tratar missing values de forma auditavel no RiskBands."
+description: "Como usar standard, separate_bin, forbid e merge para tratar missing values de forma auditavel no RiskBands."
 ---
 
 ## Ideia central
@@ -25,9 +25,39 @@ binner = RiskBands(missing_policy="separate_bin")
 | `standard` | Preserva o comportamento compativel atual. | Reproducao de fluxos existentes e compatibilidade. |
 | `separate_bin` | Cria bin explicito `Missing` para missing nas features selecionadas. | Analise auditavel de missing como grupo proprio. |
 | `forbid` | Falha em `fit` ou `transform` quando encontra missing. | Governanca que exige tratamento upstream antes do binning. |
+| `merge` | Aprende no `fit` um bin regular de destino para o grupo missing. | Quando missing deve ser auditado, mas roteado para o bin mais parecido. |
 
 `legacy` pode aparecer em metadados antigos como compatibilidade, mas nao e
 recomendacao nova. O nome canonico atual e `standard`.
+
+## Merge auditavel
+
+`missing_policy="merge"` e opt-in e exige um criterio explicito:
+
+```python
+binner = RiskBands(
+    missing_policy="merge",
+    missing_merge_criterion="nearest_event_rate",
+    missing_merge_fallback="separate_bin",
+)
+```
+
+```python
+binner = RiskBands(
+    missing_policy="merge",
+    missing_merge_criterion="nearest_woe",
+    missing_merge_fallback="raise",
+)
+```
+
+`nearest_event_rate` escolhe o bin regular com menor distancia absoluta de taxa
+de evento em relacao ao grupo missing no fit. `nearest_woe` usa a menor
+distancia absoluta de WoE no mesmo perfil de fit.
+
+O merge nao e imputacao opaca. A decisao fica em `missing_decision_log_`, os
+candidatos ficam em `missing_merge_candidates_`, e o mapa aprendido fica em
+`missing_merge_map_`. O `transform(...)` usa apenas essa decisao aprendida no
+fit; ele nao aprende regra nova com a base de aplicacao.
 
 ## Exemplo pandas
 
@@ -120,6 +150,10 @@ tomada por variavel.
 - `effective_missing_policy`
 - `missing_profile`
 - `missing_decision_log`
+- `missing_merge_criterion`
+- `missing_merge_fallback`
+- `missing_merge_candidates`
+- `missing_merge_map`
 
 ```python
 from riskbands.reporting import load_bundle
@@ -135,13 +169,13 @@ Bundles antigos sem esses campos continuam carregando como `standard`.
 
 ## O que nao esta implementado
 
-Esta pagina documenta o contrato atual. Ela nao anuncia novas features.
+Esta pagina documenta o contrato atual. Ainda nao existem:
 
-Ainda nao existem:
-
-- merge policies auditaveis para unir o bin missing a outro bin;
+- `temporal_stable` como criterio de merge;
+- `monotonic_neighbor` como criterio de merge;
+- criterios de merge alem de `nearest_event_rate` e `nearest_woe`;
+- PySpark merge completo;
 - imputacao inteligente dentro do RiskBands;
-- similaridade comportamental automatica para missing;
 - fitting estatistico totalmente distribuido em Spark.
 
 O RiskBands ajuda a tornar a decisao defensavel e auditavel, mas nao garante

--- a/docs-site/src/content/docs/technical/outputs.md
+++ b/docs-site/src/content/docs/technical/outputs.md
@@ -1,11 +1,11 @@
 ---
-title: "Outputs e diagnóstico"
+title: "Outputs e diagnostico"
 description: "Como interpretar os principais outputs do Binner depois do fit, com foco em auditoria, score e leitura temporal."
 ---
 
 ## O que aparece depois do `fit`
 
-Depois de ajustar um `Binner`, a API pública expõe artefatos mais amigáveis para inspeção:
+Depois de ajustar um `Binner`, a API publica expoe artefatos amigaveis:
 
 - `binning_table()`
 - `feature_binning_table()` e `get_binning_table()`
@@ -23,7 +23,7 @@ Depois de ajustar um `Binner`, a API pública expõe artefatos mais amigáveis p
 - `export_binnings_json()`
 - `export_bundle()`
 
-Também ficam disponíveis atributos pós-fit úteis, como:
+Tambem ficam disponiveis atributos pos-fit como:
 
 - `binning_table_`
 - `summary_`
@@ -35,119 +35,64 @@ Também ficam disponíveis atributos pós-fit úteis, como:
 - `score_`
 - `comparison_score_`
 
-## `binning_table()`
+## Tabelas principais
 
-Use quando quiser ver os cortes ou bins finais de forma direta.
+`binning_table()` mostra cortes ou bins finais. `score_table()` e a tabela curta
+para explicar objective, pesos, componentes normalizados e componentes raw.
+`audit_table()` combina cortes, IV, score temporal, penalidades, cobertura,
+bins raros, reversoes e rationale resumido.
 
-Perguntas que ela ajuda a responder:
+## Diagnostico temporal
 
-- quantos bins ficaram?
-- quais intervalos ou grupos foram formados?
-- qual é a ordem dos bins?
+Use `diagnostics(kind="bin")` para abrir detalhe por bin e periodo. Use
+`diagnostics(kind="variable")` para resumo temporal agregado por variavel.
 
-## `score_table()`
-
-É a tabela mais curta para notebook quando a pergunta central é:
-
-- por que esse score saiu assim?
-- quais pesos entraram?
-- quais componentes pesaram mais?
-- qual normalização está ativa?
-
-Ela expõe:
-
-- `objective_score`
-- `objective_preference_score`
-- `weight_profile`
-- `normalized_component_profile`
-- `raw_component_profile`
-- colunas detalhadas `objective_weight_*`, `objective_norm_*` e `objective_raw_*`
-
-## `audit_table()`
-
-É a tabela mais útil para revisão auditável e model risk.
-
-Ela combina em uma única visão:
-
-- cortes
-- IV e score temporal
-- score e penalidades
-- cobertura, bins raros e reversões
-- rationale resumido
-
-## `diagnostics()`
-
-Use `diagnostics(kind="bin")` quando quiser abrir o detalhe por bin e período.
-
-Use `diagnostics(kind="variable")` quando quiser o resumo temporal agregado por variável.
-
-É a melhor porta para investigar:
+Essa e a melhor porta para investigar:
 
 - cobertura
 - volatilidade de event rate
 - volatilidade de WoE
 - share dos bins
-- reversões de ranking
+- reversoes de ranking
 - quebras de monotonicidade
 
-## `metadata_`
+## Metadata
 
-O metadata pós-fit agora é mais auditável.
+`metadata_` inclui versao do `riskbands`, estrategia, `score_strategy`,
+`normalization_strategy`, `woe_shrinkage_strength`, pesos, `target_name`,
+`time_col` e features ajustadas.
 
-Ele inclui:
+## Export auditavel
 
-- versão do `riskbands`
-- `strategy`
-- `score_strategy`
-- `normalization_strategy`
-- `woe_shrinkage_strength`
-- pesos informados e pesos efetivos
-- `target_name`
-- `time_col`
-- features ajustadas
+`export_binnings_json(path)` gera um JSON unico com metadata, pesos do score,
+bins por feature, resumo, score details e auditoria por feature.
 
-## Export auditável
+`export_bundle(path)` gera JSON legivel, CSVs, tabelas por feature e Parquet
+opcional quando houver engine disponivel.
 
-### `export_binnings_json(path)`
-
-Gera um JSON único com:
-
-- metadata geral do fit
-- pesos do score
-- bins por feature
-- resumo, score details e auditoria por feature
-
-### `export_bundle(path)`
-
-Gera um pacote de auditoria com:
-
-- JSON legível
-- CSVs prontos para notebook ou governança
-- tabelas por feature
-- Parquet opcional quando houver engine disponível
-
-## Leitura rápida do score
-
-Uma regra simples:
-
-- `standard`: score bruto maior é melhor
-- `stable`: score bruto menor é melhor
-
-Se quiser uma régua consolidada para comparação entre estratégias, olhe também `objective_preference_score`.
-
-Bundles também persistem a trilha de missing values quando disponível:
-`missing_policy`, `effective_missing_policy`, `missing_profile` e
-`missing_decision_log`.
+Bundles tambem persistem a trilha de missing values quando disponivel:
+`missing_policy`, `effective_missing_policy`, `missing_profile`,
+`missing_decision_log`, `missing_merge_criterion`, `missing_merge_fallback`,
+`missing_merge_candidates` e `missing_merge_map`.
 
 Esses campos registram a decisao de tratamento de missing values. Eles nao
-representam imputacao opaca nem merge policies.
+representam imputacao opaca.
 
 Use `missing_profile_` para revisar volume, share e event rate dos missing por
-variavel. Use `missing_decision_log_` para ver se a acao foi preservar o
-comportamento `standard`, criar bin `Missing` com `separate_bin` ou bloquear o
-fluxo com `forbid`.
+variavel. Use `missing_decision_log_` para ver se a acao foi preservar
+`standard`, criar bin `Missing` com `separate_bin`, bloquear com `forbid` ou
+rotear missing com `merge`. Para merge, use `missing_merge_candidates_` para
+revisar candidatos e distancias e `missing_merge_map_` para ver o destino
+aprendido.
 
 Guia dedicado: [Missing policy](../missing-policy/).
+
+## Leitura rapida do score
+
+- `standard`: score bruto maior e melhor
+- `stable`: score bruto menor e melhor
+
+Para uma regua consolidada entre estrategias, veja `objective_preference_score`.
 
 ## Exemplo
 

--- a/docs-site/src/content/docs/technical/quickstart.md
+++ b/docs-site/src/content/docs/technical/quickstart.md
@@ -5,14 +5,14 @@ description: "Ajuste seu primeiro RiskBands com a API mais amigavel do projeto e
 
 ## O fluxo recomendado hoje
 
-Para um usuário novo, o caminho mais simples e completo é:
+Para um usuario novo, o caminho mais simples e completo e:
 
 1. criar um `RiskBands`
 2. ajustar com `fit(df, y="target", column="score", time_col="month")`
 3. olhar `summary()`
 4. abrir `score_table()` e `audit_table()`
-5. exportar os artefatos auditáveis
-6. usar os plots públicos para leitura temporal
+5. exportar os artefatos auditaveis
+6. usar os plots publicos para leitura temporal
 
 ```python
 import numpy as np
@@ -63,74 +63,46 @@ voce precisa auditar missing values explicitamente, use
 `missing_policy="separate_bin"`. Quando missing values devem ser bloqueados
 antes do binning, use `missing_policy="forbid"`.
 
-Essas politicas nao fazem imputacao opaca e nao incluem merge policies.
+Quando missing deve continuar auditavel, mas ser roteado para um bin regular,
+use `missing_policy="merge"` com `missing_merge_criterion="nearest_event_rate"`
+ou `missing_merge_criterion="nearest_woe"`.
+
+Essas politicas nao fazem imputacao opaca. Em merge, a regra e aprendida no
+`fit` e reutilizada no `transform`, sem recalcular destino com a base de
+aplicacao.
 
 Para exemplos pandas e PySpark completos, veja [Missing policy](../missing-policy/).
-
-## Por que esse fluxo é mais amigável
-
-Ele segue convenções familiares:
-
-- `fit(...)`
-- `transform(...)`
-- `fit_transform(...)`
-- `DataFrame` e `Series` do pandas como primeira opção
-- tabelas curtas para notebook antes de abrir o detalhe completo
-
-Também evita exigir que você monte pivots, bundles ou dicionários internos logo no começo.
 
 ## O que olhar primeiro
 
 ### `summary()`
 
-É a melhor primeira parada depois do ajuste.
-
-Use quando quiser responder rapidamente:
-
-- quantos bins ficaram?
-- qual foi o IV?
-- qual estratégia de score está ativa?
-- existem alertas temporais relevantes?
+Melhor primeira parada depois do ajuste: bins, IV, estrategia de score e alertas
+temporais.
 
 ### `score_table()`
 
-É a leitura mais curta para explicar o objective.
-
-Ela ajuda a enxergar:
-
-- score final
-- score de comparação
-- direção do objective
-- pesos usados
-- componentes e penalidades mais relevantes
+Leitura curta para explicar score final, score de comparacao, direcao do
+objective, pesos e componentes mais relevantes.
 
 ### `audit_table()`
 
-É a visão consolidada para revisão auditável.
-
-Ela junta:
-
-- cortes finais
-- score
-- cobertura
-- bins raros
-- reversões
-- rationale resumido
+Visao consolidada para revisao auditavel: cortes finais, score, cobertura, bins
+raros, reversoes e rationale resumido.
 
 ## Quando usar `stable`
 
-Para um novo usuário, `stable` costuma ser a melhor estratégia pública para começar quando:
+Para um novo usuario, `stable` costuma ser a melhor estrategia publica para
+comecar quando existe coluna temporal, estabilidade importa e voce quer
+equilibrar separacao e robustez.
 
-- existe coluna temporal
-- estabilidade importa de verdade
-- você quer equilibrar separação e robustez
+Se voce precisa reproduzir comportamento historico ou comparar com a abordagem
+anterior, use `standard`.
 
-Se você precisa reproduzir um comportamento mais histórico ou comparar com a abordagem anterior, use `standard`.
-
-## Próximos passos
+## Proximos passos
 
 - [Auditoria e plots](../audit-and-plots/)
 - [Missing policy](../missing-policy/)
-- [Outputs e diagnóstico](../outputs/)
-- [Score e estratégias](../score-strategy/)
+- [Outputs e diagnostico](../outputs/)
+- [Score e estrategias](../score-strategy/)
 - [Exemplos](../examples/)

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -15,7 +15,7 @@ from riskbands import (
 
 Current version:
 
-- `2.2.0`
+- `2.3.0`
 
 ## `RiskBands` / `Binner`
 
@@ -34,7 +34,9 @@ Common parameters:
 - `check_stability`: enables temporal checks in the flow
 - `use_optuna`: enables hyperparameter search for `strategy="supervised"`
 - `time_col`: period column used by temporal diagnostics
-- `missing_policy`: `"standard"` (default), `"separate_bin"`, or `"forbid"`
+- `missing_policy`: `"standard"` (default), `"separate_bin"`, `"forbid"`, or `"merge"`
+- `missing_merge_criterion`: required for `missing_policy="merge"`; `"nearest_event_rate"` or `"nearest_woe"`
+- `missing_merge_fallback`: `"separate_bin"` (default) or `"raise"` for transform-time missing values when no fit-time merge decision exists
 - `score_strategy`: `"standard"` or `"stable"`; `"legacy"` remains a compatibility alias for `"standard"`
 - `score_weights`: optional weights for `stable`
 - `normalization_strategy`: currently `absolute` for standalone-safe normalization
@@ -89,9 +91,16 @@ Missing policy semantics:
 - `standard`: preserves the current missing-value behavior and is the default.
 - `separate_bin`: creates an explicit, auditable `Missing` bin.
 - `forbid`: raises a clear error in `fit` or `transform` when selected features contain missing values.
+- `merge`: learns a fit-time destination for the missing group and routes missing values to the selected regular bin during pandas transform.
 
-No opaque missing-value imputation is added. Merge policies such as
-`merge_nearest_woe` and `merge_nearest_event_rate` are not part of v2.2.0.
+For `merge`, use one supported criterion:
+
+- `nearest_event_rate`: selects the candidate bin with the smallest absolute event-rate distance from the fit-time missing group.
+- `nearest_woe`: selects the candidate bin with the smallest absolute WoE distance from the fit-time missing group.
+
+The decision is learned only during `fit(...)`; `transform(...)` does not use application target values, application event rates, application WoE, or out-of-time distributions to retarget missing values.
+
+No opaque missing-value imputation is added. The v2.3.0 merge contract does not include `temporal_stable`, `monotonic_neighbor`, custom criteria, or full PySpark merge routing.
 
 For user guidance and runnable examples, see
 [`docs/missing_policy_user_guide.md`](missing_policy_user_guide.md) and:
@@ -105,6 +114,10 @@ The main audit attributes are:
 - `effective_missing_policy_`
 - `missing_profile_`
 - `missing_decision_log_`
+- `missing_merge_criterion_`
+- `missing_merge_fallback_`
+- `missing_merge_candidates_`
+- `missing_merge_map_`
 
 These fields are also persisted by `export_bundle(...)` when available.
 
@@ -129,6 +142,7 @@ Main attributes after `fit`:
 - `validation_report_` as the latest validation report compatibility alias
 - `fit_profile_`, `source_profile_`, and `reference_profile_` when available
 - `missing_policy_`, `effective_missing_policy_`, `missing_profile_`, and `missing_decision_log_`
+- `missing_merge_criterion_`, `missing_merge_fallback_`, `missing_merge_candidates_`, and `missing_merge_map_` when merge is enabled
 - `iv_`
 - `iv_by_variable_`
 - `objective_config_`
@@ -180,6 +194,7 @@ Main attributes after `fit`:
 - fit metadata and RiskBands version
 - strategy, score strategy, normalization mode, shrinkage configuration
 - missing policy and effective missing policy
+- missing merge criterion and fallback when merge is enabled
 - target, time column, fitted features and generation timestamp
 - auditable score weights and effective score-weight profile
 - per-feature binning tables, score details and audit-friendly summaries
@@ -190,6 +205,7 @@ Main attributes after `fit`:
 - `binnings.json`
 - friendly CSV outputs such as `summary.csv`, `score_table.csv`, `audit_table.csv`, and `report.csv`
 - missing audit outputs such as `missing_profile.csv` and `missing_decision_log.csv` when available
+- merge audit outputs such as `missing_merge_candidates.csv` when available
 - per-feature tables under `feature_tables/`
 - parquet artifacts when the environment has parquet support available
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,13 @@ Entry point for the project documentation.
 - [docs/v2.2.0_user_guide.md](v2.2.0_user_guide.md)
   v2.2.0 import, missing policies, pandas/PySpark, validation, and bundle guide.
 - [docs/missing_policy_user_guide.md](missing_policy_user_guide.md)
-  Dedicated guide for `standard`, `separate_bin`, `forbid`, pandas/PySpark examples, audit fields, and bundle reporting.
+  Dedicated guide for `standard`, `separate_bin`, `forbid`, `merge`, pandas/PySpark examples, audit fields, and bundle reporting.
+- [docs/releases/2.3.0.md](releases/2.3.0.md)
+  v2.3.0 release-prep notes for auditable missing merge policies.
+- [docs/missing_merge_nearest_event_rate_design.md](missing_merge_nearest_event_rate_design.md)
+  Internal design note for `missing_merge_criterion="nearest_event_rate"`.
+- [docs/missing_merge_nearest_woe_design.md](missing_merge_nearest_woe_design.md)
+  Internal design note for `missing_merge_criterion="nearest_woe"`.
 - [docs/migration.md](migration.md)
   Breaking migration guide for users coming from `NASABinning`.
 - [examples/README.md](../examples/README.md)
@@ -33,7 +39,7 @@ Entry point for the project documentation.
 - [examples/temporal_stability/temporal_stability_example.py](../examples/temporal_stability/temporal_stability_example.py)
   Minimal temporal quickstart.
 - [examples/missing_policy/missing_policy_pandas_demo.py](../examples/missing_policy/missing_policy_pandas_demo.py)
-  Small pandas demo for missing-policy behavior, audit fields, and bundle roundtrip.
+  Small pandas demo for missing-policy behavior, merge with nearest event rate and nearest WoE, audit fields, and bundle roundtrip.
 - [examples/missing_policy/missing_policy_pyspark_demo.py](../examples/missing_policy/missing_policy_pyspark_demo.py)
   Small optional PySpark demo for `separate_bin`, `forbid`, and `transform(validate=True)`.
 - [examples/pd_vintage_champion_challenger/pd_vintage_champion_challenger.py](../examples/pd_vintage_champion_challenger/pd_vintage_champion_challenger.py)

--- a/docs/missing_merge_nearest_event_rate_design.md
+++ b/docs/missing_merge_nearest_event_rate_design.md
@@ -93,7 +93,7 @@ Bundle export and JSON/Excel report paths persist the merge audit fields.
 
 ## PySpark Boundary
 
-E1 does not implement PySpark merge routing. PySpark fit or transform with
+v2.3.0 does not implement PySpark merge routing. PySpark fit or transform with
 `missing_policy="merge"` raises:
 
 ```text

--- a/docs/missing_merge_nearest_woe_design.md
+++ b/docs/missing_merge_nearest_woe_design.md
@@ -98,7 +98,7 @@ distance metric, event-rate distance, and WOE distance.
 
 ## PySpark Boundary
 
-PySpark merge remains intentionally unsupported in E2. Fit or transform with
+PySpark merge remains intentionally unsupported in v2.3.0. Fit or transform with
 `missing_policy="merge"` raises a clear `NotImplementedError` for both
 `nearest_event_rate` and `nearest_woe`. Existing PySpark behavior for
 `separate_bin` and `forbid` remains covered by regression tests.

--- a/docs/missing_policy_user_guide.md
+++ b/docs/missing_policy_user_guide.md
@@ -2,8 +2,8 @@
 
 Este guia explica como usar `missing_policy` no RiskBands em fluxos pandas e
 PySpark, com foco em risco de credito, auditabilidade e revisao defensavel do
-binning. Ele complementa o contrato tecnico da v2.2.0 e prepara a trilha
-docs-only v2.2.0 documentation update.
+binning. Ele reflete a preparacao da v2.3.0 para merge auditavel de missing
+values, sem afirmar publicacao.
 
 ## Por que missing values importam
 
@@ -35,6 +35,7 @@ Valores aceitos:
 | `standard` | Preserva o comportamento compativel atual. | Quando voce precisa manter compatibilidade com fluxos existentes. | E o default. |
 | `separate_bin` | Cria um bin explicito `Missing` quando ha missing nas features selecionadas. | Quando missing pode carregar sinal de risco e precisa aparecer no reporting. | Recomendado para analise auditavel de missing. |
 | `forbid` | Falha em `fit` ou `transform` se houver missing nas features selecionadas. | Quando a governanca exige que dados ausentes sejam tratados antes do binning. | Nao corrige os dados; bloqueia o fluxo. |
+| `merge` | Aprende no `fit` um bin regular de destino para o grupo missing. | Quando missing deve ser auditado, mas roteado para o bin mais parecido. | Requer `missing_merge_criterion`. |
 
 `legacy` nao e recomendacao nova para `missing_policy`. Quando aparecer em
 metadados antigos, ele e tratado como compatibilidade historica e normalizado
@@ -86,6 +87,46 @@ Use quando:
 - o time de model risk quer revisar se missing deve ficar separado no scorecard.
 
 Essa politica nao faz imputacao opaca. Ela separa missing como bin observavel.
+
+## `merge`
+
+`merge` e uma politica opt-in para pandas. Ela primeiro trata missing como grupo
+observavel no `fit`, depois escolhe um bin regular de destino com criterio
+explicito e auditavel.
+
+```python
+binner = RiskBands(
+    max_bins=4,
+    missing_policy="merge",
+    missing_merge_criterion="nearest_event_rate",
+    missing_merge_fallback="separate_bin",
+)
+```
+
+Os criterios suportados sao:
+
+- `nearest_event_rate`: escolhe o bin regular cuja taxa de evento no fit fica
+  mais perto da taxa de evento do grupo missing.
+- `nearest_woe`: escolhe o bin regular cujo WoE no fit fica mais perto do WoE
+  do grupo missing.
+
+Use `nearest_event_rate` quando a revisao quer explicar a decisao em termos de
+taxa de evento observada. Use `nearest_woe` quando a similaridade do scorecard
+deve seguir a escala WoE ja usada no binner.
+
+`missing_merge_fallback` controla missing que aparece no `transform` sem uma
+decisao aprendida no `fit`:
+
+- `separate_bin`: retorna `Missing` para esses valores.
+- `raise`: falha com erro claro.
+
+O `transform(...)` nunca aprende uma nova regra de merge. Ele usa apenas
+`missing_merge_map_`, aprendido no `fit`, e nao usa target, event rate, WoE ou
+distribuicao da base de aplicacao para retargeting.
+
+Com `return_woe=True`, missing values roteados por merge recebem o WoE do bin de
+destino aprendido. Se nao houve destino aprendido e o fallback gerou `Missing`,
+nao ha WoE ajustado para esse novo label e o metodo falha com erro claro.
 
 ## `forbid`
 
@@ -142,6 +183,11 @@ print(df_binned.head())
 print(binner.missing_profile_)
 print(binner.missing_decision_log_)
 ```
+
+O mesmo exemplo tambem roda `missing_policy="merge"` com
+`missing_merge_criterion="nearest_event_rate"` e
+`missing_merge_criterion="nearest_woe"`, imprime `missing_merge_candidates_` e
+faz roundtrip de bundle para confirmar persistencia dos campos de merge.
 
 ## Exemplo PySpark
 
@@ -205,6 +251,10 @@ decisions = binner.missing_decision_log_
 - `effective_missing_policy`
 - `missing_profile`
 - `missing_decision_log`
+- `missing_merge_criterion`
+- `missing_merge_fallback`
+- `missing_merge_candidates`
+- `missing_merge_map`
 
 ```python
 from riskbands.reporting import load_bundle
@@ -221,12 +271,13 @@ compatibilidade.
 
 ## O que ainda nao existe
 
-Esta sprint nao implementa novas politicas nem muda o comportamento do core.
-Ainda nao existem:
+Na preparacao v2.3.0, o escopo e propositalmente estreito. Ainda nao existem:
 
-- merge policies auditaveis para unir o bin missing a outro bin;
+- `temporal_stable` como criterio de merge;
+- `monotonic_neighbor` como criterio de merge;
+- criterios de merge alem de `nearest_event_rate` e `nearest_woe`;
+- PySpark merge completo;
 - imputacao inteligente dentro do RiskBands;
-- similaridade comportamental automatica para decidir destino de missing;
 - backend Spark distribuido completo para o fitting estatistico.
 
 Esses itens devem ser tratados como pesquisa ou trabalho futuro, nunca como

--- a/docs/releases/2.3.0.md
+++ b/docs/releases/2.3.0.md
@@ -1,0 +1,58 @@
+# RiskBands 2.3.0
+
+Type: compatible minor release.
+
+## Positioning
+
+RiskBands v2.3.0 - auditable missing merge policies.
+
+Version 2.3.0 adds opt-in, auditable merge handling for missing values in pandas workflows. `missing_policy="merge"` can route the fit-time missing group into the closest regular bin using `nearest_event_rate` or `nearest_woe`, while preserving the original missing profile, decision log, candidate table, bundle fields, and reporting evidence.
+
+## Added
+
+- `missing_policy="merge"` for pandas fitting and transform routing.
+- `missing_merge_criterion="nearest_event_rate"` to select the regular candidate bin with the smallest absolute event-rate distance from the missing group.
+- `missing_merge_criterion="nearest_woe"` to select the regular candidate bin with the smallest absolute WoE distance from the missing group.
+- `missing_merge_fallback="separate_bin"` for transform-time missing values when no fit-time merge decision exists.
+- `missing_merge_fallback="raise"` for governance flows that must fail instead of creating a transform-only `Missing` label.
+- `missing_merge_candidates_` and `missing_merge_map_` audit attributes.
+- Bundle/reporting persistence for merge criterion, fallback, selected destination, candidate distances, `missing_profile_`, and `missing_decision_log_`.
+- Correct `return_woe=True` behavior for merged missing values by routing to the learned destination bin before mapping to WoE.
+
+## Compatibility
+
+- `missing_policy="standard"` remains the default.
+- `missing_policy="separate_bin"` and `missing_policy="forbid"` are preserved.
+- `score_strategy="standard"` remains canonical.
+- `score_strategy="legacy"` remains a compatibility alias for `standard`.
+- `RiskBands is Binner` remains true.
+- Old bundles without missing-merge fields load with missing-merge metadata as `None`.
+- Base installation does not install PySpark.
+- The Spark extra remains constrained to `pyspark>=3.5,<4`.
+
+## No-Leakage Contract
+
+Merge decisions are learned during `fit(...)` only. `transform(...)` does not inspect application target values, application event rates, application WoE, or out-of-time distributions to choose or change the destination bin.
+
+If missing values appear only during transform and no fit-time merge destination exists:
+
+- `missing_merge_fallback="separate_bin"` returns `Missing`;
+- `missing_merge_fallback="raise"` raises a clear error.
+
+## PySpark Boundary
+
+PySpark support for `standard`, `separate_bin`, and `forbid` remains available through the optional `riskbands[spark]` extra. Full PySpark merge routing is not implemented in v2.3.0. PySpark fit or transform with `missing_policy="merge"` raises an explicit `NotImplementedError`.
+
+## Out Of Scope
+
+- No `temporal_stable` merge criterion.
+- No `monotonic_neighbor` merge criterion.
+- No custom merge criteria beyond `nearest_event_rate` and `nearest_woe`.
+- No opaque intelligent imputation.
+- No full distributed Spark fitting backend for merge.
+- No PySpark 4.x support promise.
+- No regulatory compliance guarantee.
+
+## Documentation
+
+The release-prep updates README, `docs/`, docs-site pt-BR/en pages, examples, and the publication checklist. It does not create a tag, push to GitHub, upload to PyPI, upload to TestPyPI, or run `twine upload`.

--- a/docs/releases/2.3.0_publication_checklist.md
+++ b/docs/releases/2.3.0_publication_checklist.md
@@ -1,0 +1,93 @@
+# RiskBands 2.3.0 Publication Checklist
+
+Status: prepared for manual review. Do not publish from this checklist until the branch is reviewed and merged.
+
+## Identity
+
+- [x] Version target: `2.3.0`
+- [x] Branch: `release/v2.3.0-prep`
+- [x] Base commit: `94d9b95ee60d023cf054cf2d2844814cd6d2727e`
+- [x] Planned tag after review: `v2.3.0`
+- [x] Local `git tag --list v2.3.0`: no tag
+- [x] No push performed by Sprint E3
+- [x] No PyPI upload performed by Sprint E3
+- [x] No TestPyPI upload performed by Sprint E3
+- [x] No `twine upload` performed by Sprint E3
+
+## Feature Scope
+
+- [x] `missing_policy="merge"` documented
+- [x] `missing_merge_criterion="nearest_event_rate"` documented
+- [x] `missing_merge_criterion="nearest_woe"` documented
+- [x] `missing_merge_fallback` documented
+- [x] `missing_profile_` documented
+- [x] `missing_decision_log_` documented
+- [x] `missing_merge_candidates_` documented
+- [x] bundle/reporting persistence documented
+- [x] no-leakage transform behavior documented
+- [x] PySpark merge boundary documented
+- [x] `missing_policy="standard"` remains default
+- [x] `standard`, `separate_bin`, `forbid` preserved
+- [x] `legacy` alias preserved
+- [x] `RiskBands is Binner` preserved
+- [x] PySpark remains optional
+- [x] Spark extra remains `pyspark>=3.5,<4`
+
+## Out Of Scope Confirmed
+
+- [x] No `temporal_stable`
+- [x] No `monotonic_neighbor`
+- [x] No PySpark merge implementation
+- [x] No merge criteria beyond `nearest_event_rate` and `nearest_woe`
+- [x] No opaque intelligent imputation
+- [x] No PySpark 4.x promise
+- [x] No regulatory compliance guarantee
+
+## Validation Matrix
+
+| Gate | Result |
+| --- | --- |
+| Version import | PASS: `2.3.0`, `RiskBands is Binner=True` |
+| Public API/API usability | PASS: 20 passed |
+| Example smoke | PASS: 6 passed |
+| Compatibility/bundle | PASS: 46 passed |
+| Missing merge focused | PASS: 66 passed |
+| Full core pytest | PASS: 293 passed |
+| Spark real | PASS: 26 selected tests passed, not fully skipped |
+| Ruff | PASS |
+| Bandit | PASS |
+| pip-audit | PASS: no known vulnerabilities found |
+| Docs-site build | PASS: 39 pages built after sandbox EPERM rerun with approval |
+| Docs routes | PASS: PT/EN home, missing policy and release notes exist |
+| Build | PASS: wheel and sdist built |
+| Twine check | PASS |
+| Smoke base | PASS: no PySpark installed |
+| Smoke `[spark]` | PASS: PySpark 3.5.8 |
+
+## Manual Plan After Review
+
+Run only after reviewing the final diff:
+
+```bash
+git commit -m "Prepare RiskBands v2.3.0 release"
+git push -u origin release/v2.3.0-prep
+gh pr create --base main --head release/v2.3.0-prep
+```
+
+After merge and final validation:
+
+```bash
+git switch main
+git pull --ff-only origin main
+git tag -a v2.3.0 -m "Release v2.3.0"
+git push origin v2.3.0
+gh workflow run publish-pypi.yml --ref v2.3.0
+```
+
+Optional TestPyPI validation can be run before PyPI if desired by project policy.
+
+## Residual Notes
+
+- Spark tests printed Windows cleanup `Acesso negado` after exit code 0; GOAL states this is non-blocking.
+- Smoke venvs print warnings about stale `pip-24.0.dist-info` metadata after pip upgrade, but `pip check` exits 0.
+- No publication or tag step has been executed.

--- a/docs/releases/2.3.0_release_prep_report.md
+++ b/docs/releases/2.3.0_release_prep_report.md
@@ -1,0 +1,86 @@
+# RiskBands 2.3.0 Release Prep Report
+
+Status: `V230_RELEASE_PREP_READY`
+
+Branch: `release/v2.3.0-prep`
+
+Base commit: `94d9b95ee60d023cf054cf2d2844814cd6d2727e`
+
+Target version: `2.3.0`
+
+## Summary
+
+This preparation updates RiskBands to `2.3.0` after Sprint E1/E2 missing-merge work. It does not publish, tag, or push.
+
+Positioning:
+
+```text
+RiskBands v2.3.0 - auditable missing merge policies
+```
+
+Main user-facing scope:
+
+- `missing_policy="merge"`
+- `missing_merge_criterion="nearest_event_rate"`
+- `missing_merge_criterion="nearest_woe"`
+- `missing_merge_fallback`
+- audit trail through profile, decision log, candidates and merge map
+- bundle/reporting persistence
+- transform no-leakage contract
+- explicit PySpark merge boundary
+
+## Files Updated
+
+- `pyproject.toml`
+- `README.md`
+- `RELEASE.md`
+- `docs/releases/2.3.0.md`
+- `docs/releases/2.3.0_publication_checklist.md`
+- `docs/releases/2.3.0_release_prep_report.md`
+- `docs/api_reference.md`
+- `docs/index.md`
+- `docs/missing_policy_user_guide.md`
+- `docs/missing_merge_nearest_event_rate_design.md`
+- `docs/missing_merge_nearest_woe_design.md`
+- docs-site PT/EN index, release notes, quickstart, API overview, missing policy, outputs and examples
+- `examples/README.md`
+- `examples/missing_policy/missing_policy_pandas_demo.py`
+- `tests/test_examples_smoke.py`
+
+## Validation Results
+
+| Area | Evidence |
+| --- | --- |
+| Version | import printed `2.3.0 True` |
+| Public API/API usability | `20 passed` |
+| Example smoke | `6 passed` |
+| Compatibility/bundle | `46 passed` |
+| Missing merge focused | `66 passed` |
+| Full core | `293 passed` |
+| Spark real | `26 passed`, not fully skipped |
+| Ruff | `All checks passed!` |
+| Bandit | exit code 0 |
+| pip-audit | `No known vulnerabilities found` |
+| Docs-site | `39 page(s) built`; required routes exist |
+| Build | `riskbands-2.3.0.tar.gz`, `riskbands-2.3.0-py3-none-any.whl` |
+| Twine | both artifacts `PASSED` |
+| Smoke base | version `2.3.0`, `RiskBands is Binner=True`, `pyspark_installed=False`, `pip check` OK |
+| Smoke spark | version `2.3.0`, `RiskBands is Binner=True`, `pyspark=3.5.8`, `pip check` OK |
+
+## Constraints
+
+- No tag was created.
+- No push was performed.
+- No PyPI upload was performed.
+- No TestPyPI upload was performed.
+- No `twine upload` was run.
+- `missing_policy="standard"` remains default.
+- `legacy` and `Binner` compatibility remain.
+- PySpark is still optional and constrained to major 3 through `pyspark>=3.5,<4`.
+- `temporal_stable`, `monotonic_neighbor`, PySpark merge, and extra merge criteria were not added.
+
+## Residual Notes
+
+- The initial docs build hit sandbox `spawn EPERM`; the approved rerun passed.
+- The initial smoke-base install could not resolve dependencies under sandbox; the approved rerun passed.
+- Windows Spark cleanup printed `ERRO: Acesso negado` after successful test exits, which the GOAL explicitly marks non-blocking.

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,7 +12,7 @@
   Demo minima comparando o score `legacy` com `stable` sobre a mesma cesta de candidatos, mostrando como a decisao muda quando a funcao objetivo passa a priorizar robustez temporal.
 
 - `examples/missing_policy/missing_policy_pandas_demo.py`
-  Demo pequena em pandas para `standard`, `separate_bin`, `forbid`, `missing_profile_`, `missing_decision_log_` e bundle.
+  Demo pequena em pandas para `standard`, `separate_bin`, `forbid`, `missing_policy="merge"` com `nearest_event_rate` e `nearest_woe`, `missing_profile_`, `missing_decision_log_`, `missing_merge_candidates_` e bundle.
 
 - `examples/missing_policy/missing_policy_pyspark_demo.py`
   Demo pequena e opcional em PySpark para `separate_bin`, `forbid` e `transform(validate=True)`, com guarda quando PySpark nao esta instalado.
@@ -51,7 +51,7 @@
 - Comece por `riskbands_synthetic_plotly_comparative_demo.ipynb` se a sua pergunta principal for:
   "Qual e o jeito mais curto e familiar de usar o RiskBands hoje?"
 - Comece por `missing_policy/` se a sua pergunta principal for:
-  "Como tornar missing values visiveis, bloqueados ou auditaveis no binning?"
+  "Como tornar missing values visiveis, bloqueados, auditaveis ou roteados por merge no binning?"
 - Start with `temporal_stability/` if you want to understand the mechanics of the API before going into credit-specific trade-offs.
 - Go to `pd_vintage_champion_challenger/` if your main question is:
   "How can a binning that looks stronger in train lose to a more robust alternative over time?"
@@ -81,5 +81,4 @@ The anchor PD example also reuses the synthetic credit helpers under `research/r
 
 - `credit_data_synthesizer.py` for the vintage panel
 - `credit_data_sampler.py` for an optional sampling preview
-
 

--- a/examples/missing_policy/missing_policy_pandas_demo.py
+++ b/examples/missing_policy/missing_policy_pandas_demo.py
@@ -12,6 +12,7 @@ from riskbands.reporting import load_bundle
 
 
 FEATURES = ["score", "rating"]
+MERGE_FEATURE = "score"
 
 
 def make_demo_frame() -> pd.DataFrame:
@@ -56,6 +57,23 @@ def make_demo_frame() -> pd.DataFrame:
     )
 
 
+def make_missing_merge_frame() -> pd.DataFrame:
+    """Create a synthetic single-feature dataset for missing merge demos."""
+
+    score: list[float] = []
+    target: list[int] = []
+    for value, event_rate in [(-5.0, 0.05), (-3.0, 0.20), (0.0, 0.50), (3.0, 0.80), (5.0, 0.95)]:
+        n = 40
+        events = int(n * event_rate)
+        score.extend([value] * n)
+        target.extend([1] * events + [0] * (n - events))
+
+    score.extend([np.nan] * 40)
+    target.extend([1] * 20 + [0] * 20)
+
+    return pd.DataFrame({"score": score, "target": target})
+
+
 def _fit_policy(df: pd.DataFrame, policy: str) -> dict[str, object]:
     binner = RiskBands(
         max_bins=4,
@@ -75,17 +93,60 @@ def _fit_policy(df: pd.DataFrame, policy: str) -> dict[str, object]:
     }
 
 
+def _fit_merge_policy(df: pd.DataFrame, criterion: str) -> dict[str, object]:
+    binner = RiskBands(
+        max_bins=5,
+        min_event_rate_diff=0.0,
+        missing_policy="merge",
+        missing_merge_criterion=criterion,
+        missing_merge_fallback="separate_bin",
+    )
+    binner.fit(df, y="target", column=MERGE_FEATURE, validate=True)
+    transformed = binner.transform(pd.DataFrame({MERGE_FEATURE: [np.nan, -5.0, 0.0, 5.0]}), validate=True)
+    transformed_woe = binner.transform(
+        pd.DataFrame({MERGE_FEATURE: [np.nan, -5.0, 0.0, 5.0]}),
+        return_woe=True,
+    )
+
+    with TemporaryDirectory(prefix=f"riskbands_missing_merge_{criterion}_") as tmpdir:
+        binner.export_bundle(tmpdir)
+        bundle = load_bundle(tmpdir)
+        bundle_summary = {
+            "missing_policy": bundle["missing_policy"],
+            "effective_missing_policy": bundle["effective_missing_policy"],
+            "missing_merge_criterion": bundle["missing_merge_criterion"],
+            "missing_merge_fallback": bundle["missing_merge_fallback"],
+            "missing_merge_candidates_rows": len(bundle["missing_merge_candidates"]),
+            "missing_merge_map": bundle["missing_merge_map"],
+        }
+
+    return {
+        "criterion": criterion,
+        "transformed": transformed,
+        "transformed_woe": transformed_woe,
+        "missing_profile": binner.missing_profile_.copy(),
+        "missing_decision_log": binner.missing_decision_log_.copy(),
+        "missing_merge_candidates": binner.missing_merge_candidates_.copy(),
+        "missing_merge_map": dict(binner.missing_merge_map_),
+        "bundle_summary": bundle_summary,
+        "binner": binner,
+    }
+
+
 def _show(title: str, value: object) -> None:
     print(f"\n=== {title} ===")
     print(value)
 
 
 def run_pandas_missing_policy_demo() -> dict[str, object]:
-    """Run standard, separate_bin and forbid examples without persistent files."""
+    """Run standard, separate_bin, forbid and merge examples without persistent files."""
 
     df = make_demo_frame()
+    merge_df = make_missing_merge_frame()
     standard = _fit_policy(df, "standard")
     separate = _fit_policy(df, "separate_bin")
+    merge_nearest_event_rate = _fit_merge_policy(merge_df, "nearest_event_rate")
+    merge_nearest_woe = _fit_merge_policy(merge_df, "nearest_woe")
 
     try:
         RiskBands(
@@ -127,6 +188,9 @@ def run_pandas_missing_policy_demo() -> dict[str, object]:
         "dataset": df,
         "standard": standard,
         "separate_bin": separate,
+        "merge_dataset": merge_df,
+        "merge_nearest_event_rate": merge_nearest_event_rate,
+        "merge_nearest_woe": merge_nearest_woe,
         "forbid_fit_error": forbid_fit_error,
         "forbid_transform_error": forbid_transform_error,
         "bundle_summary": bundle_summary,
@@ -143,6 +207,17 @@ def main() -> None:
         _show(f"{policy} transformed head", result["transformed_head"])
         _show(f"{policy} missing_profile_", result["missing_profile"])
         _show(f"{policy} missing_decision_log_", result["missing_decision_log"])
+
+    _show("Merge synthetic input", results["merge_dataset"].head(10))
+    for key in ["merge_nearest_event_rate", "merge_nearest_woe"]:
+        result = results[key]
+        _show(f"{key} transformed", result["transformed"])
+        _show(f"{key} transformed return_woe", result["transformed_woe"])
+        _show(f"{key} missing_profile_", result["missing_profile"])
+        _show(f"{key} missing_decision_log_", result["missing_decision_log"])
+        _show(f"{key} missing_merge_candidates_", result["missing_merge_candidates"])
+        _show(f"{key} missing_merge_map_", result["missing_merge_map"])
+        _show(f"{key} bundle summary", result["bundle_summary"])
 
     _show("forbid fit error", results["forbid_fit_error"])
     _show("forbid transform error", results["forbid_transform_error"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "riskbands"
-version = "2.2.0"
+version = "2.3.0"
 description = "Interpretable binning with temporal stability diagnostics for credit risk, PD, and scorecard workflows."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -2,6 +2,8 @@
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 
+import pandas as pd
+
 
 def _load_example_module(relative_path: str):
     root = Path(__file__).resolve().parents[1]
@@ -157,6 +159,9 @@ def test_missing_policy_pandas_example_flow_smoke():
         "dataset",
         "standard",
         "separate_bin",
+        "merge_dataset",
+        "merge_nearest_event_rate",
+        "merge_nearest_woe",
         "forbid_fit_error",
         "forbid_transform_error",
         "bundle_summary",
@@ -166,6 +171,21 @@ def test_missing_policy_pandas_example_flow_smoke():
     assert set(results["separate_bin"]["transformed_head"]["rating"].astype(str)) >= {"Missing"}
     assert "missing_policy='forbid'" in results["forbid_fit_error"]
     assert results["bundle_summary"]["missing_policy"] == "separate_bin"
+
+    for key, criterion in [
+        ("merge_nearest_event_rate", "nearest_event_rate"),
+        ("merge_nearest_woe", "nearest_woe"),
+    ]:
+        merge = results[key]
+        assert merge["missing_decision_log"].iloc[0]["action"] == "missing_merged"
+        assert merge["missing_decision_log"].iloc[0]["missing_merge_criterion"] == criterion
+        assert not merge["missing_merge_candidates"].empty
+        assert merge["missing_merge_map"]["score"] == merge["missing_decision_log"].iloc[0]["selected_bin_label"]
+        assert merge["transformed"].loc[0, "score"] == merge["missing_decision_log"].iloc[0]["selected_bin_label"]
+        assert merge["transformed"].loc[0, "score"] != "Missing"
+        assert pd.api.types.is_numeric_dtype(merge["transformed_woe"]["score"])
+        assert merge["bundle_summary"]["missing_policy"] == "merge"
+        assert merge["bundle_summary"]["missing_merge_criterion"] == criterion
 
 
 def test_missing_policy_pyspark_example_optional_guard(monkeypatch):
@@ -177,5 +197,3 @@ def test_missing_policy_pyspark_example_optional_guard(monkeypatch):
     results = module.run_pyspark_missing_policy_demo()
 
     assert results == {"skipped": True, "reason": "pyspark is not installed"}
-
-


### PR DESCRIPTION
Prepares RiskBands v2.3.0 release metadata, release notes, pt-BR/en documentation, missing merge examples, validation checklist, and packaging smoke evidence after the auditable missing merge policies sprints.