### PR TITLE
Add Spark transform support for missing merge

### DIFF
--- a/docs/pyspark_missing_merge_transform_design.md
+++ b/docs/pyspark_missing_merge_transform_design.md
@@ -1,0 +1,69 @@
+# PySpark Missing Merge Transform Design
+
+## G1 scope
+
+Sprint G1 supports the narrow path:
+
+```text
+pandas fit -> Spark transform
+```
+
+The missing merge decision is still learned only during pandas fit. Spark transform applies the learned decision with native Spark expressions.
+
+## Allowed
+
+- `RiskBands(..., missing_policy="merge").fit(pandas_df, y=...)`
+- `binner.transform(spark_df, return_woe=False)` after the pandas fit
+- `missing_merge_criterion="nearest_event_rate"`
+- `missing_merge_criterion="nearest_woe"`
+- `missing_merge_fallback="separate_bin"`
+- `missing_merge_fallback="raise"`
+- `transform(validate=True)` when the Spark input includes the fitted target column
+- `export_bundle(...)` / `load_bundle(...)` preserving merge metadata while the fitted in-memory model continues to transform Spark inputs
+
+## Still blocked
+
+- Spark fit with `missing_policy="merge"`
+- Spark `return_woe=True`
+- PySpark learning of merge decisions
+- Spark sampled-to-pandas fit with merge enabled
+
+## Spark transform semantics
+
+For every selected feature, Spark first uses the existing native expression to map regular values to fitted bins.
+
+For numeric supervised features:
+
+- `NULL` is missing.
+- `NaN` is missing for Spark `FloatType` and `DoubleType`.
+- If `missing_merge_map_[feature]` exists, missing values return the learned destination bin label.
+- If no decision exists and fallback is `separate_bin`, missing values return `"Missing"`.
+- If no decision exists and fallback is `raise`, Spark aggregates missing counts for the affected feature and raises before applying the transform.
+
+For categorical features:
+
+- `NULL` is missing.
+- Non-null unknown categories keep the fitted unknown/default-bin behavior.
+- The pandas internal `_MISSING_` token remains an implementation detail and is not used as a Spark input sentinel.
+
+## Validation
+
+`transform(validate=True)` reuses the Spark aggregate profile path. The application profile is built from final Spark bin labels, so learned missing merges appear in the destination bin and fallback `separate_bin` appears as `"Missing"`.
+
+## Bundle
+
+The audit bundle persists:
+
+- `missing_policy`
+- `missing_merge_criterion`
+- `missing_merge_fallback`
+- `missing_merge_map`
+- missing profile and decision logs
+
+`load_bundle(...)` loads these audit fields for review. It does not reconstruct a fitted estimator; Spark transformation remains the responsibility of the fitted in-memory `RiskBands` object.
+
+## Next steps
+
+- G2: design Spark sampled-to-pandas fit support for merge, if still desired.
+- G3: refine Spark validation/reporting metadata around missing merge transform fallback logs.
+- G4: update public docs and release notes after functional gates are accepted.

--- a/riskbands/binning_engine.py
+++ b/riskbands/binning_engine.py
@@ -45,8 +45,8 @@ _VALID_MISSING_MERGE_FALLBACKS = {
     _RAISE_MISSING_MERGE_FALLBACK,
 }
 _PYSPARK_MISSING_MERGE_UNIMPLEMENTED_MESSAGE = (
-    'missing_policy="merge" with PySpark is not implemented in this release. '
-    'Use pandas fit/transform or missing_policy="separate_bin"/"forbid".'
+    'missing_policy="merge" with PySpark fit is not implemented in this release. '
+    "Fit with pandas first, then use Spark transform with return_woe=False."
 )
 
 
@@ -418,18 +418,34 @@ class Binner(BaseEstimator, TransformerMixin):
         return isinstance(data_type, (T.DoubleType, T.FloatType))
 
     # ------------------------------------------------------------------
+    @staticmethod
+    def _spark_data_types_by_column(X) -> dict[str, Any]:
+        schema = getattr(X, "schema", None)
+        fields = getattr(schema, "fields", []) or []
+        return {
+            str(field.name): getattr(field, "dataType", None)
+            for field in fields
+            if hasattr(field, "name")
+        }
+
+    # ------------------------------------------------------------------
     def _spark_missing_count_expressions(self, X, columns: Sequence[str], F):
-        fields = {field.name: field.dataType for field in X.schema.fields}
+        fields = self._spark_data_types_by_column(X)
         expressions = []
         for column in columns:
