### PR TITLE
Add Spark missing merge transform hardening

### DIFF
--- a/docs/pyspark_missing_merge_transform_design.md
+++ b/docs/pyspark_missing_merge_transform_design.md
@@ -10,6 +10,10 @@ pandas fit -> Spark transform
 
 The missing merge decision is still learned only during pandas fit. Spark transform applies the learned decision with native Spark expressions.
 
+## G1B hardening status
+
+Sprint G1B does not add API surface. It hardens the same G1 path with adversarial tests and regression gates around pandas/Spark equivalence, multi-feature transforms, missing detection, validation, bundle metadata, and static source guards.
+
 ## Allowed
 
 - `RiskBands(..., missing_policy="merge").fit(pandas_df, y=...)`
@@ -19,6 +23,7 @@ The missing merge decision is still learned only during pandas fit. Spark transf
 - `missing_merge_fallback="separate_bin"`
 - `missing_merge_fallback="raise"`
 - `transform(validate=True)` when the Spark input includes the fitted target column
+- `transform(validate=True)` without the target column, returning a skipped transform validation report
 - `export_bundle(...)` / `load_bundle(...)` preserving merge metadata while the fitted in-memory model continues to transform Spark inputs
 
 ## Still blocked
@@ -46,9 +51,18 @@ For categorical features:
 - Non-null unknown categories keep the fitted unknown/default-bin behavior.
 - The pandas internal `_MISSING_` token remains an implementation detail and is not used as a Spark input sentinel.
 
+For multi-feature transforms:
+
+- `columns=[...]` selects only fitted features requested by the caller.
+- Extra columns in the Spark input are not included in the transform output.
+- `missing_merge_map_` is applied independently per selected feature.
+- If one selected feature has no learned missing decision, fallback handling is scoped to that feature.
+
 ## Validation
 
 `transform(validate=True)` reuses the Spark aggregate profile path. The application profile is built from final Spark bin labels, so learned missing merges appear in the destination bin and fallback `separate_bin` appears as `"Missing"`.
+
+If the fitted target column is absent from the Spark input, validation is skipped with `reason == "target_not_available"` and no application profile is created. The reference profile from fit is not modified by transform validation.
 
 ## Bundle
 
@@ -59,11 +73,24 @@ The audit bundle persists:
 - `missing_merge_fallback`
 - `missing_merge_map`
 - missing profile and decision logs
+- missing merge candidate tables
+- Spark transform fallback logs when a fallback error is observed before export
 
 `load_bundle(...)` loads these audit fields for review. It does not reconstruct a fitted estimator; Spark transformation remains the responsibility of the fitted in-memory `RiskBands` object.
+
+## Static guard
+
+G1B adds tests that inspect the direct Spark transform methods and block accidental introduction of:
+
+- Python UDFs
+- pandas UDFs
+- `.collect(` in direct transform expressions
+- `.toPandas(` in direct transform expressions
+
+Collection remains allowed only in named aggregate/profile helpers, such as missing-count aggregation for fallback `raise` and bounded validation profile collection.
 
 ## Next steps
 
 - G2: design Spark sampled-to-pandas fit support for merge, if still desired.
-- G3: refine Spark validation/reporting metadata around missing merge transform fallback logs.
-- G4: update public docs and release notes after functional gates are accepted.
+- G3: decide whether a reconstructed callable estimator from bundle is required, separate from the current audit-only `load_bundle(...)` contract.
+- G4: update public docs and release notes only after functional gates are accepted.

