### PR TITLE
Add missing merge hardening and diagnostics

### DIFF
--- a/docs-site/src/content/docs/en/technical/examples.md
+++ b/docs-site/src/content/docs/en/technical/examples.md
@@ -37,6 +37,8 @@ auditable way without opaque imputation.
 
 - [pandas missing policy demo](https://github.com/joaaomaia/RiskBands/blob/main/examples/missing_policy/missing_policy_pandas_demo.py)
 - [PySpark missing policy demo](https://github.com/joaaomaia/RiskBands/blob/main/examples/missing_policy/missing_policy_pyspark_demo.py)
+- [Missing policy comparison diagnostic](https://github.com/joaaomaia/RiskBands/blob/main/examples/missing_policy/missing_policy_comparison_demo.py)
+- [Synthetic credit-risk missing merge example](https://github.com/joaaomaia/RiskBands/blob/main/examples/missing_policy/credit_risk_missing_merge_demo.py)
 
 They show:
 
@@ -50,6 +52,8 @@ They show:
 - `missing_merge_candidates_`
 - bundle fields for missing policy and missing merge
 - optional guard for PySpark
+- comparison across `standard`, `separate_bin`, `forbid`, `merge + nearest_event_rate`, and `merge + nearest_woe`
+- synthetic credit-risk data without real or sensitive records
 
 ### PD vintage champion/challenger
 

--- a/docs-site/src/content/docs/en/technical/missing-policy.md
+++ b/docs-site/src/content/docs/en/technical/missing-policy.md
@@ -60,6 +60,14 @@ and the learned routing map is stored in `missing_merge_map_`. `transform(...)`
 uses only the fit-time decision; it does not learn a new rule from application
 data.
 
+Compare merge against `separate_bin` before accepting the decision. The
+[`missing_policy_comparison_demo.py`](https://github.com/joaaomaia/RiskBands/blob/main/examples/missing_policy/missing_policy_comparison_demo.py)
+script builds a table with IV, number of bins, missing event rate, action,
+selected bin, distance, candidates, fallback, and a simple period metric. The
+[`credit_risk_missing_merge_demo.py`](https://github.com/joaaomaia/RiskBands/blob/main/examples/missing_policy/credit_risk_missing_merge_demo.py)
+script shows the same flow on synthetic credit data with `bureau_score`,
+`income`, `internal_rating`, `channel`, `product`, `vintage`, and `target`.
+
 ## pandas example
 
 The complete script is available at
@@ -119,6 +127,7 @@ It uses:
 - `missing_policy="separate_bin"`;
 - `transform(validate=True)`;
 - `missing_policy="forbid"` producing a clear error;
+- an explicit boundary for `missing_policy="merge"` in PySpark;
 - no UDF.
 
 ```bash

--- a/docs-site/src/content/docs/technical/examples.md
+++ b/docs-site/src/content/docs/technical/examples.md
@@ -37,6 +37,8 @@ forma auditavel sem imputacao opaca.
 
 - [Demo pandas de missing policy](https://github.com/joaaomaia/RiskBands/blob/main/examples/missing_policy/missing_policy_pandas_demo.py)
 - [Demo PySpark de missing policy](https://github.com/joaaomaia/RiskBands/blob/main/examples/missing_policy/missing_policy_pyspark_demo.py)
+- [Diagnostico comparativo de missing policy](https://github.com/joaaomaia/RiskBands/blob/main/examples/missing_policy/missing_policy_comparison_demo.py)
+- [Exemplo sintetico de credito com missing merge](https://github.com/joaaomaia/RiskBands/blob/main/examples/missing_policy/credit_risk_missing_merge_demo.py)
 
 Eles mostram:
 
@@ -50,6 +52,8 @@ Eles mostram:
 - `missing_merge_candidates_`
 - bundle com campos de missing policy e missing merge
 - guarda opcional para PySpark
+- comparacao entre `standard`, `separate_bin`, `forbid`, `merge + nearest_event_rate` e `merge + nearest_woe`
+- exemplo sintetico de risco de credito sem dados reais
 
 ### PD vintage champion challenger
 

--- a/docs-site/src/content/docs/technical/missing-policy.md
+++ b/docs-site/src/content/docs/technical/missing-policy.md
@@ -59,6 +59,15 @@ candidatos ficam em `missing_merge_candidates_`, e o mapa aprendido fica em
 `missing_merge_map_`. O `transform(...)` usa apenas essa decisao aprendida no
 fit; ele nao aprende regra nova com a base de aplicacao.
 
+Compare merge contra `separate_bin` antes de aceitar a decisao. O script
+[`missing_policy_comparison_demo.py`](https://github.com/joaaomaia/RiskBands/blob/main/examples/missing_policy/missing_policy_comparison_demo.py)
+gera uma tabela com IV, numero de bins, evento do missing, acao tomada, bin
+selecionado, distancia, candidatos, fallback e uma metrica simples por periodo.
+O script
+[`credit_risk_missing_merge_demo.py`](https://github.com/joaaomaia/RiskBands/blob/main/examples/missing_policy/credit_risk_missing_merge_demo.py)
+mostra o mesmo fluxo em dados sinteticos de credito com `bureau_score`,
+`income`, `internal_rating`, `channel`, `product`, `vintage` e `target`.
+
 ## Exemplo pandas
 
 O script completo esta em
@@ -118,6 +127,7 @@ Ele usa:
 - `missing_policy="separate_bin"`;
 - `transform(validate=True)`;
 - `missing_policy="forbid"` gerando erro claro;
+- boundary explicito para `missing_policy="merge"` em PySpark;
 - nenhum UDF.
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,8 @@ Entry point for the project documentation.
   v2.2.0 import, missing policies, pandas/PySpark, validation, and bundle guide.
 - [docs/missing_policy_user_guide.md](missing_policy_user_guide.md)
   Dedicated guide for `standard`, `separate_bin`, `forbid`, `merge`, pandas/PySpark examples, audit fields, and bundle reporting.
+- [docs/missing_policy_methodological_guide.md](missing_policy_methodological_guide.md)
+  Methodological guidance for choosing missing policies and reviewing merge decisions.
 - [docs/releases/2.3.0.md](releases/2.3.0.md)
   v2.3.0 release-prep notes for auditable missing merge policies.
 - [docs/missing_merge_nearest_event_rate_design.md](missing_merge_nearest_event_rate_design.md)
@@ -42,6 +44,10 @@ Entry point for the project documentation.
   Small pandas demo for missing-policy behavior, merge with nearest event rate and nearest WoE, audit fields, and bundle roundtrip.
 - [examples/missing_policy/missing_policy_pyspark_demo.py](../examples/missing_policy/missing_policy_pyspark_demo.py)
   Small optional PySpark demo for `separate_bin`, `forbid`, and `transform(validate=True)`.
+- [examples/missing_policy/missing_policy_comparison_demo.py](../examples/missing_policy/missing_policy_comparison_demo.py)
+  Comparative diagnostic for `standard`, `separate_bin`, `forbid`, and both merge criteria.
+- [examples/missing_policy/credit_risk_missing_merge_demo.py](../examples/missing_policy/credit_risk_missing_merge_demo.py)
+  Synthetic credit-risk example with informative missingness and auditable merge decisions.
 - [examples/pd_vintage_champion_challenger/pd_vintage_champion_challenger.py](../examples/pd_vintage_champion_challenger/pd_vintage_champion_challenger.py)
   Credit-risk / PD anchor example with vintages.
 

--- a/docs/missing_policy_methodological_guide.md
+++ b/docs/missing_policy_methodological_guide.md
@@ -1,0 +1,105 @@
+# Missing policy methodological guide
+
+This guide helps reviewers choose among the RiskBands missing-value policies in
+v2.3.0. It is methodological guidance, not a regulatory certification. Every
+choice should still be reviewed against the project data, controls, sampling
+design, and model-governance process.
+
+## Policy selection
+
+Use `missing_policy="standard"` when the current RiskBands treatment is the
+desired baseline, when compatibility is more important than explicit missing
+segmentation, or when the missing volume is known to be immaterial. `standard`
+is the default and should remain the first comparison point.
+
+Use `missing_policy="separate_bin"` when missingness is informative enough to
+monitor as its own segment. This is often the most transparent choice for model
+risk review because the missing group keeps its own volume, event rate, WoE,
+and IV contribution. It is also the safest contrast before considering merge.
+
+Use `missing_policy="forbid"` when missing values indicate an upstream data
+quality failure or when the modeling contract requires fully observed inputs.
+This policy is useful in production checks because it fails explicitly during
+`fit` or `transform` instead of silently routing missing values.
+
+Use `missing_policy="merge"` with
+`missing_merge_criterion="nearest_event_rate"` when the missing group should be
+audited but routed into the regular bin whose fit-time event rate is closest.
+This criterion is easy to explain in terms of observed bad-rate distance.
+
+Use `missing_policy="merge"` with `missing_merge_criterion="nearest_woe"` when
+the review needs the missing group routed by scorecard-similarity in WoE space.
+It can be more aligned with downstream scorecard interpretation, but it depends
+on finite and stable WoE estimates.
+
+Do not use merge just because it reduces the number of visible bins. Do not use
+merge when the missing group is large and materially different from every
+candidate, when the candidate distances are unstable, when the missing pattern
+may encode unavailable future information, or when separate monitoring is more
+defensible.
+
+## Reading the audit artifacts
+
+Start with `missing_profile_`. For each variable with missing values it records
+fit-time missing count, share, events, event rate, WoE when available, backend,
+policy, and merge status. Use this table to decide whether the missing group is
+rare, frequent, event-heavy, event-light, or operationally meaningful.
+
+Read `missing_decision_log_` next. For merge, it records the requested policy,
+criterion, fallback, selected bin, selected-bin event rate/WoE, distance metric,
+distance value, candidate count, tie-break fields, and whether fallback was
+used. This is the primary trace of the decision.
+
+Read `missing_merge_candidates_` when merge is used. It lists every regular
+candidate considered, the candidate rank, event rate, WoE, distance values,
+and selected flag. A defensible merge should have a selected candidate whose
+distance is explainable, not merely technically available.
+
+Compare every merge run against `separate_bin`. The separate-bin result shows
+what is lost when the missing group is no longer visible as a final bin. Review
+changes in IV, bin count, event rate, WoE, and any stability metric by period.
+
+## Risk controls
+
+Leakage: missingness can encode process timing, data availability, channel
+behavior, or downstream decisions. If missingness is caused by information that
+would not exist at decision time, neither separate-bin nor merge makes the
+feature safe. Fix the data contract first.
+
+Small samples: event-rate and WoE distances become fragile when either the
+missing group or the candidate bins have low counts. Treat tie-breaks and small
+distance differences as review signals, not automatic approval.
+
+Very rare missing: a rare missing group may look close to a candidate by chance.
+Prefer `standard` or `forbid` when missing is unexpected; prefer
+`separate_bin` when the rare group still needs monitoring.
+
+Very frequent missing: a frequent missing group can dominate the merged bin and
+change its event rate, WoE, and IV. Review `metrics_before`,
+`metrics_after`, `bin_summary`, and `fit_profile_` before accepting the merge.
+
+Fallbacks: `missing_merge_fallback="separate_bin"` keeps transform-time missing
+as `Missing` when no fit-time merge decision exists.
+`missing_merge_fallback="raise"` fails explicitly in that situation. Pick the fallback based on the
+production contract, not convenience.
+
+## PySpark boundary
+
+In v2.3.0, full PySpark merge is intentionally not implemented. PySpark fit or
+transform with `missing_policy="merge"` raises an explicit
+`NotImplementedError`. PySpark remains available for supported policies such as
+`standard`, `separate_bin`, and `forbid`, including validation paths covered by
+the test suite.
+
+## Not implemented in this release
+
+The following features are future work and should not be documented as
+available behavior:
+
+- `temporal_stable`;
+- `monotonic_neighbor`;
+- full PySpark missing merge.
+
+Use the current audit artifacts to compare policies today. Do not infer that
+future criteria already exist, and do not create local policy names outside the
+public v2.3.0 contract.

--- a/examples/missing_policy/_comparison_utils.py
+++ b/examples/missing_policy/_comparison_utils.py
@@ -1,0 +1,237 @@
+"""Utilities for synthetic missing-policy comparison examples."""
+
+from __future__ import annotations
+
+from tempfile import TemporaryDirectory
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from riskbands import RiskBands
+from riskbands.reporting import load_bundle
+
+POLICY_CONFIGS: tuple[dict[str, Any], ...] = (
+    {"name": "standard", "kwargs": {"missing_policy": "standard"}},
+    {"name": "separate_bin", "kwargs": {"missing_policy": "separate_bin"}},
+    {
+        "name": "merge_nearest_event_rate",
+        "kwargs": {
+            "missing_policy": "merge",
+            "missing_merge_criterion": "nearest_event_rate",
+            "missing_merge_fallback": "separate_bin",
+        },
+    },
+    {
+        "name": "merge_nearest_woe",
+        "kwargs": {
+            "missing_policy": "merge",
+            "missing_merge_criterion": "nearest_woe",
+            "missing_merge_fallback": "separate_bin",
+        },
+    },
+    {"name": "forbid", "kwargs": {"missing_policy": "forbid"}},
+)
+
+
+def make_policy_comparison_frame() -> pd.DataFrame:
+    """Build a deterministic credit-like single-feature frame with vintages."""
+
+    rows: list[dict[str, Any]] = []
+    vintages = ["2025Q1", "2025Q2", "2025Q3", "2025Q4"]
+    regular_specs = [
+        (420.0, 0.36),
+        (520.0, 0.24),
+        (620.0, 0.12),
+        (720.0, 0.06),
+    ]
+    for vintage_idx, vintage in enumerate(vintages):
+        drift = (vintage_idx - 1.5) * 0.015
+        for score, base_rate in regular_specs:
+            n = 24
+            event_rate = min(max(base_rate + drift, 0.02), 0.95)
+            events = int(round(n * event_rate))
+            for row_idx in range(n):
+                rows.append(
+                    {
+                        "score": score + (row_idx % 3) * 2.0,
+                        "vintage": vintage,
+                        "target": int(row_idx < events),
+                    }
+                )
+
+        missing_n = 14
+        missing_rate = min(max(0.23 + drift, 0.02), 0.95)
+        missing_events = int(round(missing_n * missing_rate))
+        for row_idx in range(missing_n):
+            rows.append(
+                {
+                    "score": np.nan,
+                    "vintage": vintage,
+                    "target": int(row_idx < missing_events),
+                }
+            )
+
+    return pd.DataFrame(rows)
+
+
+def _first_record(frame: pd.DataFrame) -> dict[str, Any]:
+    if frame is None or frame.empty:
+        return {}
+    return frame.iloc[0].to_dict()
+
+
+def _bool_or_none(value: Any) -> bool | None:
+    if value is None or (isinstance(value, float) and np.isnan(value)):
+        return None
+    return bool(value)
+
+
+def compute_time_stability_metric(
+    source: pd.DataFrame,
+    transformed: pd.DataFrame,
+    *,
+    feature: str,
+    target: str,
+    time_col: str | None,
+) -> float | None:
+    """Mean range of event rates across periods for transformed bins."""
+
+    if time_col is None or time_col not in source.columns:
+        return None
+    tmp = pd.DataFrame(
+        {
+            "bin": transformed[feature].astype(str),
+            "target": source[target].to_numpy(),
+            "time": source[time_col].astype(str).to_numpy(),
+        }
+    )
+    rates = tmp.groupby(["bin", "time"], dropna=False)["target"].mean().unstack("time")
+    if rates.empty:
+        return None
+    return float((rates.max(axis=1) - rates.min(axis=1)).mean())
+
+
+def summarize_policy_result(
+    *,
+    policy_name: str,
+    binner: RiskBands | None,
+    source: pd.DataFrame,
+    transformed: pd.DataFrame | None,
+    feature: str,
+    target: str,
+    time_col: str | None,
+    error: str | None = None,
+) -> dict[str, Any]:
+    if binner is None:
+        return {
+            "policy": policy_name,
+            "merge_criterion": None,
+            "n_bins": None,
+            "iv": None,
+            "missing_event_rate": None,
+            "missing_action": "error",
+            "selected_bin": None,
+            "distance": None,
+            "candidate_count": 0,
+            "fallback_used": None,
+            "time_stability_metric": None,
+            "bundle_export_possible": False,
+            "error": error,
+        }
+
+    decision = _first_record(getattr(binner, "missing_decision_log_", pd.DataFrame()))
+    profile = _first_record(getattr(binner, "missing_profile_", pd.DataFrame()))
+    bundle_export_possible = False
+    try:
+        with TemporaryDirectory(prefix="riskbands_missing_policy_comparison_") as tmpdir:
+            binner.export_bundle(tmpdir)
+            loaded = load_bundle(tmpdir)
+            bundle_export_possible = loaded["missing_policy"] == binner.missing_policy_
+    except Exception:
+        bundle_export_possible = False
+
+    return {
+        "policy": policy_name,
+        "merge_criterion": getattr(binner, "missing_merge_criterion_", None),
+        "n_bins": int(len(binner.bin_summary)),
+        "iv": float(getattr(binner, "iv_by_variable_", pd.Series(dtype=float)).get(feature, np.nan)),
+        "missing_event_rate": profile.get("event_rate_missing_fit"),
+        "missing_action": decision.get("action"),
+        "selected_bin": decision.get("selected_bin_label"),
+        "distance": decision.get("distance"),
+        "candidate_count": int(decision.get("candidate_count") or 0),
+        "fallback_used": _bool_or_none(decision.get("fallback_used")),
+        "time_stability_metric": compute_time_stability_metric(
+            source,
+            transformed,
+            feature=feature,
+            target=target,
+            time_col=time_col,
+        )
+        if transformed is not None
+        else None,
+        "bundle_export_possible": bundle_export_possible,
+        "error": error,
+    }
+
+
+def run_policy_comparison(
+    df: pd.DataFrame | None = None,
+    *,
+    feature: str = "score",
+    target: str = "target",
+    time_col: str | None = "vintage",
+) -> dict[str, Any]:
+    """Compare standard, separate, forbid and merge policies on synthetic data."""
+
+    df = make_policy_comparison_frame() if df is None else df.copy()
+    rows: list[dict[str, Any]] = []
+    details: dict[str, dict[str, Any]] = {}
+
+    for config in POLICY_CONFIGS:
+        name = config["name"]
+        kwargs = dict(config["kwargs"])
+        binner = RiskBands(max_bins=5, min_event_rate_diff=0.0, **kwargs)
+        try:
+            binner.fit(df, y=target, column=feature, time_col=time_col)
+            transformed = binner.transform(df[[feature]])
+            rows.append(
+                summarize_policy_result(
+                    policy_name=name,
+                    binner=binner,
+                    source=df,
+                    transformed=transformed,
+                    feature=feature,
+                    target=target,
+                    time_col=time_col,
+                )
+            )
+            details[name] = {
+                "binner": binner,
+                "transformed_head": transformed.head(8),
+                "missing_profile": binner.missing_profile_.copy(),
+                "missing_decision_log": binner.missing_decision_log_.copy(),
+                "missing_merge_candidates": getattr(
+                    binner,
+                    "missing_merge_candidates_",
+                    pd.DataFrame(),
+                ).copy(),
+            }
+        except ValueError as exc:
+            rows.append(
+                summarize_policy_result(
+                    policy_name=name,
+                    binner=None,
+                    source=df,
+                    transformed=None,
+                    feature=feature,
+                    target=target,
+                    time_col=time_col,
+                    error=str(exc),
+                )
+            )
+            details[name] = {"error": str(exc)}
+
+    comparison = pd.DataFrame(rows)
+    return {"dataset": df, "comparison": comparison, "details": details}

--- a/examples/missing_policy/credit_risk_missing_merge_demo.py
+++ b/examples/missing_policy/credit_risk_missing_merge_demo.py
@@ -1,0 +1,218 @@
+"""Synthetic credit-risk example for auditable missing merge policies."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from riskbands import RiskBands
+
+FEATURES = ["bureau_score", "income", "internal_rating", "channel", "product"]
+CATEGORICAL_FEATURES = ["internal_rating", "channel", "product"]
+
+
+def make_credit_risk_missing_frame(n: int = 720) -> pd.DataFrame:
+    """Create deterministic synthetic credit-risk data with informative missingness."""
+
+    channels = ["branch", "digital", "partner"]
+    products = ["card", "loan", "overdraft"]
+    ratings = ["A", "B", "C", "D"]
+    vintages = ["2024Q1", "2024Q2", "2024Q3", "2024Q4", "2025Q1", "2025Q2"]
+
+    rows: list[dict[str, Any]] = []
+    for idx in range(n):
+        channel = channels[idx % len(channels)]
+        product = products[(idx // 3) % len(products)]
+        vintage = vintages[(idx // 17) % len(vintages)]
+        rating = ratings[(idx // 11) % len(ratings)]
+
+        score = 430 + (idx * 37) % 360
+        income = 1800 + (idx * 911) % 13800
+        risk = 0.04 + max(0.0, (680 - score) / 1500)
+        risk += {"A": 0.00, "B": 0.035, "C": 0.075, "D": 0.135}[rating]
+        risk += {"card": 0.015, "loan": 0.025, "overdraft": 0.055}[product]
+        risk += {"branch": -0.005, "digital": 0.015, "partner": 0.035}[channel]
+        risk += (vintages.index(vintage) - 2.5) * 0.005
+
+        bureau_missing = (channel == "partner" and idx % 4 != 0) or (product == "overdraft" and idx % 9 == 0)
+        income_missing = (channel == "digital" and idx % 5 == 0) or (income < 2800 and idx % 2 == 0)
+        rating_missing = (channel == "partner" and product == "card") or (idx % 53 == 0)
+
+        if bureau_missing:
+            risk += 0.055
+            score_value = np.nan
+        else:
+            score_value = float(score)
+        if income_missing:
+            risk += 0.035
+            income_value = np.nan
+        else:
+            income_value = float(income)
+            risk += max(0.0, (4500 - income) / 50000)
+        if rating_missing:
+            risk += 0.045
+            rating_value = None
+        else:
+            rating_value = rating
+
+        risk = min(max(risk, 0.015), 0.72)
+        target = int(((idx * 73) % 1000) / 1000 < risk)
+        rows.append(
+            {
+                "bureau_score": score_value,
+                "income": income_value,
+                "internal_rating": rating_value,
+                "channel": channel,
+                "product": product,
+                "vintage": vintage,
+                "target": target,
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+def _fit_policy(df: pd.DataFrame, *, policy: str, criterion: str | None = None) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {"missing_policy": policy}
+    if criterion is not None:
+        kwargs["missing_merge_criterion"] = criterion
+        kwargs["missing_merge_fallback"] = "separate_bin"
+    binner = RiskBands(
+        max_bins=5,
+        min_event_rate_diff=0.0,
+        force_categorical=CATEGORICAL_FEATURES,
+        **kwargs,
+    ).fit(df, y="target", columns=FEATURES, time_col="vintage")
+    transformed = binner.transform(df[FEATURES])
+    transformed_woe = binner.transform(df[FEATURES], return_woe=True)
+    return {
+        "policy": policy,
+        "criterion": criterion,
+        "binner": binner,
+        "transformed_head": transformed.head(8),
+        "transformed_woe_head": transformed_woe.head(8),
+        "missing_profile": binner.missing_profile_.copy(),
+        "missing_decision_log": binner.missing_decision_log_.copy(),
+        "missing_merge_candidates": getattr(binner, "missing_merge_candidates_", pd.DataFrame()).copy(),
+    }
+
+
+def _decision_for_variable(decisions: pd.DataFrame, variable: str) -> dict[str, Any]:
+    rows = decisions.loc[decisions["variable"].astype(str) == variable]
+    if rows.empty:
+        return {}
+    return rows.iloc[0].to_dict()
+
+
+def _profile_for_variable(profile: pd.DataFrame, variable: str) -> dict[str, Any]:
+    rows = profile.loc[profile["variable"].astype(str) == variable]
+    if rows.empty:
+        return {}
+    return rows.iloc[0].to_dict()
+
+
+def _comparison_rows(results: dict[str, dict[str, Any]]) -> pd.DataFrame:
+    rows = []
+    for name, result in results.items():
+        binner = result["binner"]
+        decisions = result["missing_decision_log"]
+        profile = result["missing_profile"]
+        for variable in FEATURES:
+            decision = _decision_for_variable(decisions, variable)
+            missing_profile = _profile_for_variable(profile, variable)
+            bin_rows = binner.bin_summary.loc[binner.bin_summary["variable"].astype(str) == variable]
+            rows.append(
+                {
+                    "policy": name,
+                    "merge_criterion": result["criterion"],
+                    "variable": variable,
+                    "n_bins": int(len(bin_rows)),
+                    "iv": float(getattr(binner, "iv_by_variable_", pd.Series(dtype=float)).get(variable, np.nan)),
+                    "missing_event_rate": missing_profile.get("event_rate_missing_fit"),
+                    "missing_action": decision.get("action"),
+                    "selected_bin": decision.get("selected_bin_label"),
+                    "distance": decision.get("distance"),
+                    "candidate_count": int(decision.get("candidate_count") or 0),
+                    "fallback_used": bool(decision.get("fallback_used"))
+                    if decision.get("fallback_used") is not None
+                    else None,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def _missing_rate_table(df: pd.DataFrame) -> pd.DataFrame:
+    rows = []
+    for variable in FEATURES:
+        missing_mask = df[variable].isna()
+        rows.append(
+            {
+                "variable": variable,
+                "missing_count": int(missing_mask.sum()),
+                "missing_share": float(missing_mask.mean()),
+                "target_rate_when_missing": float(df.loc[missing_mask, "target"].mean())
+                if bool(missing_mask.any())
+                else None,
+                "target_rate_when_observed": float(df.loc[~missing_mask, "target"].mean())
+                if bool((~missing_mask).any())
+                else None,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _method_notes() -> list[str]:
+    return [
+        "Use separate_bin when missingness is itself a defensible segment to monitor.",
+        "Use merge only after comparing it against separate_bin and reviewing the candidate distances.",
+        "Prefer nearest_event_rate for direct event-rate explanations; "
+        "prefer nearest_woe for scorecard-similarity review.",
+        "Do not treat this synthetic example as regulatory validation or as evidence that merge is always better.",
+    ]
+
+
+def run_credit_risk_missing_merge_demo() -> dict[str, object]:
+    """Run the credit-risk missing merge demo and return all audit tables."""
+
+    df = make_credit_risk_missing_frame()
+    results = {
+        "separate_bin": _fit_policy(df, policy="separate_bin"),
+        "merge_nearest_event_rate": _fit_policy(df, policy="merge", criterion="nearest_event_rate"),
+        "merge_nearest_woe": _fit_policy(df, policy="merge", criterion="nearest_woe"),
+    }
+    return {
+        "dataset": df,
+        "missing_rates": _missing_rate_table(df),
+        "policy_results": results,
+        "comparison": _comparison_rows(results),
+        "method_notes": _method_notes(),
+    }
+
+
+def _show(title: str, value: object) -> None:
+    print(f"\n=== {title} ===")
+    print(value)
+
+
+def main() -> None:
+    pd.set_option("display.max_columns", 50)
+    pd.set_option("display.width", 180)
+
+    results = run_credit_risk_missing_merge_demo()
+    _show("Synthetic credit-risk data sample", results["dataset"].head(12))
+    _show("Missing rates", results["missing_rates"])
+    _show("Policy comparison", results["comparison"])
+
+    for key in ["separate_bin", "merge_nearest_event_rate", "merge_nearest_woe"]:
+        policy_result = results["policy_results"][key]
+        _show(f"{key} missing_profile_", policy_result["missing_profile"])
+        _show(f"{key} missing_decision_log_", policy_result["missing_decision_log"])
+        _show(f"{key} missing_merge_candidates_", policy_result["missing_merge_candidates"])
+
+    _show("Method notes", pd.Series(results["method_notes"], name="note"))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/missing_policy/missing_policy_comparison_demo.py
+++ b/examples/missing_policy/missing_policy_comparison_demo.py
@@ -1,0 +1,61 @@
+"""Compare RiskBands missing policies on a deterministic synthetic dataset."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _comparison_utils import run_policy_comparison  # noqa: E402
+
+
+def _show(title: str, value: object) -> None:
+    print(f"\n=== {title} ===")
+    print(value)
+
+
+def run_missing_policy_comparison_demo() -> dict[str, object]:
+    """Run a side-by-side diagnostic for standard, separate, merge and forbid."""
+
+    results = run_policy_comparison()
+    comparison = results["comparison"].copy()
+    ordered_columns = [
+        "policy",
+        "merge_criterion",
+        "n_bins",
+        "iv",
+        "missing_event_rate",
+        "missing_action",
+        "selected_bin",
+        "distance",
+        "candidate_count",
+        "fallback_used",
+        "time_stability_metric",
+        "bundle_export_possible",
+        "error",
+    ]
+    results["comparison"] = comparison.loc[:, ordered_columns]
+    return results
+
+
+def main() -> None:
+    pd.set_option("display.max_columns", 40)
+    pd.set_option("display.width", 160)
+
+    results = run_missing_policy_comparison_demo()
+    _show("Synthetic data sample", results["dataset"].head(10))
+    _show("Policy comparison", results["comparison"])
+
+    for key in ["merge_nearest_event_rate", "merge_nearest_woe"]:
+        detail = results["details"][key]
+        _show(f"{key} missing_decision_log_", detail["missing_decision_log"])
+        _show(f"{key} missing_merge_candidates_", detail["missing_merge_candidates"])
+
+    _show("forbid expected error", results["details"]["forbid"]["error"])
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -1,4 +1,4 @@
-﻿import sys
+import sys
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 
@@ -186,6 +186,69 @@ def test_missing_policy_pandas_example_flow_smoke():
         assert pd.api.types.is_numeric_dtype(merge["transformed_woe"]["score"])
         assert merge["bundle_summary"]["missing_policy"] == "merge"
         assert merge["bundle_summary"]["missing_merge_criterion"] == criterion
+
+
+def test_missing_policy_comparison_example_flow_smoke():
+    module = _load_example_module(
+        "examples/missing_policy/missing_policy_comparison_demo.py"
+    )
+
+    results = module.run_missing_policy_comparison_demo()
+    comparison = results["comparison"]
+
+    assert {"dataset", "comparison", "details"} <= set(results)
+    assert {
+        "standard",
+        "separate_bin",
+        "merge_nearest_event_rate",
+        "merge_nearest_woe",
+        "forbid",
+    } == set(comparison["policy"])
+    assert comparison.loc[
+        comparison["policy"].eq("merge_nearest_event_rate"),
+        "merge_criterion",
+    ].iloc[0] == "nearest_event_rate"
+    assert comparison.loc[
+        comparison["policy"].eq("merge_nearest_woe"),
+        "merge_criterion",
+    ].iloc[0] == "nearest_woe"
+    assert comparison["bundle_export_possible"].fillna(False).sum() >= 4
+    assert "missing_policy='forbid'" in results["details"]["forbid"]["error"]
+
+
+def test_credit_risk_missing_merge_example_flow_smoke():
+    module = _load_example_module(
+        "examples/missing_policy/credit_risk_missing_merge_demo.py"
+    )
+
+    results = module.run_credit_risk_missing_merge_demo()
+    comparison = results["comparison"]
+
+    assert {"dataset", "missing_rates", "policy_results", "comparison", "method_notes"} <= set(results)
+    assert {"bureau_score", "income", "internal_rating"} <= set(
+        results["missing_rates"].loc[
+            results["missing_rates"]["missing_count"].gt(0),
+            "variable",
+        ]
+    )
+    assert {
+        "separate_bin",
+        "merge_nearest_event_rate",
+        "merge_nearest_woe",
+    } == set(comparison["policy"])
+    for key, criterion in [
+        ("merge_nearest_event_rate", "nearest_event_rate"),
+        ("merge_nearest_woe", "nearest_woe"),
+    ]:
+        policy_result = results["policy_results"][key]
+        assert policy_result["criterion"] == criterion
+        assert not policy_result["missing_profile"].empty
+        assert not policy_result["missing_merge_candidates"].empty
+        assert set(policy_result["missing_decision_log"]["action"]) >= {
+            "missing_merged",
+            "no_missing_detected",
+        }
+    assert len(results["method_notes"]) >= 3
 
 
 def test_missing_policy_pyspark_example_optional_guard(monkeypatch):

--- a/tests/test_missing_merge_hardening_edge_cases.py
+++ b/tests/test_missing_merge_hardening_edge_cases.py
@@ -1,0 +1,342 @@
+import json
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from riskbands import RiskBands
+
+
+def _block(value, n, events):
+    return [value] * n, [1] * events + [0] * (n - events)
+
+
+def make_numeric_frame(*, missing_events=12, missing_non_events=12, regular_specs=None):
+    regular_specs = regular_specs or [
+        (-5.0, 40, 4),
+        (-1.0, 40, 16),
+        (1.0, 40, 24),
+        (5.0, 40, 36),
+    ]
+    score = []
+    target = []
+    for value, n, events in regular_specs:
+        values, outcomes = _block(value, n, events)
+        score.extend(values)
+        target.extend(outcomes)
+    score.extend([np.nan] * (missing_events + missing_non_events))
+    target.extend([1] * missing_events + [0] * missing_non_events)
+    return pd.DataFrame({"score": score, "target": target})
+
+
+def fit_numeric_merge(df, *, criterion="nearest_event_rate", **kwargs):
+    binner = RiskBands(
+        max_bins=5,
+        min_event_rate_diff=0.0,
+        missing_policy="merge",
+        missing_merge_criterion=criterion,
+        **kwargs,
+    )
+    return binner.fit(df, y="target", column="score")
+
+
+def selected_candidate(binner):
+    selected = binner.missing_merge_candidates_.loc[binner.missing_merge_candidates_["selected"]]
+    assert len(selected) == 1
+    return selected.iloc[0]
+
+
+def row_for_label(df, label_column, label):
+    rows = df.loc[df[label_column].map(str) == str(label)]
+    assert len(rows) == 1
+    return rows.iloc[0]
+
+
+def make_manual_profile(*, regular_rows):
+    rows = [
+        {
+            "variable": "score",
+            "bin_id": "missing",
+            "bin_label": "Missing",
+            "bin_order": 99,
+            "n": 20,
+            "events": 10,
+            "non_events": 10,
+            "event_rate": 0.5,
+            "share": 0.25,
+            "woe": 0.0,
+            "is_missing_bin": True,
+            "is_special_bin": False,
+            "is_regular_bin": False,
+        }
+    ]
+    rows.extend(regular_rows)
+    return pd.DataFrame(rows)
+
+
+def regular_profile_row(label, *, n, events, event_rate=None, woe=0.0, order=0):
+    event_rate = events / n if event_rate is None else event_rate
+    return {
+        "variable": "score",
+        "bin_id": label,
+        "bin_label": label,
+        "bin_order": order,
+        "n": n,
+        "events": events,
+        "non_events": n - events,
+        "event_rate": event_rate,
+        "share": n / 80,
+        "woe": woe,
+        "is_missing_bin": False,
+        "is_special_bin": False,
+        "is_regular_bin": True,
+    }
+
+
+def build_manual_audit(profile, *, criterion="nearest_event_rate", fallback="separate_bin"):
+    binner = RiskBands(
+        missing_policy="merge",
+        missing_merge_criterion=criterion,
+        missing_merge_fallback=fallback,
+    )
+    binner.feature_names_in_ = ["score"]
+    total_regular = int(profile.loc[~profile["is_missing_bin"], "n"].sum())
+    X = pd.DataFrame({"score": [np.nan] * 20 + [0.0] * total_regular})
+    y = pd.Series([0, 1] * ((len(X) + 1) // 2), name="target").iloc[: len(X)]
+    binner._build_missing_merge_audit_from_fit(X, y, profile, backend="pandas")
+    return binner
+
+
+@pytest.mark.parametrize(
+    ("missing_events", "missing_non_events", "expected_n"),
+    [
+        (1, 0, 1),
+        (120, 40, 160),
+    ],
+)
+def test_nearest_event_rate_handles_very_rare_and_very_frequent_missing(
+    missing_events,
+    missing_non_events,
+    expected_n,
+):
+    df = make_numeric_frame(
+        missing_events=missing_events,
+        missing_non_events=missing_non_events,
+    )
+    binner = fit_numeric_merge(df)
+
+    decision = binner.missing_decision_log_.iloc[0]
+    profile = binner.missing_profile_.iloc[0]
+
+    assert decision["action"] == "missing_merged"
+    assert decision["candidate_count"] >= 1
+    assert int(profile["n_missing_fit"]) == expected_n
+    assert profile["merge_status"] == "merged"
+
+
+@pytest.mark.parametrize(
+    ("missing_events", "missing_non_events", "expected_rate"),
+    [
+        (0, 24, 0.0),
+        (24, 0, 1.0),
+    ],
+)
+def test_zero_or_all_event_missing_groups_still_route_and_return_woe(
+    missing_events,
+    missing_non_events,
+    expected_rate,
+):
+    df = make_numeric_frame(
+        missing_events=missing_events,
+        missing_non_events=missing_non_events,
+    )
+    binner = fit_numeric_merge(df)
+
+    transformed_woe = binner.transform(pd.DataFrame({"score": [np.nan, -5.0]}), return_woe=True)
+
+    assert binner.missing_profile_.iloc[0]["event_rate_missing_fit"] == pytest.approx(expected_rate)
+    assert binner.missing_decision_log_.iloc[0]["action"] == "missing_merged"
+    assert pd.api.types.is_numeric_dtype(transformed_woe["score"])
+    assert np.isfinite(float(transformed_woe.loc[0, "score"]))
+
+
+def test_missing_event_rate_equal_to_candidate_records_zero_distance():
+    df = make_numeric_frame(
+        missing_events=12,
+        missing_non_events=12,
+        regular_specs=[
+            (-5.0, 40, 4),
+            (-1.0, 40, 20),
+            (1.0, 40, 28),
+            (5.0, 40, 36),
+        ],
+    )
+    binner = fit_numeric_merge(df)
+    candidate = selected_candidate(binner)
+
+    assert candidate["missing_event_rate"] == pytest.approx(candidate["candidate_event_rate"])
+    assert candidate["distance_event_rate"] == pytest.approx(0.0)
+    assert binner.missing_decision_log_.iloc[0]["distance"] == pytest.approx(0.0)
+
+
+def test_nearest_event_rate_tie_break_is_deterministic():
+    profile = make_manual_profile(
+        regular_rows=[
+            regular_profile_row("A", n=20, events=8, event_rate=0.4, woe=-0.5, order=0),
+            regular_profile_row("B", n=40, events=24, event_rate=0.6, woe=0.5, order=1),
+        ]
+    )
+    binner = build_manual_audit(profile)
+    decision = binner.missing_decision_log_.iloc[0]
+    candidate = selected_candidate(binner)
+
+    assert bool(decision["tie_detected"]) is True
+    assert bool(decision["tie_break_applied"]) is True
+    assert candidate["candidate_bin_label"] == "B"
+    assert candidate["candidate_n"] == 40
+    assert "candidate_n desc" in decision["tie_break_rule"]
+
+
+def test_nearest_woe_tie_break_is_deterministic():
+    profile = make_manual_profile(
+        regular_rows=[
+            regular_profile_row("A", n=20, events=8, event_rate=0.4, woe=-1.0, order=0),
+            regular_profile_row("B", n=40, events=24, event_rate=0.6, woe=1.0, order=1),
+        ]
+    )
+    binner = build_manual_audit(profile, criterion="nearest_woe")
+    decision = binner.missing_decision_log_.iloc[0]
+    candidate = selected_candidate(binner)
+
+    assert bool(decision["tie_detected"]) is True
+    assert candidate["candidate_bin_label"] == "B"
+    assert candidate["distance_woe"] == pytest.approx(1.0)
+
+
+def test_single_candidate_bin_is_selected_without_tie():
+    profile = make_manual_profile(
+        regular_rows=[
+            regular_profile_row("Only regular bin", n=40, events=20, event_rate=0.5, woe=0.0)
+        ]
+    )
+    binner = build_manual_audit(profile)
+    decision = binner.missing_decision_log_.iloc[0]
+    candidate = selected_candidate(binner)
+
+    assert decision["action"] == "missing_merged"
+    assert decision["candidate_count"] == 1
+    assert bool(decision["tie_detected"]) is False
+    assert candidate["candidate_bin_label"] == "Only regular bin"
+
+
+def test_no_regular_candidate_uses_separate_bin_fallback():
+    profile = make_manual_profile(regular_rows=[])
+    binner = build_manual_audit(profile, fallback="separate_bin")
+    decision = binner.missing_decision_log_.iloc[0]
+
+    assert decision["action"] == "missing_kept_separate"
+    assert decision["status"] == "kept_separate"
+    assert decision["reason"] == "no_regular_candidate_bins"
+    assert bool(decision["fallback_used"]) is True
+    assert binner.missing_merge_candidates_.empty
+    assert binner.missing_merge_map_ == {}
+
+
+def test_no_regular_candidate_raise_fallback_errors():
+    profile = make_manual_profile(regular_rows=[])
+
+    with pytest.raises(ValueError, match="no regular candidate bin"):
+        build_manual_audit(profile, fallback="raise")
+
+
+def test_categorical_missing_with_rare_category_keeps_merge_auditable():
+    rating = []
+    target = []
+    for category, n, events in [
+        ("A", 40, 4),
+        ("B", 40, 20),
+        ("C", 40, 32),
+        ("Rare", 2, 1),
+    ]:
+        rating.extend([category] * n)
+        target.extend([1] * events + [0] * (n - events))
+    rating.extend([None] * 20)
+    target.extend([1] * 10 + [0] * 10)
+    df = pd.DataFrame({"rating": rating, "target": target})
+
+    binner = RiskBands(
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        force_categorical=["rating"],
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    ).fit(df, y="target", column="rating")
+    transformed = binner.transform(pd.DataFrame({"rating": [None, "Rare"]}))
+
+    assert binner.missing_decision_log_.iloc[0]["action"] == "missing_merged"
+    assert not binner.missing_merge_candidates_.empty
+    assert transformed.loc[0, "rating"] == binner.missing_decision_log_.iloc[0]["selected_bin_label"]
+
+
+def test_force_numeric_missing_merge_routes_string_numeric_inputs():
+    df = make_numeric_frame()
+    df["score"] = df["score"].map(lambda value: None if pd.isna(value) else f"{value:.1f}")
+
+    binner = RiskBands(
+        max_bins=5,
+        min_event_rate_diff=0.0,
+        force_numeric=["score"],
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    ).fit(df, y="target", column="score")
+    transformed = binner.transform(pd.DataFrame({"score": [None, "-5.0"]}))
+
+    assert binner.missing_decision_log_.iloc[0]["action"] == "missing_merged"
+    assert transformed.loc[0, "score"] == binner.missing_decision_log_.iloc[0]["selected_bin_label"]
+    assert transformed.loc[0, "score"] != "Missing"
+
+
+@pytest.mark.parametrize("fallback", ["separate_bin", "raise"])
+def test_transform_missing_unobserved_during_fit_uses_configured_fallback(fallback):
+    df = make_numeric_frame(missing_events=0, missing_non_events=0)
+    binner = fit_numeric_merge(df, missing_merge_fallback=fallback)
+    transform_df = pd.DataFrame({"score": [np.nan, -5.0]})
+
+    assert binner.missing_decision_log_.iloc[0]["action"] == "no_missing_detected"
+    assert binner.missing_merge_map_ == {}
+    if fallback == "separate_bin":
+        transformed = binner.transform(transform_df)
+        assert transformed.loc[0, "score"] == "Missing"
+        assert binner.missing_transform_fallback_log_.iloc[0]["action"] == (
+            "missing_transform_fallback_separate_bin"
+        )
+    else:
+        with pytest.raises(ValueError, match="no missing merge decision was learned"):
+            binner.transform(transform_df)
+        assert binner.missing_transform_fallback_log_.iloc[0]["action"] == (
+            "missing_transform_fallback_raise"
+        )
+
+
+def test_missing_merge_candidates_are_json_serializable_in_extreme_case():
+    binner = fit_numeric_merge(make_numeric_frame(missing_events=24, missing_non_events=0))
+
+    payload = binner.missing_merge_candidates_.to_dict(orient="records")
+
+    assert payload
+    json.dumps(payload)
+
+
+def test_bin_summary_and_fit_profile_remain_consistent_after_merge():
+    binner = fit_numeric_merge(make_numeric_frame())
+    selected_label = binner.missing_decision_log_.iloc[0]["selected_bin_label"]
+    summary_row = row_for_label(binner.bin_summary, "bin", selected_label)
+    profile_row = row_for_label(binner.fit_profile_, "bin_label", selected_label)
+
+    assert "Missing" not in set(binner.bin_summary["bin"].astype(str))
+    assert summary_row["count"] == pytest.approx(profile_row["n"])
+    assert summary_row["event"] == pytest.approx(profile_row["events"])
+    assert summary_row["non_event"] == pytest.approx(profile_row["non_events"])
+    assert summary_row["event_rate"] == pytest.approx(profile_row["event_rate"])
+    assert summary_row["woe"] == pytest.approx(profile_row["woe"])
+    assert summary_row["iv_component"] == pytest.approx(profile_row["iv_component"])

--- a/tests/test_missing_merge_hardening_regression.py
+++ b/tests/test_missing_merge_hardening_regression.py
@@ -1,0 +1,143 @@
+import json
+
+import numpy as np
+import pandas as pd
+import pytest
+from pandas.testing import assert_frame_equal
+
+from riskbands import RiskBands
+from riskbands.reporting import load_bundle
+from tests.test_missing_merge_hardening_edge_cases import (
+    fit_numeric_merge,
+    make_numeric_frame,
+    row_for_label,
+)
+
+
+def assert_summary_matches_profile(binner):
+    selected_label = binner.missing_decision_log_.iloc[0]["selected_bin_label"]
+    summary_row = row_for_label(binner.bin_summary, "bin", selected_label)
+    profile_row = row_for_label(binner.fit_profile_, "bin_label", selected_label)
+
+    assert summary_row["count"] == pytest.approx(profile_row["n"])
+    assert summary_row["event"] == pytest.approx(profile_row["events"])
+    assert summary_row["non_event"] == pytest.approx(profile_row["non_events"])
+    assert summary_row["event_rate"] == pytest.approx(profile_row["event_rate"])
+    assert summary_row["woe"] == pytest.approx(profile_row["woe"])
+    assert summary_row["iv_component"] == pytest.approx(profile_row["iv_component"])
+
+
+@pytest.mark.parametrize("criterion", ["nearest_event_rate", "nearest_woe"])
+def test_return_woe_bundle_reporting_and_candidate_serialization_for_merge(tmp_path, criterion):
+    binner = fit_numeric_merge(make_numeric_frame(), criterion=criterion)
+    transform_df = pd.DataFrame({"score": [np.nan, -5.0, -1.0, 5.0]})
+
+    transformed_woe = binner.transform(transform_df, return_woe=True)
+    report = binner.report()
+    binner.save_report(tmp_path / f"{criterion}_report.json")
+    binner.export_bundle(tmp_path / criterion)
+    loaded = load_bundle(tmp_path / criterion)
+
+    assert pd.api.types.is_numeric_dtype(transformed_woe["score"])
+    assert transformed_woe["score"].notna().all()
+    assert report.iloc[0]["missing_policy"] == "merge"
+    assert report.iloc[0]["missing_merge_criterion"] == criterion
+    assert loaded["missing_policy"] == "merge"
+    assert loaded["effective_missing_policy"] == "merge"
+    assert loaded["missing_merge_criterion"] == criterion
+    assert loaded["missing_decision_log"][0]["action"] == "missing_merged"
+    assert loaded["missing_merge_candidates"]
+    assert loaded["missing_merge_map"] == binner.missing_merge_map_
+    assert_summary_matches_profile(binner)
+    json.dumps(binner.missing_merge_candidates_.to_dict(orient="records"))
+
+
+@pytest.mark.parametrize("criterion", ["nearest_event_rate", "nearest_woe"])
+def test_repeated_transform_is_deterministic_for_merge(criterion):
+    binner = fit_numeric_merge(make_numeric_frame(), criterion=criterion)
+    transform_df = pd.DataFrame({"score": [np.nan, -5.0, -1.0, 1.0, 5.0, np.nan]})
+
+    first = binner.transform(transform_df)
+    second = binner.transform(transform_df)
+    first_woe = binner.transform(transform_df, return_woe=True)
+    second_woe = binner.transform(transform_df, return_woe=True)
+
+    assert_frame_equal(first, second)
+    assert_frame_equal(first_woe, second_woe)
+
+
+def test_set_params_preserves_missing_merge_contract_and_clears_criterion():
+    binner = RiskBands(max_bins=3)
+
+    binner.set_params(
+        missing_policy="merge",
+        missing_merge_criterion="nearest_woe",
+        missing_merge_fallback="raise",
+    )
+    assert binner.missing_policy == "merge"
+    assert binner.missing_merge_criterion == "nearest_woe"
+    assert binner.missing_merge_fallback == "raise"
+
+    binner.set_params(missing_policy="standard")
+    assert binner.missing_policy == "standard"
+    assert binner.missing_merge_criterion is None
+    assert binner.missing_merge_criterion_ is None
+
+    with pytest.raises(ValueError, match="required when missing_policy='merge'"):
+        RiskBands().set_params(missing_policy="merge")
+
+
+@pytest.mark.parametrize("criterion", ["nearest_event_rate", "nearest_woe"])
+def test_optuna_path_preserves_missing_merge_audit_artifacts(criterion):
+    df = make_numeric_frame(missing_events=8, missing_non_events=8)
+    binner = RiskBands(
+        max_bins=5,
+        min_event_rate_diff=0.0,
+        use_optuna=True,
+        missing_policy="merge",
+        missing_merge_criterion=criterion,
+        strategy_kwargs={"n_trials": 2, "sampler_seed": 321},
+    ).fit(df, y="target", column="score")
+
+    decision = binner.missing_decision_log_.iloc[0]
+    transformed = binner.transform(pd.DataFrame({"score": [np.nan, -5.0]}), return_woe=True)
+
+    assert decision["action"] == "missing_merged"
+    assert decision["missing_merge_criterion"] == criterion
+    assert not binner.missing_profile_.empty
+    assert not binner.missing_merge_candidates_.empty
+    assert binner.missing_merge_map_["score"] == decision["selected_bin_label"]
+    assert pd.api.types.is_numeric_dtype(transformed["score"])
+    assert_summary_matches_profile(binner)
+
+
+def test_standard_separate_bin_and_forbid_basic_paths_do_not_regress():
+    missing_df = make_numeric_frame(missing_events=4, missing_non_events=4)
+    clean_df = missing_df.dropna(subset=["score"]).copy()
+
+    standard = RiskBands(
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        missing_policy="standard",
+    ).fit(missing_df, y="target", column="score")
+    separate = RiskBands(
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        missing_policy="separate_bin",
+    ).fit(missing_df, y="target", column="score")
+    forbid = RiskBands(
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        missing_policy="forbid",
+    ).fit(clean_df, y="target", column="score")
+
+    standard_transformed = standard.transform(missing_df[["score"]])
+    separate_transformed = separate.transform(missing_df[["score"]])
+
+    assert standard.report().iloc[0]["missing_policy"] == "standard"
+    assert separate.report().iloc[0]["missing_policy"] == "separate_bin"
+    assert forbid.report().iloc[0]["missing_policy"] == "forbid"
+    assert "Missing" in set(separate_transformed["score"].astype(str))
+    assert standard_transformed.shape[0] == len(missing_df)
+    with pytest.raises(ValueError, match="missing_policy='forbid'"):
+        forbid.transform(pd.DataFrame({"score": [np.nan, -5.0]}))

--- a/tests/test_missing_merge_pyspark_boundary.py
+++ b/tests/test_missing_merge_pyspark_boundary.py
@@ -3,6 +3,7 @@ import pytest
 
 from riskbands import RiskBands
 from tests.test_missing_values_current_behavior import make_numeric_missing_frame
+from tests.test_missing_values_pyspark_current_behavior import install_to_pandas_guard
 
 pytestmark = pytest.mark.spark
 pytest_plugins = ["tests.test_missing_values_pyspark_current_behavior"]
@@ -42,6 +43,27 @@ def test_merge_nearest_woe_spark_fit_fails_explicitly(spark_session):
         ).fit(sdf, y="target", column="score")
 
 
+@pytest.mark.parametrize("criterion", ["nearest_event_rate", "nearest_woe"])
+def test_merge_spark_boundary_fails_before_collecting_data(spark_session, monkeypatch, criterion):
+    sdf = _numeric_spark_frame(spark_session, [(1.0, 0), (None, 1), (3.0, 0), (4.0, 1)])
+    from pyspark.sql import DataFrame as SparkDataFrame
+
+    def fail_collect(self, *args, **kwargs):
+        raise AssertionError("missing_policy='merge' PySpark boundary should fail before collect")
+
+    def fail_to_pandas(self, *args, **kwargs):
+        raise AssertionError("missing_policy='merge' PySpark boundary should fail before toPandas")
+
+    monkeypatch.setattr(SparkDataFrame, "collect", fail_collect)
+    monkeypatch.setattr(SparkDataFrame, "toPandas", fail_to_pandas)
+
+    with pytest.raises(NotImplementedError, match=SPARK_MERGE_MESSAGE):
+        RiskBands(
+            missing_policy="merge",
+            missing_merge_criterion=criterion,
+        ).fit(sdf, y="target", column="score")
+
+
 def test_merge_pandas_fit_spark_transform_fails_explicitly(spark_session):
     binner = RiskBands(
         missing_policy="merge",
@@ -78,6 +100,31 @@ def test_separate_bin_spark_transform_still_works(spark_session):
 
     assert transformed.__class__.__module__.startswith("pyspark")
     assert observed.count("Missing") == 2
+
+
+def test_separate_bin_spark_validate_still_uses_bounded_native_profile(spark_session, monkeypatch):
+    rows = []
+    for idx in range(90):
+        score = None if idx % 13 == 0 else float((idx % 9) - 4)
+        target = int(idx % 4 == 0 or score is None)
+        rows.append((score, target))
+    sdf = _numeric_spark_frame(spark_session, rows).repartition(2)
+    binner = RiskBands(
+        missing_policy="separate_bin",
+        min_event_rate_diff=0.0,
+        sample_size=90,
+    ).fit(sdf, y="target", column="score", validate=True)
+    calls = install_to_pandas_guard(monkeypatch, max_rows=30)
+
+    transformed = binner.transform(sdf, column="score", validate=True)
+    missing_rows = binner.application_profile_.loc[binner.application_profile_["is_missing_bin"]]
+
+    assert transformed.__class__.__module__.startswith("pyspark")
+    assert calls
+    assert max(call["rows"] for call in calls) <= 30
+    assert len(missing_rows) == 1
+    assert missing_rows.iloc[0]["bin_label"] == "Missing"
+    assert binner.transform_validation_report_["backend"] == "pyspark"
 
 
 def test_forbid_spark_transform_still_enforces_missing_policy(spark_session):


### PR DESCRIPTION
Adds adversarial tests, comparative diagnostics, a synthetic credit-risk example, methodological guidance, and documentation updates for auditable missing merge policies. This is a hardening/docs/examples sprint only: no new public API, no new merge criterion, no package version bump, no tag, and no publication.