-            col_expr = F.col(column)
-            missing_condition = col_expr.isNull()
-            if self._spark_column_supports_nan(fields.get(column)):
-                missing_condition = missing_condition | F.isnan(col_expr)
+            missing_condition = self._spark_missing_condition(column, F, data_type=fields.get(str(column)))
             expressions.append(
                 F.sum(F.when(missing_condition, F.lit(1)).otherwise(F.lit(0))).alias(str(column))
             )
         return expressions
+
+    # ------------------------------------------------------------------
+    def _spark_missing_condition(self, column: str, F, *, data_type: Any | None = None):
+        col_expr = F.col(column)
+        missing_condition = col_expr.isNull()
+        if self._spark_column_supports_nan(data_type):
+            missing_condition = missing_condition | F.isnan(col_expr)
+        return missing_condition
 
     # ------------------------------------------------------------------
     def _pyspark_missing_counts(self, X, columns: Sequence[str]) -> dict[str, int]:
@@ -449,7 +465,40 @@ class Binner(BaseEstimator, TransformerMixin):
         context: str,
     ) -> None:
         if self.missing_policy == _MERGE_MISSING_POLICY:
-            raise NotImplementedError(_PYSPARK_MISSING_MERGE_UNIMPLEMENTED_MESSAGE)
+            if context == "fit":
+                raise NotImplementedError(_PYSPARK_MISSING_MERGE_UNIMPLEMENTED_MESSAGE)
+            fit_backend = getattr(self, "fit_backend_", None)
+            if fit_backend not in {"pandas", "pandas_core"}:
+                raise NotImplementedError(
+                    "missing_policy='merge' Spark transform is only supported after pandas fit."
+                )
+            if self.missing_merge_fallback != _RAISE_MISSING_MERGE_FALLBACK:
+                return
+            merge_map = getattr(self, "missing_merge_map_", {}) or {}
+            columns_without_decision = [column for column in columns if str(column) not in merge_map]
+            counts = self._pyspark_missing_counts(X, columns_without_decision)
+            present = {column: count for column, count in counts.items() if count > 0}
+            if not present:
+                return
+            variable, count = next(iter(present.items()))
+            self.missing_transform_fallback_log_ = pd.DataFrame(
+                [
+                    {
+                        "variable": variable,
+                        "missing_detected": True,
+                        "n_missing_transform": int(count),
+                        "action": "missing_transform_fallback_raise",
+                        "selected_bin_label": None,
+                        "fallback_used": True,
+                        "training_decision_used": False,
+                        "backend": "pyspark",
+                    }
+                ]
+            )
+            raise ValueError(
+                "missing_policy='merge' detected missing values during Spark transform "
+                f"for feature {variable}, but no merge decision was learned during fit."
+            )
         if self.missing_policy != _FORBID_MISSING_POLICY:
             return
         self._raise_forbidden_missing(
@@ -683,27 +732,33 @@ class Binner(BaseEstimator, TransformerMixin):
         return labels.loc[mask].tolist()
 
     # ------------------------------------------------------------------
-    def _numeric_supervised_spark_expression(self, column: str, F):
+    def _missing_merge_spark_label(self, column: str) -> Any:
+        merge_map = getattr(self, "missing_merge_map_", {}) or {}
+        if str(column) in merge_map:
+            return merge_map[str(column)]
+        if self.missing_merge_fallback == _SEPARATE_BIN_MISSING_MERGE_FALLBACK:
+            return "Missing"
+        return "Missing"
+
+    # ------------------------------------------------------------------
+    def _numeric_supervised_spark_expression(self, column: str, F, *, data_type: Any | None = None):
         model = self._per_feature_binners[column].models_[column]
         splits = [float(split) for split in getattr(model, "splits", [])]
         labels = self._regular_model_bins(model.binning_table.build())
         if len(labels) != len(splits) + 1:
             labels = self.binning_table(column=column)["bin"].tolist()
         col_expr = F.col(column)
-        missing_condition = col_expr.isNull()
-        try:
-            missing_condition = missing_condition | F.isnan(col_expr)
-        except Exception:  # pragma: no cover - depends on Spark/F implementation
-            missing_condition = col_expr.isNull()
-        expr = F.when(missing_condition, F.lit("Missing"))
+        missing_condition = self._spark_missing_condition(column, F, data_type=data_type)
+        missing_label = (
+            self._missing_merge_spark_label(column)
+            if self.missing_policy == _MERGE_MISSING_POLICY
+            else "Missing"
+        )
+        expr = F.when(missing_condition, F.lit(missing_label))
 
         for idx, label in enumerate(labels):
             if not splits:
-                condition = col_expr.isNotNull()
-                try:
-                    condition = condition & (~F.isnan(col_expr))
-                except Exception:  # pragma: no cover
-                    condition = col_expr.isNotNull()
+                condition = ~missing_condition
             elif idx == 0:
                 condition = col_expr < F.lit(splits[0])
             elif idx == len(labels) - 1:
@@ -714,13 +769,20 @@ class Binner(BaseEstimator, TransformerMixin):
         return expr.otherwise(F.lit(labels[-1] if labels else None))
 
     # ------------------------------------------------------------------
-    def _numeric_unsupervised_spark_expression(self, column: str, F):
+    def _numeric_unsupervised_spark_expression(self, column: str, F, *, data_type: Any | None = None):
         strategy = self._per_feature_binners[column]
         column_index = list(getattr(strategy._kbd, "feature_names_in_", [column])).index(column)
         edges = [float(edge) for edge in strategy._kbd.bin_edges_[column_index]]
         labels = [float(idx) for idx in range(max(0, len(edges) - 1))]
         col_expr = F.col(column)
-        expr = F.when(col_expr.isNull(), F.lit(float("nan")))
+        missing_condition = self._spark_missing_condition(column, F, data_type=data_type)
+        if self.missing_policy == _MERGE_MISSING_POLICY:
+            missing_label = self._missing_merge_spark_label(column)
+        elif self.missing_policy == _SEPARATE_BIN_MISSING_POLICY:
+            missing_label = "Missing"
+        else:
+            missing_label = float("nan")
+        expr = F.when(missing_condition, F.lit(missing_label))
         for idx, label in enumerate(labels):
             if idx == 0:
                 condition = col_expr < F.lit(edges[1])
@@ -740,7 +802,9 @@ class Binner(BaseEstimator, TransformerMixin):
         default_bin = getattr(strategy, "default_bin_", mapping.get(unknown_token))
         col_expr = F.col(column)
         str_col = col_expr.cast("string")
-        if self.missing_policy == _SEPARATE_BIN_MISSING_POLICY:
+        if self.missing_policy == _MERGE_MISSING_POLICY:
+            expr = F.when(col_expr.isNull(), F.lit(self._missing_merge_spark_label(column)))
+        elif self.missing_policy == _SEPARATE_BIN_MISSING_POLICY:
             expr = F.when(col_expr.isNull(), F.lit("Missing"))
         else:
             expr = F.when(col_expr.isNull(), F.lit(mapping.get(missing_token, default_bin)))
@@ -751,12 +815,12 @@ class Binner(BaseEstimator, TransformerMixin):
         return expr.otherwise(F.lit(default_bin))
 
     # ------------------------------------------------------------------
-    def _spark_transform_expression(self, column: str, F):
+    def _spark_transform_expression(self, column: str, F, *, data_type: Any | None = None):
         strategy = self._per_feature_binners[column]
         if hasattr(strategy, "models_") and column in getattr(strategy, "models_", {}):
-            return self._numeric_supervised_spark_expression(column, F)
+            return self._numeric_supervised_spark_expression(column, F, data_type=data_type)
         if hasattr(strategy, "_kbd"):
-            return self._numeric_unsupervised_spark_expression(column, F)
+            return self._numeric_unsupervised_spark_expression(column, F, data_type=data_type)
         if hasattr(strategy, "category_mapping_"):
             return self._categorical_spark_expression(column, F)
         raise TypeError(f"Feature '{column}' uses an unsupported binner for Spark transform.")
@@ -787,11 +851,16 @@ class Binner(BaseEstimator, TransformerMixin):
         )
         self._check_missing_policy_pyspark(X, selected_columns, context="transform")
         F = self._spark_functions()