--- a/tests/test_missing_merge_pyspark_bundle_transform.py
+++ b/tests/test_missing_merge_pyspark_bundle_transform.py
@@ -52,7 +52,13 @@ def test_bundle_load_preserves_merge_decision_and_model_transforms_spark(
     observed = _values(transformed)
 
     assert loaded["missing_policy"] == "merge"
+    assert loaded["missing_merge_criterion"] == binner.missing_merge_criterion
+    assert loaded["missing_merge_fallback"] == binner.missing_merge_fallback
     assert loaded["missing_merge_map"]["score"] == learned_label
+    assert loaded["missing_profile"]
+    assert loaded["missing_decision_log"]
+    assert loaded["missing_merge_candidates"]
+    assert loaded["missing_decision_log"][0]["selected_bin_label"] == learned_label
     assert transformed.__class__.__module__.startswith("pyspark")
     assert Counter(observed)[learned_label] >= 2
     assert "Missing" not in observed
@@ -77,8 +83,42 @@ def test_bundle_load_preserves_merge_fallback_and_model_transforms_spark(spark_s
 
     assert loaded["missing_merge_fallback"] == "separate_bin"
     assert loaded["missing_merge_map"] == {}
+    assert loaded["missing_decision_log"]
+    assert loaded["missing_decision_log"][0]["action"] == "no_missing_detected"
     assert transformed.__class__.__module__.startswith("pyspark")
     assert Counter(_values(transformed))["Missing"] == 2
+
+
+def test_bundle_load_then_spark_raise_fallback_records_transform_log(spark_session, tmp_path):
+    fit_df = pd.DataFrame({"score": [-5.0, -4.0, 0.0, 3.0, 5.0] * 8, "target": [0, 0, 1, 1, 1] * 8})
+    binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        missing_merge_fallback="raise",
+    ).fit(fit_df, y="target", column="score")
+    binner.export_bundle(tmp_path / "before_transform")
+    loaded_before = load_bundle(tmp_path / "before_transform")
+
+    assert loaded_before["missing_merge_fallback"] == "raise"
+    assert loaded_before["missing_merge_map"] == {}
+
+    with pytest.raises(ValueError, match="no merge decision was learned"):
+        binner.transform(
+            _numeric_spark_frame(spark_session, [(None, 0), (-5.0, 0)]),
+            column="score",
+        )
+
+    assert binner.missing_transform_fallback_log_ is not None
+    assert not binner.missing_transform_fallback_log_.empty
+    assert binner.missing_transform_fallback_log_.iloc[0]["backend"] == "pyspark"
+
+    binner.export_bundle(tmp_path / "after_transform")
+    loaded_after = load_bundle(tmp_path / "after_transform")
+
+    assert loaded_after["missing_transform_fallback_log"]
+    assert loaded_after["missing_transform_fallback_log"][0]["backend"] == "pyspark"
 
 
 def test_bundle_model_still_blocks_spark_return_woe(spark_session, tmp_path):

--- a/tests/test_missing_merge_pyspark_edge_cases.py
+++ b/tests/test_missing_merge_pyspark_edge_cases.py
@@ -1,0 +1,163 @@
+from collections import Counter
+
+import pandas as pd
+import pytest
+
+from riskbands import RiskBands
+from tests.test_missing_merge_nearest_event_rate_pandas import (
+    fit_numeric_merge,
+    make_categorical_event_rate_frame,
+)
+
+pytestmark = pytest.mark.spark
+pytest_plugins = ["tests.test_missing_values_pyspark_current_behavior"]
+
+
+def _numeric_spark_frame(spark_session, rows):
+    from pyspark.sql import types as T
+
+    schema = T.StructType([T.StructField("score", T.DoubleType(), True)])
+    return spark_session.createDataFrame([(value,) for value in rows], schema=schema)
+
+
+def _categorical_spark_frame(spark_session, rows):
+    from pyspark.sql import types as T
+
+    schema = T.StructType([T.StructField("rating", T.StringType(), True)])
+    return spark_session.createDataFrame([(value,) for value in rows], schema=schema)
+
+
+def _mixed_spark_frame(spark_session, rows):
+    from pyspark.sql import types as T
+
+    schema = T.StructType(
+        [
+            T.StructField("score", T.DoubleType(), True),
+            T.StructField("rating", T.StringType(), True),
+        ]
+    )
+    return spark_session.createDataFrame(rows, schema=schema)
+
+
+def _values(spark_df, column):
+    return [row[column] for row in spark_df.select(column).collect()]
+
+
+def _string_counts(values):
+    return Counter(str(value) for value in values)
+
+
+def _fit_categorical_merge():
+    return RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        force_categorical=["rating"],
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    ).fit(make_categorical_event_rate_frame(), y="target", column="rating")
+
+
+def _fit_no_decision_mixed_binner(*, fallback):
+    fit_df = pd.DataFrame(
+        {
+            "score": [-5.0, -4.0, 0.0, 3.0, 5.0] * 8,
+            "rating": ["A", "A", "B", "C", "C"] * 8,
+            "target": [0, 0, 1, 1, 1] * 8,
+        }
+    )
+    return RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        force_categorical=["rating"],
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        missing_merge_fallback=fallback,
+    ).fit(fit_df, y="target", columns=["score", "rating"])
+
+
+def test_numeric_null_routes_to_learned_missing_merge_label(spark_session):
+    binner, _ = fit_numeric_merge()
+
+    observed = _values(binner.transform(_numeric_spark_frame(spark_session, [None]), column="score"), "score")
+
+    assert [str(value) for value in observed] == [str(binner.missing_merge_map_["score"])]
+
+
+def test_numeric_nan_routes_to_learned_missing_merge_label(spark_session):
+    binner, _ = fit_numeric_merge()
+
+    observed = _values(
+        binner.transform(_numeric_spark_frame(spark_session, [float("nan")]), column="score"),
+        "score",
+    )
+
+    assert [str(value) for value in observed] == [str(binner.missing_merge_map_["score"])]
+
+
+def test_numeric_null_and_nan_in_same_spark_frame_route_to_merge_label(spark_session):
+    binner, _ = fit_numeric_merge()
+
+    observed = _values(
+        binner.transform(_numeric_spark_frame(spark_session, [None, float("nan"), -5.0]), column="score"),
+        "score",
+    )
+
+    assert _string_counts(observed)[str(binner.missing_merge_map_["score"])] >= 2
+    assert "Missing" not in _string_counts(observed)
+
+
+def test_categorical_null_routes_to_merge_label_and_unknown_stays_distinct(spark_session):
+    binner = _fit_categorical_merge()
+    expected_unknown = binner.transform(pd.DataFrame({"rating": ["Z"]}), column="rating").loc[0, "rating"]
+
+    transformed = binner.transform(_categorical_spark_frame(spark_session, [None, "Z", "A"]), column="rating")
+    observed = _values(transformed, "rating")
+
+    assert str(observed[0]) == str(binner.missing_merge_map_["rating"])
+    assert str(observed[1]) == str(expected_unknown)
+    assert str(observed[1]) != str(observed[0])
+    assert str(observed[1]) != "Missing"
+
+
+def test_separate_bin_fallback_without_decision_handles_numeric_and_categorical_missing(
+    spark_session,
+):
+    binner = _fit_no_decision_mixed_binner(fallback="separate_bin")
+    assert binner.missing_merge_map_ == {}
+    spark_df = _mixed_spark_frame(
+        spark_session,
+        [(None, None), (float("nan"), "Z"), (-5.0, "A")],
+    )
+
+    transformed = binner.transform(spark_df, columns=["score", "rating"])
+
+    assert _string_counts(_values(transformed, "score"))["Missing"] == 2
+    assert _string_counts(_values(transformed, "rating"))["Missing"] == 1
+
+
+def test_raise_fallback_without_decision_reports_one_missing_column(spark_session):
+    binner = _fit_no_decision_mixed_binner(fallback="raise")
+    spark_df = _mixed_spark_frame(
+        spark_session,
+        [(None, None), (float("nan"), "Z"), (-5.0, "A")],
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="missing_policy='merge' detected missing values during Spark transform for feature (score|rating)",
+    ):
+        binner.transform(spark_df, columns=["score", "rating"])
+
+    assert binner.missing_transform_fallback_log_ is not None
+    assert binner.missing_transform_fallback_log_.iloc[0]["variable"] in {"score", "rating"}
+
+
+def test_raise_fallback_without_decision_allows_transform_when_no_missing(spark_session):
+    binner = _fit_no_decision_mixed_binner(fallback="raise")
+    spark_df = _mixed_spark_frame(spark_session, [(-5.0, "A"), (0.0, "B"), (5.0, "Z")])
+
+    transformed = binner.transform(spark_df, columns=["score", "rating"])
+
+    assert transformed.__class__.__module__.startswith("pyspark")
+    assert "Missing" not in _string_counts(_values(transformed, "score"))
+    assert "Missing" not in _string_counts(_values(transformed, "rating"))

--- a/tests/test_missing_merge_pyspark_equivalence.py
+++ b/tests/test_missing_merge_pyspark_equivalence.py
@@ -1,0 +1,119 @@
+from collections import Counter
+
+import pandas as pd
+import pytest
+
+from riskbands import RiskBands
+from tests.test_missing_merge_nearest_event_rate_pandas import (
+    fit_numeric_merge,
+    make_categorical_event_rate_frame,
+)
+from tests.test_missing_merge_nearest_woe_pandas import (
+    fit_categorical_woe_merge,
+    fit_numeric_woe_merge,
+)
+
+pytestmark = pytest.mark.spark
+pytest_plugins = ["tests.test_missing_values_pyspark_current_behavior"]
+
+
+def _canonical(value):
+    if pd.isna(value):
+        return "<NA>"
+    return str(value)
+
+
+def _counter(values):
+    return Counter(_canonical(value) for value in values)
+
+
+def _spark_values(spark_df, column):
+    return [row[column] for row in spark_df.select(column).collect()]
+
+
+def _numeric_spark_frame(spark_session, rows):
+    from pyspark.sql import types as T
+
+    schema = T.StructType([T.StructField("score", T.DoubleType(), True)])
+    return spark_session.createDataFrame([(value,) for value in rows], schema=schema)
+
+
+def _categorical_spark_frame(spark_session, rows):
+    from pyspark.sql import types as T
+
+    schema = T.StructType([T.StructField("rating", T.StringType(), True)])
+    return spark_session.createDataFrame([(value,) for value in rows], schema=schema)
+
+
+def _assert_transform_equivalent(binner, pandas_df, spark_df, column):
+    pandas_values = binner.transform(pandas_df, column=column)[column].tolist()
+    spark_values = _spark_values(binner.transform(spark_df, column=column), column)
+
+    assert _counter(spark_values) == _counter(pandas_values)
+
+
+@pytest.mark.parametrize(
+    "fit_factory",
+    [
+        fit_numeric_merge,
+        fit_numeric_woe_merge,
+    ],
+)
+def test_numeric_supervised_pandas_fit_spark_transform_matches_pandas(
+    spark_session,
+    fit_factory,
+):
+    binner, fit_df = fit_factory()
+    assert fit_df["score"].isna().any()
+    assert binner.missing_merge_map_["score"]
+
+    transform_values = [None, float("nan"), -5.0, -3.0, 0.0, 3.0, 5.0, 8.0]
+    pandas_df = pd.DataFrame({"score": transform_values})
+    spark_df = _numeric_spark_frame(spark_session, transform_values)
+
+    _assert_transform_equivalent(binner, pandas_df, spark_df, "score")
+
+
+def test_categorical_nearest_event_rate_pandas_fit_spark_transform_matches_pandas(spark_session):
+    fit_df = make_categorical_event_rate_frame()
+    binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        force_categorical=["rating"],
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    ).fit(fit_df, y="target", column="rating")
+    assert fit_df["rating"].isna().any()
+    assert binner.missing_merge_map_["rating"]
+
+    transform_values = [None, "A", "B", "C", "Z", "A", None]
+    pandas_df = pd.DataFrame({"rating": transform_values})
+    spark_df = _categorical_spark_frame(spark_session, transform_values)
+
+    _assert_transform_equivalent(binner, pandas_df, spark_df, "rating")
+
+
+def test_categorical_nearest_woe_pandas_fit_spark_transform_matches_pandas(spark_session):
+    binner, fit_df = fit_categorical_woe_merge()
+    assert fit_df["rating"].isna().any()
+    assert binner.missing_merge_map_["rating"]
+
+    transform_values = [None, "A", "B", "C", "Z", "A", None]
+    pandas_df = pd.DataFrame({"rating": transform_values})
+    spark_df = _categorical_spark_frame(spark_session, transform_values)
+
+    _assert_transform_equivalent(binner, pandas_df, spark_df, "rating")
+
+
+def test_numeric_unsupervised_missing_merge_equivalence_not_supported_by_pandas_transform():
+    fit_df = pd.DataFrame({"score": [-5.0, -4.0, 0.0, 3.0, 5.0] * 8, "target": [0, 0, 1, 1, 1] * 8})
+    binner = RiskBands(
+        strategy="unsupervised",
+        max_bins=3,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        missing_merge_fallback="separate_bin",
+    ).fit(fit_df, y="target", column="score")
+
+    with pytest.raises(ValueError, match="KBinsDiscretizer does not accept missing values"):
+        binner.transform(pd.DataFrame({"score": [float("nan"), -5.0]}), column="score")