+        fields = self._spark_data_types_by_column(X)
         transformed = X
         for selected_column in selected_columns:
             transformed = transformed.withColumn(
                 selected_column,
-                self._spark_transform_expression(selected_column, F),
+                self._spark_transform_expression(
+                    selected_column,
+                    F,
+                    data_type=fields.get(str(selected_column)),
+                ),
             )
         output = transformed.select(*selected_columns)
         if validate:
@@ -2523,6 +2592,7 @@ class Binner(BaseEstimator, TransformerMixin):
         settings = self._default_validation_settings()
         max_profile_rows = int(settings.get("max_profile_rows_to_collect", _MAX_PROFILE_ROWS_TO_COLLECT))
         existing_columns = list(X.columns)
+        fields = self._spark_data_types_by_column(X)
         bin_col = self._make_temp_column_name(existing_columns, "__riskbands_bin_label")
         target_col = self._make_temp_column_name(
             [*existing_columns, bin_col],
@@ -2538,7 +2608,14 @@ class Binner(BaseEstimator, TransformerMixin):
 
         for variable in feature_columns:
             profile_sdf = (
-                X.withColumn(bin_col, self._spark_transform_expression(variable, F))
+                X.withColumn(
+                    bin_col,
+                    self._spark_transform_expression(
+                        variable,
+                        F,
+                        data_type=fields.get(str(variable)),
+                    ),
+                )
                 .withColumn(target_col, F.col(target_name).cast("double"))
                 .groupBy(bin_col)
                 .agg(

--- a/tests/test_missing_merge_pyspark_boundary.py
+++ b/tests/test_missing_merge_pyspark_boundary.py
@@ -8,7 +8,7 @@ from tests.test_missing_values_pyspark_current_behavior import install_to_pandas
 pytestmark = pytest.mark.spark
 pytest_plugins = ["tests.test_missing_values_pyspark_current_behavior"]
 
-SPARK_MERGE_MESSAGE = 'missing_policy="merge" with PySpark is not implemented in this release'
+SPARK_MERGE_MESSAGE = 'missing_policy="merge" with PySpark fit is not implemented in this release'
 
 
 def _numeric_spark_frame(spark_session, rows):
@@ -64,7 +64,7 @@ def test_merge_spark_boundary_fails_before_collecting_data(spark_session, monkey
         ).fit(sdf, y="target", column="score")
 
 
-def test_merge_pandas_fit_spark_transform_fails_explicitly(spark_session):
+def test_merge_pandas_fit_spark_transform_is_allowed(spark_session):
     binner = RiskBands(
         missing_policy="merge",
         missing_merge_criterion="nearest_event_rate",
@@ -72,11 +72,13 @@ def test_merge_pandas_fit_spark_transform_fails_explicitly(spark_session):
     ).fit(make_numeric_missing_frame(), y="target", column="score")
     sdf = _numeric_spark_frame(spark_session, [(1.0, 0), (None, 1)])
 
-    with pytest.raises(NotImplementedError, match=SPARK_MERGE_MESSAGE):
-        binner.transform(sdf, column="score")
+    transformed = binner.transform(sdf, column="score")
+
+    assert transformed.__class__.__module__.startswith("pyspark")
+    assert "Missing" not in transformed.toPandas()["score"].tolist()
 
 
-def test_merge_nearest_woe_pandas_fit_spark_transform_fails_explicitly(spark_session):
+def test_merge_nearest_woe_pandas_fit_spark_transform_is_allowed(spark_session):
     binner = RiskBands(
         missing_policy="merge",
         missing_merge_criterion="nearest_woe",
@@ -84,8 +86,10 @@ def test_merge_nearest_woe_pandas_fit_spark_transform_fails_explicitly(spark_ses
     ).fit(make_numeric_missing_frame(), y="target", column="score")
     sdf = _numeric_spark_frame(spark_session, [(1.0, 0), (None, 1)])
 
-    with pytest.raises(NotImplementedError, match=SPARK_MERGE_MESSAGE):
-        binner.transform(sdf, column="score")
+    transformed = binner.transform(sdf, column="score")
+
+    assert transformed.__class__.__module__.startswith("pyspark")
+    assert "Missing" not in transformed.toPandas()["score"].tolist()
 
 
 def test_separate_bin_spark_transform_still_works(spark_session):

--- a/tests/test_missing_merge_pyspark_bundle_transform.py
+++ b/tests/test_missing_merge_pyspark_bundle_transform.py
@@ -1,0 +1,95 @@
+from collections import Counter
+
+import pandas as pd
+import pytest
+
+from riskbands import RiskBands
+from riskbands.reporting import load_bundle
+from tests.test_missing_merge_nearest_event_rate_pandas import fit_numeric_merge
+from tests.test_missing_merge_nearest_woe_pandas import fit_numeric_woe_merge
+
+pytestmark = pytest.mark.spark
+pytest_plugins = ["tests.test_missing_values_pyspark_current_behavior"]
+
+
+def _numeric_spark_frame(spark_session, rows):
+    from pyspark.sql import types as T
+
+    schema = T.StructType(
+        [
+            T.StructField("score", T.DoubleType(), True),
+            T.StructField("target", T.IntegerType(), True),
+        ]
+    )
+    return spark_session.createDataFrame(rows, schema=schema)
+
+
+def _values(spark_df):
+    return [row["score"] for row in spark_df.select("score").collect()]
+
+
+@pytest.mark.parametrize(
+    "fit_factory",
+    [
+        fit_numeric_merge,
+        fit_numeric_woe_merge,
+    ],
+)
+def test_bundle_load_preserves_merge_decision_and_model_transforms_spark(
+    spark_session,
+    tmp_path,
+    fit_factory,
+):
+    binner, _ = fit_factory()
+    learned_label = binner.missing_merge_map_["score"]
+    binner.export_bundle(tmp_path / "bundle")
+
+    loaded = load_bundle(tmp_path / "bundle")
+    transformed = binner.transform(
+        _numeric_spark_frame(spark_session, [(None, 0), (float("nan"), 1), (-5.0, 0)]),
+        column="score",
+    )
+    observed = _values(transformed)
+
+    assert loaded["missing_policy"] == "merge"
+    assert loaded["missing_merge_map"]["score"] == learned_label
+    assert transformed.__class__.__module__.startswith("pyspark")
+    assert Counter(observed)[learned_label] >= 2
+    assert "Missing" not in observed
+
+
+def test_bundle_load_preserves_merge_fallback_and_model_transforms_spark(spark_session, tmp_path):
+    fit_df = pd.DataFrame({"score": [-5.0, -4.0, 0.0, 3.0, 5.0] * 8, "target": [0, 0, 1, 1, 1] * 8})
+    binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        missing_merge_fallback="separate_bin",
+    ).fit(fit_df, y="target", column="score")
+    binner.export_bundle(tmp_path / "bundle")
+
+    loaded = load_bundle(tmp_path / "bundle")
+    transformed = binner.transform(
+        _numeric_spark_frame(spark_session, [(None, 0), (float("nan"), 1), (-5.0, 0)]),
+        column="score",
+    )
+
+    assert loaded["missing_merge_fallback"] == "separate_bin"
+    assert loaded["missing_merge_map"] == {}
+    assert transformed.__class__.__module__.startswith("pyspark")
+    assert Counter(_values(transformed))["Missing"] == 2
+
+
+def test_bundle_model_still_blocks_spark_return_woe(spark_session, tmp_path):
+    binner, _ = fit_numeric_merge()
+    binner.export_bundle(tmp_path / "bundle")
+    loaded = load_bundle(tmp_path / "bundle")
+
+    assert loaded["missing_merge_map"] == binner.missing_merge_map_
+    with pytest.raises(NotImplementedError, match="return_woe=False"):
+        binner.transform(
+            _numeric_spark_frame(spark_session, [(None, 0), (1.0, 1)]),
+            column="score",
+            return_woe=True,
+        )

--- a/tests/test_missing_merge_pyspark_transform.py
+++ b/tests/test_missing_merge_pyspark_transform.py
@@ -1,0 +1,298 @@
+from collections import Counter
+
+import pandas as pd
+import pytest
+
+from riskbands import RiskBands
+from tests.test_missing_merge_nearest_event_rate_pandas import (
+    fit_numeric_merge,
+    make_categorical_event_rate_frame,
+)
+from tests.test_missing_merge_nearest_woe_pandas import (
+    fit_categorical_woe_merge,
+    fit_numeric_woe_merge,
+)
+
+pytestmark = pytest.mark.spark
+pytest_plugins = ["tests.test_missing_values_pyspark_current_behavior"]
+
+SPARK_MERGE_FIT_MESSAGE = 'missing_policy="merge" with PySpark fit is not implemented'
+SPARK_WOE_MESSAGE = "PySpark transform currently supports return_woe=False only"
+
+
+def _numeric_spark_frame(spark_session, rows):
+    from pyspark.sql import types as T
+
+    schema = T.StructType(
+        [
+            T.StructField("score", T.DoubleType(), True),
+            T.StructField("target", T.IntegerType(), True),
+        ]
+    )
+    return spark_session.createDataFrame(rows, schema=schema)
+
+
+def _categorical_spark_frame(spark_session, rows, *, column="rating"):
+    from pyspark.sql import types as T
+
+    schema = T.StructType(
+        [
+            T.StructField(column, T.StringType(), True),
+            T.StructField("target", T.IntegerType(), True),
+        ]
+    )
+    return spark_session.createDataFrame(rows, schema=schema)
+
+
+def _only_column_values(spark_df, column):
+    return [row[column] for row in spark_df.select(column).collect()]
+
+
+def _single_value(spark_df, column):
+    values = _only_column_values(spark_df, column)
+    assert len(values) == 1
+    return values[0]
+
+
+@pytest.mark.parametrize(
+    "fit_factory",
+    [
+        fit_numeric_merge,
+        fit_numeric_woe_merge,
+    ],
+)
+def test_numeric_merge_pandas_fit_spark_transform_routes_null_and_nan(spark_session, fit_factory):
+    binner, _ = fit_factory()
+    learned_label = binner.missing_merge_map_["score"]
+    sdf = _numeric_spark_frame(spark_session, [(None, 0), (float("nan"), 1), (-5.0, 0)])
+
+    transformed = binner.transform(sdf, column="score")
+    observed = _only_column_values(transformed, "score")
+
+    assert transformed.__class__.__module__.startswith("pyspark")
+    assert Counter(observed)[learned_label] >= 2
+    assert "Missing" not in observed
+
+
+def test_unsupervised_merge_spark_transform_routes_null_and_nan_to_separate_fallback(spark_session):
+    fit_df = pd.DataFrame({"score": [-5.0, -4.0, 0.0, 3.0, 5.0] * 8, "target": [0, 0, 1, 1, 1] * 8})
+    binner = RiskBands(
+        strategy="unsupervised",
+        max_bins=3,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        missing_merge_fallback="separate_bin",
+    ).fit(fit_df, y="target", column="score")
+    sdf = _numeric_spark_frame(spark_session, [(None, 0), (float("nan"), 1), (-5.0, 0)])
+
+    observed = _only_column_values(binner.transform(sdf, column="score"), "score")
+
+    assert binner.missing_merge_map_ == {}
+    assert Counter(observed)["Missing"] == 2
+
+
+def test_unsupervised_merge_spark_transform_applies_existing_merge_map(spark_session):
+    fit_df = pd.DataFrame({"score": [-5.0, -4.0, 0.0, 3.0, 5.0] * 8, "target": [0, 0, 1, 1, 1] * 8})
+    binner = RiskBands(
+        strategy="unsupervised",
+        max_bins=3,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    ).fit(fit_df, y="target", column="score")
+    learned_label = 1.0
+    binner.missing_merge_map_["score"] = learned_label
+    sdf = _numeric_spark_frame(spark_session, [(None, 0), (float("nan"), 1), (-5.0, 0)])
+
+    observed = _only_column_values(binner.transform(sdf, column="score"), "score")
+
+    assert Counter(observed)[learned_label] >= 2
+    assert "Missing" not in observed
+
+
+def test_unsupervised_merge_spark_transform_raise_fallback_detects_missing(spark_session):
+    fit_df = pd.DataFrame({"score": [-5.0, -4.0, 0.0, 3.0, 5.0] * 8, "target": [0, 0, 1, 1, 1] * 8})
+    binner = RiskBands(
+        strategy="unsupervised",
+        max_bins=3,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        missing_merge_fallback="raise",
+    ).fit(fit_df, y="target", column="score")
+    sdf = _numeric_spark_frame(spark_session, [(None, 0), (-5.0, 0)])
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "missing_policy='merge' detected missing values during Spark transform for feature score, "
+            "but no merge decision was learned during fit"
+        ),
+    ):
+        binner.transform(sdf, column="score")
+
+
+def test_categorical_nearest_event_rate_merge_routes_null_and_keeps_unknown_distinct(spark_session):
+    df = make_categorical_event_rate_frame()
+    binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        force_categorical=["rating"],
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    ).fit(df, y="target", column="rating")
+    learned_label = binner.missing_merge_map_["rating"]
+    expected_unknown = binner.transform(pd.DataFrame({"rating": ["Z"]})).loc[0, "rating"]
+
+    missing_value = _single_value(
+        binner.transform(_categorical_spark_frame(spark_session, [(None, 1)]), column="rating"),
+        "rating",
+    )
+    unknown_value = _single_value(
+        binner.transform(_categorical_spark_frame(spark_session, [("Z", 0)]), column="rating"),
+        "rating",
+    )
+
+    assert str(missing_value) == str(learned_label)
+    assert str(unknown_value) == str(expected_unknown)
+    assert str(unknown_value) != str(missing_value)
+
+
+def test_categorical_nearest_woe_merge_routes_null_and_keeps_unknown_distinct(spark_session):
+    binner, _ = fit_categorical_woe_merge()
+    learned_label = binner.missing_merge_map_["rating"]
+    expected_unknown = binner.transform(pd.DataFrame({"rating": ["Z"]})).loc[0, "rating"]
+
+    missing_value = _single_value(
+        binner.transform(_categorical_spark_frame(spark_session, [(None, 1)]), column="rating"),
+        "rating",
+    )
+    unknown_value = _single_value(
+        binner.transform(_categorical_spark_frame(spark_session, [("Z", 0)]), column="rating"),
+        "rating",
+    )
+
+    assert str(missing_value) == str(learned_label)
+    assert str(unknown_value) == str(expected_unknown)
+    assert str(unknown_value) != str(missing_value)
+
+
+def test_merge_spark_fit_still_fails_before_collection(spark_session, monkeypatch):
+    sdf = _numeric_spark_frame(spark_session, [(1.0, 0), (None, 1), (3.0, 0), (4.0, 1)])
+    from pyspark.sql import DataFrame as SparkDataFrame
+
+    def fail_collect(self, *args, **kwargs):
+        raise AssertionError("missing_policy='merge' PySpark fit should fail before collect")
+
+    def fail_to_pandas(self, *args, **kwargs):
+        raise AssertionError("missing_policy='merge' PySpark fit should fail before toPandas")
+
+    monkeypatch.setattr(SparkDataFrame, "collect", fail_collect)
+    monkeypatch.setattr(SparkDataFrame, "toPandas", fail_to_pandas)
+
+    with pytest.raises(NotImplementedError, match=SPARK_MERGE_FIT_MESSAGE):
+        RiskBands(
+            missing_policy="merge",
+            missing_merge_criterion="nearest_event_rate",
+        ).fit(sdf, y="target", column="score")
+
+
+def test_merge_spark_transform_return_woe_still_fails(spark_session):
+    binner, _ = fit_numeric_merge()
+    sdf = _numeric_spark_frame(spark_session, [(None, 0), (1.0, 1)])
+
+    with pytest.raises(NotImplementedError, match=SPARK_WOE_MESSAGE):
+        binner.transform(sdf, column="score", return_woe=True)
+
+
+def test_merge_no_fit_missing_spark_transform_uses_separate_bin_fallback(spark_session):
+    fit_df = pd.DataFrame({"score": [-5.0, -4.0, 0.0, 3.0, 5.0] * 8, "target": [0, 0, 1, 1, 1] * 8})
+    binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        missing_merge_fallback="separate_bin",
+    ).fit(fit_df, y="target", column="score")
+    sdf = _numeric_spark_frame(spark_session, [(None, 0), (float("nan"), 1), (-5.0, 0)])
+
+    observed = _only_column_values(binner.transform(sdf, column="score"), "score")
+
+    assert binner.missing_merge_map_ == {}
+    assert Counter(observed)["Missing"] == 2
+
+
+def test_merge_no_fit_missing_spark_transform_raise_fallback_detects_missing(spark_session):
+    fit_df = pd.DataFrame({"score": [-5.0, -4.0, 0.0, 3.0, 5.0] * 8, "target": [0, 0, 1, 1, 1] * 8})
+    binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        missing_merge_fallback="raise",
+    ).fit(fit_df, y="target", column="score")
+    sdf = _numeric_spark_frame(spark_session, [(None, 0), (-5.0, 0)])
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "missing_policy='merge' detected missing values during Spark transform for feature score, "
+            "but no merge decision was learned during fit"
+        ),
+    ):
+        binner.transform(sdf, column="score")
+
+
+def test_merge_no_fit_missing_spark_transform_raise_fallback_allows_no_missing(spark_session):
+    fit_df = pd.DataFrame({"score": [-5.0, -4.0, 0.0, 3.0, 5.0] * 8, "target": [0, 0, 1, 1, 1] * 8})
+    binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        missing_merge_fallback="raise",
+    ).fit(fit_df, y="target", column="score")
+    sdf = _numeric_spark_frame(spark_session, [(-5.0, 0), (0.0, 1)])
+
+    transformed = binner.transform(sdf, column="score")
+
+    assert transformed.__class__.__module__.startswith("pyspark")
+    assert "Missing" not in _only_column_values(transformed, "score")
+
+
+def test_categorical_no_fit_missing_spark_transform_uses_separate_bin_fallback(spark_session):
+    fit_df = pd.DataFrame({"rating": ["A", "B", "C", "A", "B", "C"] * 8, "target": [0, 1, 1, 0, 1, 1] * 8})
+    binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        force_categorical=["rating"],
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        missing_merge_fallback="separate_bin",
+    ).fit(fit_df, y="target", column="rating")
+    sdf = _categorical_spark_frame(spark_session, [(None, 0), ("Z", 1)])
+
+    observed = _only_column_values(binner.transform(sdf, column="rating"), "rating")
+
+    assert binner.missing_merge_map_ == {}
+    assert Counter(observed)["Missing"] == 1
+
+
+def test_categorical_no_fit_missing_spark_transform_raise_fallback_detects_null(spark_session):
+    fit_df = pd.DataFrame({"rating": ["A", "B", "C", "A", "B", "C"] * 8, "target": [0, 1, 1, 0, 1, 1] * 8})
+    binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        force_categorical=["rating"],
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        missing_merge_fallback="raise",
+    ).fit(fit_df, y="target", column="rating")
+    sdf = _categorical_spark_frame(spark_session, [(None, 0), ("A", 1)])
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "missing_policy='merge' detected missing values during Spark transform for feature rating, "
+            "but no merge decision was learned during fit"
+        ),
+    ):
+        binner.transform(sdf, column="rating")

--- a/tests/test_missing_merge_pyspark_validation.py
+++ b/tests/test_missing_merge_pyspark_validation.py
@@ -1,0 +1,78 @@
+from collections import Counter
+
+import pandas as pd
+import pytest
+
+from riskbands import RiskBands
+from tests.test_missing_merge_nearest_event_rate_pandas import fit_numeric_merge
+from tests.test_missing_values_pyspark_current_behavior import install_to_pandas_guard
+
+pytestmark = pytest.mark.spark
+pytest_plugins = ["tests.test_missing_values_pyspark_current_behavior"]
+
+
+def _numeric_spark_frame(spark_session, rows):
+    from pyspark.sql import types as T
+
+    schema = T.StructType(
+        [
+            T.StructField("score", T.DoubleType(), True),
+            T.StructField("target", T.IntegerType(), True),
+        ]
+    )
+    return spark_session.createDataFrame(rows, schema=schema)
+
+
+def _bin_counts(profile):
+    return Counter(profile["bin_label"].astype(str).tolist())
+
+
+def test_merge_spark_transform_validate_true_profiles_final_merged_bin(spark_session, monkeypatch):
+    binner, _ = fit_numeric_merge()
+    learned_label = binner.missing_merge_map_["score"]
+    sdf = _numeric_spark_frame(
+        spark_session,
+        [(None, 1), (float("nan"), 0), (-5.0, 0), (-3.0, 0), (0.0, 1), (3.0, 1), (5.0, 1)],
+    ).repartition(2)
+    calls = install_to_pandas_guard(monkeypatch, max_rows=20)
+
+    transformed = binner.transform(sdf, column="score", validate=True)
+    profile = binner.application_profile_
+
+    assert transformed.__class__.__module__.startswith("pyspark")
+    assert profile is not None
+    assert binner.transform_validation_report_["backend"] == "pyspark"
+    assert binner.transform_validation_report_["summary"]["n_application_rows"] == 7
+    assert str(learned_label) in _bin_counts(profile)
+    assert "Missing" not in set(profile["bin_label"].astype(str))
+    assert not profile["is_missing_bin"].fillna(False).astype(bool).any()
+    assert calls
+    assert max(call["rows"] for call in calls) <= 20
+
+
+def test_merge_spark_transform_validate_true_profiles_separate_fallback_missing(spark_session, monkeypatch):
+    fit_df = pd.DataFrame({"score": [-5.0, -4.0, 0.0, 3.0, 5.0] * 8, "target": [0, 0, 1, 1, 1] * 8})
+    binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        missing_merge_fallback="separate_bin",
+    ).fit(fit_df, y="target", column="score")
+    sdf = _numeric_spark_frame(spark_session, [(None, 0), (float("nan"), 1), (-5.0, 0), (3.0, 1)])
+    calls = install_to_pandas_guard(monkeypatch, max_rows=20)
+
+    transformed = binner.transform(sdf, column="score", validate=True)
+    profile = binner.application_profile_
+
+    assert transformed.__class__.__module__.startswith("pyspark")
+    assert binner.missing_merge_map_ == {}
+    assert profile is not None
+    assert _bin_counts(profile)["Missing"] == 1
+    missing_rows = profile.loc[profile["bin_label"].astype(str) == "Missing"]
+    assert len(missing_rows) == 1
+    assert int(missing_rows.iloc[0]["n"]) == 2
+    assert bool(missing_rows.iloc[0]["is_missing_bin"]) is True
+    assert binner.transform_validation_report_["backend"] == "pyspark"
+    assert calls
+    assert max(call["rows"] for call in calls) <= 20


### PR DESCRIPTION
Adds narrow PySpark transform support for learned missing merge decisions after pandas fit, covering nearest_event_rate and nearest_woe, numeric NULL/NaN, categorical NULL, fallbacks, validation, bundle metadata, and preserving Spark fit and Spark return_woe boundaries. This does not implement Spark fit with merge, Spark return_woe, temporal_stable, monotonic_neighbor, or new merge criteria.