--- a/tests/test_missing_merge_pyspark_multifeature.py
+++ b/tests/test_missing_merge_pyspark_multifeature.py
@@ -1,0 +1,130 @@
+from collections import Counter
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from riskbands import RiskBands
+
+pytestmark = pytest.mark.spark
+pytest_plugins = ["tests.test_missing_values_pyspark_current_behavior"]
+
+
+def _make_mixed_fit_frame():
+    rows = []
+    specs = [
+        (-5.0, -50.0, "A", 4, 40),
+        (-3.0, -30.0, "A", 8, 40),
+        (0.0, 0.0, "B", 20, 40),
+        (3.0, 30.0, "C", 32, 40),
+        (5.0, 50.0, "C", 36, 40),
+    ]
+    for score_a, score_b, rating, events, n_rows in specs:
+        targets = [1] * events + [0] * (n_rows - events)
+        for idx, target in enumerate(targets):
+            rows.append(
+                {
+                    "score_a": score_a,
+                    "score_b": score_b + (idx % 3) * 0.01,
+                    "rating": rating,
+                    "target": target,
+                }
+            )
+    for idx, target in enumerate([1] * 20 + [0] * 20):
+        rows.append(
+            {
+                "score_a": np.nan,
+                "score_b": 10.0 + (idx % 3) * 0.01,
+                "rating": None,
+                "target": target,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _fit_mixed_binner(criterion):
+    return RiskBands(
+        max_bins=5,
+        min_event_rate_diff=0.0,
+        force_categorical=["rating"],
+        missing_policy="merge",
+        missing_merge_criterion=criterion,
+        missing_merge_fallback="separate_bin",
+    ).fit(
+        _make_mixed_fit_frame(),
+        y="target",
+        columns=["score_a", "score_b", "rating"],
+    )
+
+
+def _mixed_spark_frame(spark_session):
+    from pyspark.sql import types as T
+
+    schema = T.StructType(
+        [
+            T.StructField("score_a", T.DoubleType(), True),
+            T.StructField("score_b", T.DoubleType(), True),
+            T.StructField("rating", T.StringType(), True),
+            T.StructField("segment", T.StringType(), True),
+        ]
+    )
+    rows = [
+        (None, None, None, "extra-a"),
+        (float("nan"), float("nan"), "A", "extra-b"),
+        (-5.0, -50.0, "Z", "extra-c"),
+        (0.0, 0.0, "B", "extra-d"),
+        (5.0, 50.0, "C", "extra-e"),
+    ]
+    return spark_session.createDataFrame(rows, schema=schema)
+
+
+def _column_values(spark_df, column):
+    return [row[column] for row in spark_df.select(column).collect()]
+
+
+def _string_counts(values):
+    return Counter(str(value) for value in values)
+
+
+@pytest.mark.parametrize("criterion", ["nearest_event_rate", "nearest_woe"])
+def test_multifeature_subset_transform_uses_column_merge_maps_and_drops_extras(
+    spark_session,
+    criterion,
+):
+    binner = _fit_mixed_binner(criterion)
+    spark_df = _mixed_spark_frame(spark_session)
+
+    transformed = binner.transform(spark_df, columns=["score_a", "rating"])
+
+    assert transformed.columns == ["score_a", "rating"]
+    assert "segment" not in transformed.columns
+    assert "score_b" not in transformed.columns
+    assert _string_counts(_column_values(transformed, "score_a"))[
+        str(binner.missing_merge_map_["score_a"])
+    ] >= 2
+    assert _string_counts(_column_values(transformed, "rating"))[
+        str(binner.missing_merge_map_["rating"])
+    ] >= 1
+    assert "Missing" not in _string_counts(_column_values(transformed, "score_a"))
+    assert "Missing" not in _string_counts(_column_values(transformed, "rating"))
+
+
+@pytest.mark.parametrize("criterion", ["nearest_event_rate", "nearest_woe"])
+def test_multifeature_all_columns_uses_separate_fallback_only_for_column_without_decision(
+    spark_session,
+    criterion,
+):
+    binner = _fit_mixed_binner(criterion)
+    assert set(binner.missing_merge_map_) == {"score_a", "rating"}
+    spark_df = _mixed_spark_frame(spark_session)
+
+    transformed = binner.transform(spark_df, columns=["score_a", "score_b", "rating"])
+
+    assert transformed.columns == ["score_a", "score_b", "rating"]
+    assert _string_counts(_column_values(transformed, "score_a"))[
+        str(binner.missing_merge_map_["score_a"])
+    ] >= 2
+    assert _string_counts(_column_values(transformed, "rating"))[
+        str(binner.missing_merge_map_["rating"])
+    ] >= 1
+    assert _string_counts(_column_values(transformed, "score_b"))["Missing"] == 2

--- a/tests/test_missing_merge_pyspark_static_guards.py
+++ b/tests/test_missing_merge_pyspark_static_guards.py
@@ -1,0 +1,44 @@
+import inspect
+
+import pytest
+
+from riskbands.binning_engine import Binner
+
+DIRECT_SPARK_TRANSFORM_METHODS = [
+    "_check_missing_policy_pyspark",
+    "_transform_pyspark",
+    "_spark_transform_expression",
+    "_numeric_supervised_spark_expression",
+    "_numeric_unsupervised_spark_expression",
+    "_categorical_spark_expression",
+]
+
+FORBIDDEN_DIRECT_TOKENS = [
+    ".toPandas(",
+    ".collect(",
+    "udf(",
+    "pandas_udf",
+    "UserDefinedFunction",
+]
+
+
+@pytest.mark.parametrize("method_name", DIRECT_SPARK_TRANSFORM_METHODS)
+def test_spark_missing_merge_direct_transform_path_has_no_udf_or_full_collect(method_name):
+    source = inspect.getsource(getattr(Binner, method_name))
+
+    for token in FORBIDDEN_DIRECT_TOKENS:
+        assert token not in source
+
+
+def test_spark_collect_exceptions_are_limited_to_named_aggregate_helpers():
+    allowed_collect_helpers = {
+        "_pyspark_missing_counts": ".collect(",
+        "_collect_pyspark_profile_aggregate": ".toPandas(",
+    }
+
+    for method_name, expected_token in allowed_collect_helpers.items():
+        source = inspect.getsource(getattr(Binner, method_name))
+        assert expected_token in source
+
+    assert ".toPandas(" not in inspect.getsource(Binner._pyspark_missing_counts)
+    assert ".collect(" not in inspect.getsource(Binner._collect_pyspark_profile_aggregate)

--- a/tests/test_missing_merge_pyspark_validation.py
+++ b/tests/test_missing_merge_pyspark_validation.py
@@ -2,6 +2,7 @@ from collections import Counter
 
 import pandas as pd
 import pytest
+from pandas.testing import assert_frame_equal
 
 from riskbands import RiskBands
 from tests.test_missing_merge_nearest_event_rate_pandas import fit_numeric_merge
@@ -30,6 +31,7 @@ def _bin_counts(profile):
 def test_merge_spark_transform_validate_true_profiles_final_merged_bin(spark_session, monkeypatch):
     binner, _ = fit_numeric_merge()
     learned_label = binner.missing_merge_map_["score"]
+    reference_before = binner.reference_profile_.copy()
     sdf = _numeric_spark_frame(
         spark_session,
         [(None, 1), (float("nan"), 0), (-5.0, 0), (-3.0, 0), (0.0, 1), (3.0, 1), (5.0, 1)],
@@ -41,11 +43,15 @@ def test_merge_spark_transform_validate_true_profiles_final_merged_bin(spark_ses
 
     assert transformed.__class__.__module__.startswith("pyspark")
     assert profile is not None
+    assert binner.transform_validation_report_ is binner.validation_report_
     assert binner.transform_validation_report_["backend"] == "pyspark"
+    assert binner.transform_validation_report_["status"] in {"ok", "warning", "critical"}
+    assert binner.transform_validation_report_["summary"]["target_available"] is True
     assert binner.transform_validation_report_["summary"]["n_application_rows"] == 7
     assert str(learned_label) in _bin_counts(profile)
     assert "Missing" not in set(profile["bin_label"].astype(str))
     assert not profile["is_missing_bin"].fillna(False).astype(bool).any()
+    assert_frame_equal(binner.reference_profile_, reference_before)
     assert calls
     assert max(call["rows"] for call in calls) <= 20
 
@@ -74,5 +80,27 @@ def test_merge_spark_transform_validate_true_profiles_separate_fallback_missing(
     assert int(missing_rows.iloc[0]["n"]) == 2
     assert bool(missing_rows.iloc[0]["is_missing_bin"]) is True
     assert binner.transform_validation_report_["backend"] == "pyspark"
+    assert binner.transform_validation_report_["summary"]["target_available"] is True
     assert calls
     assert max(call["rows"] for call in calls) <= 20
+
+
+def test_merge_spark_transform_validate_true_without_target_skips_profile(spark_session):
+    binner, _ = fit_numeric_merge()
+    reference_before = binner.reference_profile_.copy()
+    sdf = spark_session.createDataFrame(
+        [(None,), (float("nan"),), (-5.0,), (0.0,), (5.0,)],
+        schema="score double",
+    )
+
+    transformed = binner.transform(sdf, column="score", validate=True)
+
+    assert transformed.__class__.__module__.startswith("pyspark")
+    assert binner.application_profile_ is None
+    assert binner.transform_validation_report_ is binner.validation_report_
+    assert binner.transform_validation_report_["validation_type"] == "transform"
+    assert binner.transform_validation_report_["status"] == "skipped"
+    assert binner.transform_validation_report_["reason"] == "target_not_available"
+    assert binner.transform_validation_report_["backend"] == "pyspark"
+    assert binner.transform_validation_report_["reference_profile_source"] == "fit_profile"
+    assert_frame_equal(binner.reference_profile_, reference_before)


### PR DESCRIPTION
Adds hardening coverage for PySpark missing merge transform, including pandas/Spark equivalence, multi-feature scenarios, NULL/NaN handling, unknown categories, fallback behavior, validate=True, bundle metadata, and static guards against UDF/full collect in direct transform paths. This does not add a new API, criterion, version bump, Spark fit with merge, or Spark return_woe support.