### PR TITLE
Add narrative audit report for bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,5 @@ artifacts/local/
 
 docs/presentations/
 docs/goals/
+examples/_tmp_riskbands_bundle_smoke/
+examples/exemplo0.ipynb

--- a/docs-site/src/content/docs/en/technical/api-overview.md
+++ b/docs-site/src/content/docs/en/technical/api-overview.md
@@ -38,6 +38,7 @@ compatibility, and `RiskBands is Binner` remains true.
 | `audit_table()` | Consolidated auditable review | Combines cuts, score, penalties, coverage, and rationale |
 | `diagnostics()` | Detailed temporal reading | Opens stability by bin or by variable |
 | `export_binnings_json()` | Single JSON artifact | Makes versioning and governance easier |
+| `export_audit_report()` | Narrative HTML report | Explains bundle, missing policies, merge, validation, and limitations in audit-friendly language |
 | `export_bundle()` | Complete audit package | Generates JSON, CSV, and feature-level tables |
 | `BinComparator` | Champion/challenger comparison | Helps choose between multiple candidates |
 
@@ -60,6 +61,7 @@ score_table = binner.score_table()
 audit_table = binner.audit_table()
 
 binner.export_binnings_json("artifacts/riskbands_binnings.json")
+binner.export_audit_report("artifacts/audit_report.html")
 binner.export_bundle("artifacts/run_2026_04_14")
 ```
 
@@ -117,6 +119,11 @@ After the first `fit`, the most useful trio is usually:
 - `summary()` for a short reading
 - `score_table()` to understand score and weights
 - `audit_table()` to open the auditable review
+
+To share the result with audit, governance, or model risk, use
+`export_audit_report("audit_report.html")`. The HTML is standalone,
+print-friendly, and is also included in the bundle by default through
+`export_bundle(...)`.
 
 ## Next steps
 

--- a/docs-site/src/content/docs/en/technical/examples.md
+++ b/docs-site/src/content/docs/en/technical/examples.md
@@ -55,6 +55,19 @@ They show:
 - comparison across `standard`, `separate_bin`, `forbid`, `merge + nearest_event_rate`, and `merge + nearest_woe`
 - synthetic credit-risk data without real or sensitive records
 
+### Narrative audit report
+
+- [Audit report demo](https://github.com/joaaomaia/RiskBands/blob/main/examples/audit_report/audit_bundle_report_demo.py)
+
+This flow shows:
+
+- a small synthetic dataset;
+- `missing_policy="merge"`;
+- `missing_merge_criterion="nearest_event_rate"`;
+- `export_audit_report("audit_report.html")`;
+- `export_bundle("bundle")` with `audit_report.html` included by default;
+- generated file paths without opening a browser automatically.
+
 ### PD vintage champion/challenger
 
 - [Champion/challenger script](https://github.com/joaaomaia/RiskBands/blob/main/examples/pd_vintage_champion_challenger/pd_vintage_champion_challenger.py)
@@ -82,8 +95,9 @@ decision.
 3. API overview
 4. Outputs and diagnostics
 5. Missing policy
-6. PD vintage champion/challenger
-7. PD vintage benchmark
+6. Narrative audit report
+7. PD vintage champion/challenger
+8. PD vintage benchmark
 
 ### If you want to start with the methodology
 

--- a/docs-site/src/content/docs/en/technical/outputs.md
+++ b/docs-site/src/content/docs/en/technical/outputs.md
@@ -21,6 +21,7 @@ After fitting a `Binner`, the public API exposes friendly artifacts:
 - `plot_bin_share_over_time()`
 - `plot_score_components()`
 - `export_binnings_json()`
+- `export_audit_report()`
 - `export_bundle()`
 
 Useful post-fit attributes are also available, such as:
@@ -67,8 +68,14 @@ This is the best entry point to investigate:
 `export_binnings_json(path)` generates a single JSON with metadata, score
 weights, bins by feature, summary, score details, and feature-level audit.
 
-`export_bundle(path)` generates readable JSON, CSVs, feature-level tables, and
-optional Parquet when an engine is available.
+`export_audit_report(path)` generates `audit_report.html`: a standalone
+narrative HTML report with embedded CSS, no external assets, print-friendly
+styling, and an audit/model-risk audience.
+
+`export_bundle(path)` generates readable JSON, CSVs, feature-level tables,
+optional Parquet when an engine is available, and `audit_report.html` by
+default. Use `export_bundle(path, include_audit_report=False)` only when the
+bundle must omit the narrative HTML.
 
 Bundles also persist the missing-values trail when available:
 `missing_policy`, `effective_missing_policy`, `missing_profile`,
@@ -86,6 +93,18 @@ to review candidates and distances and `missing_merge_map_` to see the learned
 destination.
 
 Dedicated guide: [Missing policy](../missing-policy/).
+
+## Narrative audit report
+
+`audit_report.html` explains configuration, variables, missing policies, merge
+decisions, evaluated candidates, validation, alerts, bundle inventory, and
+limitations. For merge, the text makes clear that the decision was learned
+during `fit` and reused during `transform`, without recalculating event rate or
+WoE on application data.
+
+The HTML is self-contained and can be printed or exported to PDF by the browser.
+It organizes technical evidence, but it does not replace independent formal
+validation and does not constitute regulatory certification.
 
 ## Fast score reading
 
@@ -105,5 +124,6 @@ score_table = binner.score_table()
 audit_table = binner.audit_table()
 
 binner.export_binnings_json("artifacts/riskbands_binnings.json")
+binner.export_audit_report("artifacts/audit_report.html")
 binner.export_bundle("artifacts/run_2026_04_14")
 ```

--- a/docs-site/src/content/docs/technical/api-overview.md
+++ b/docs-site/src/content/docs/technical/api-overview.md
@@ -1,11 +1,11 @@
 ---
-title: "Visao geral da API"
-description: "Mapa da superficie publica do RiskBands, com foco em onboarding, auditoria e leitura temporal amigavel."
+title: "Visão geral da API"
+description: "Mapa da superfície pública do RiskBands, com foco em onboarding, auditoria e leitura temporal amigável."
 ---
 
 ## Porta de entrada recomendada
 
-Na maior parte dos casos, o fluxo ideal para um usuario novo e:
+Na maior parte dos casos, o fluxo ideal para um usuário novo é:
 
 1. instanciar `RiskBands`
 2. rodar `fit(...)`
@@ -14,7 +14,7 @@ Na maior parte dos casos, o fluxo ideal para um usuario novo e:
 5. exportar os artefatos auditaveis
 6. usar os plots publicos para leitura temporal
 
-## Superficie publica principal
+## Superfície pública principal
 
 ```python
 from riskbands import RiskBands, Binner, BinComparator
@@ -25,7 +25,7 @@ from riskbands.temporal_stability import (
 )
 ```
 
-`RiskBands` e o nome preferido. `Binner` segue disponivel para compatibilidade,
+`RiskBands` é o nome preferido. `Binner` segue disponível para compatibilidade,
 e `RiskBands is Binner` continua verdadeiro.
 
 ## Blocos centrais
@@ -34,14 +34,15 @@ e `RiskBands is Binner` continua verdadeiro.
 | --- | --- | --- |
 | `RiskBands` / `Binner` | Porta de entrada principal | Ajusta, transforma, resume, exporta e plota sem exigir estruturas internas |
 | `summary()` | Resumo curto pos-fit | Ajuda a entender bins, IV e score |
-| `score_table()` | Explicacao curta do objective | Expoe score final, pesos e componentes mais relevantes |
-| `audit_table()` | Revisao auditavel consolidada | Junta cuts, score, penalidades, cobertura e rationale |
-| `diagnostics()` | Leitura temporal detalhada | Abre estabilidade por bin ou por variavel |
-| `export_binnings_json()` | Artefato unico em JSON | Facilita versionamento e governanca |
+| `score_table()` | Explicação curta do objective | Expõe score final, pesos e componentes mais relevantes |
+| `audit_table()` | Revisão auditável consolidada | Junta cuts, score, penalidades, cobertura e rationale |
+| `diagnostics()` | Leitura temporal detalhada | Abre estabilidade por bin ou por variável |
+| `export_binnings_json()` | Artefato único em JSON | Facilita versionamento e governança |
+| `export_audit_report()` | Relatório de Auditoria do Binning | Explica bundle, missing policies, merge, validação e limitações em linguagem auditável |
 | `export_bundle()` | Pacote completo de auditoria | Gera JSON, CSV e tabelas por feature |
 | `BinComparator` | Comparacao champion/challenger | Ajuda a escolher entre multiplos candidatos |
 
-## Fluxo recomendado para candidato unico
+## Fluxo recomendado para candidato único
 
 ```python
 binner = RiskBands(
@@ -60,39 +61,40 @@ score_table = binner.score_table()
 audit_table = binner.audit_table()
 
 binner.export_binnings_json("artifacts/riskbands_binnings.json")
+binner.export_audit_report("artifacts/audit_report.html")
 binner.export_bundle("artifacts/run_2026_04_14")
 ```
 
-## Estrategias de score
+## Estratégias de score
 
-A API expoe duas estrategias explicitas:
+A API expõe duas estratégias explícitas:
 
-- `standard`: score historico orientado a maximizacao. `legacy` segue aceito
-  apenas como alias compativel.
-- `stable`: objective orientado a robustez temporal e minimizacao.
+- `standard`: score histórico orientado a maximização. `legacy` segue aceito
+  apenas como alias compatível.
+- `stable`: objective orientado a robustez temporal e minimização.
 
 ## Missing values
 
 `missing_policy` aceita:
 
-- `standard`: default compativel com o comportamento atual
-- `separate_bin`: opt-in para bin explicito `Missing`
+- `standard`: default compatível com o comportamento atual
+- `separate_bin`: opt-in para bin explícito `Missing`
 - `forbid`: erro em `fit` ou `transform` quando ha missing nas features selecionadas
-- `merge`: opt-in pandas para rotear missing ao bin regular mais proximo aprendido no `fit`
+- `merge`: opt-in pandas para rotear missing ao bin regular mais próximo aprendido no `fit`
 
 `merge` exige `missing_merge_criterion="nearest_event_rate"` ou
-`missing_merge_criterion="nearest_woe"`. O primeiro usa distancia absoluta de
-taxa de evento; o segundo usa distancia absoluta de WoE. `missing_merge_fallback`
+`missing_merge_criterion="nearest_woe"`. O primeiro usa distância absoluta de
+taxa de evento; o segundo usa distância absoluta de WoE. `missing_merge_fallback`
 aceita `separate_bin` ou `raise` para missing que aparece no `transform` sem
-decisao aprendida no `fit`.
+decisão aprendida no `fit`.
 
-Essas politicas nao fazem imputacao opaca. Em merge, `transform(...)` usa
-somente a decisao aprendida no `fit` e nao aprende regra nova com a base de
-aplicacao.
+Essas políticas não fazem imputação opaca. Em merge, `transform(...)` usa
+somente a decisão aprendida no `fit` e não aprende regra nova com a base de
+aplicação.
 
 Depois do `fit`, inspecione `missing_profile_`, `missing_decision_log_`,
 `missing_merge_candidates_` e `missing_merge_map_` para revisar volume, share,
-event rate, criterio, candidatos, distancias e destino aprendido.
+event rate, critério, candidatos, distâncias e destino aprendido.
 
 Exemplo:
 
@@ -112,13 +114,17 @@ Guia dedicado: [Missing policy](../missing-policy/).
 
 ## O que olhar em seguida
 
-Depois do primeiro `fit`, o trio mais util costuma ser:
+Depois do primeiro `fit`, o trio mais útil costuma ser:
 
 - `summary()` para uma leitura curta
 - `score_table()` para entender o score e os pesos
-- `audit_table()` para abrir a revisao auditavel
+- `audit_table()` para abrir a revisão auditável
 
-## Proximos passos
+Para compartilhar o resultado com auditoria, governança ou model risk, use
+`export_audit_report("audit_report.html")`. O HTML é standalone, print-friendly
+e também entra no bundle por padrão via `export_bundle(...)`.
+
+## Próximos passos
 
 - [Quickstart](../quickstart/)
 - [Auditoria e plots](../audit-and-plots/)

--- a/docs-site/src/content/docs/technical/examples.md
+++ b/docs-site/src/content/docs/technical/examples.md
@@ -1,6 +1,6 @@
 ---
 title: "Exemplos"
-description: "Scripts e notebooks para quickstart, benchmark, auditoria e demonstracao da API amigavel do RiskBands."
+description: "Scripts e notebooks para quickstart, benchmark, auditoria e demonstração da API amigável do RiskBands."
 ---
 
 ## Comece por aqui
@@ -10,7 +10,7 @@ description: "Scripts e notebooks para quickstart, benchmark, auditoria e demons
 Porta de entrada recomendada para aprender o RiskBands com um fluxo familiar de
 pandas e sklearn.
 
-- [Notebook sintetico com Plotly](https://github.com/joaaomaia/RiskBands/blob/main/examples/riskbands_synthetic_plotly_comparative_demo.ipynb)
+- [Notebook sintético com Plotly](https://github.com/joaaomaia/RiskBands/blob/main/examples/riskbands_synthetic_plotly_comparative_demo.ipynb)
 
 Esse material mostra:
 
@@ -20,7 +20,7 @@ Esse material mostra:
 - `binning_table()`
 - `score_details()`
 - `diagnostics()`
-- comparacao entre `standard` e `stable`
+- comparação entre `standard` e `stable`
 
 ### Quickstart de estabilidade temporal
 
@@ -28,17 +28,17 @@ Esse material mostra:
 - [Notebook do quickstart](https://github.com/joaaomaia/RiskBands/blob/main/examples/temporal_stability/temporal_stability_example.ipynb)
 
 Esse fluxo mostra `score_table()`, `audit_table()`, export JSON/bundle e plots
-publicos para leitura temporal.
+públicos para leitura temporal.
 
 ### Missing policy pandas e PySpark
 
 Use estes scripts quando a pergunta principal for como tratar missing values de
-forma auditavel sem imputacao opaca.
+forma auditável sem imputação opaca.
 
 - [Demo pandas de missing policy](https://github.com/joaaomaia/RiskBands/blob/main/examples/missing_policy/missing_policy_pandas_demo.py)
 - [Demo PySpark de missing policy](https://github.com/joaaomaia/RiskBands/blob/main/examples/missing_policy/missing_policy_pyspark_demo.py)
-- [Diagnostico comparativo de missing policy](https://github.com/joaaomaia/RiskBands/blob/main/examples/missing_policy/missing_policy_comparison_demo.py)
-- [Exemplo sintetico de credito com missing merge](https://github.com/joaaomaia/RiskBands/blob/main/examples/missing_policy/credit_risk_missing_merge_demo.py)
+- [Diagnóstico comparativo de missing policy](https://github.com/joaaomaia/RiskBands/blob/main/examples/missing_policy/missing_policy_comparison_demo.py)
+- [Exemplo sintético de crédito com missing merge](https://github.com/joaaomaia/RiskBands/blob/main/examples/missing_policy/credit_risk_missing_merge_demo.py)
 
 Eles mostram:
 
@@ -52,8 +52,21 @@ Eles mostram:
 - `missing_merge_candidates_`
 - bundle com campos de missing policy e missing merge
 - guarda opcional para PySpark
-- comparacao entre `standard`, `separate_bin`, `forbid`, `merge + nearest_event_rate` e `merge + nearest_woe`
-- exemplo sintetico de risco de credito sem dados reais
+- comparação entre `standard`, `separate_bin`, `forbid`, `merge + nearest_event_rate` e `merge + nearest_woe`
+- exemplo sintético de risco de crédito sem dados reais
+
+### Relatório de Auditoria do Binning
+
+- [Demo do audit report](https://github.com/joaaomaia/RiskBands/blob/main/examples/audit_report/audit_bundle_report_demo.py)
+
+Esse fluxo mostra:
+
+- dataset sintético pequeno;
+- `missing_policy="merge"`;
+- `missing_merge_criterion="nearest_event_rate"`;
+- `export_audit_report("audit_report.html")`;
+- `export_bundle("bundle")` com `audit_report.html` incluído por padrão;
+- caminhos dos arquivos gerados sem abrir navegador automaticamente.
 
 ### PD vintage champion challenger
 
@@ -66,8 +79,8 @@ Eles mostram:
 - [Notebook do benchmark](https://github.com/joaaomaia/RiskBands/blob/main/examples/pd_vintage_benchmark/pd_vintage_benchmark.ipynb)
 
 Use este material quando a pergunta principal for por que um candidato com IV
-agregado mais forte ainda pode ser a escolha errada para credito quando o tempo
-entra na decisao.
+agregado mais forte ainda pode ser a escolha errada para crédito quando o tempo
+entra na decisão.
 
 ### Demo do score `stable`
 
@@ -75,19 +88,20 @@ entra na decisao.
 
 ## Ordem de leitura sugerida
 
-### Se voce quer comecar pela API
+### Se você quer começar pela API
 
-1. Notebook sintetico com Plotly
+1. Notebook sintético com Plotly
 2. Quickstart
 3. Auditoria e plots
-4. Visao geral da API
+4. Visão geral da API
 5. Missing policy
-6. PD vintage champion challenger
-7. Benchmark PD vintage
+6. Relatório de Auditoria do Binning
+7. PD vintage champion challenger
+8. Benchmark PD vintage
 
-### Se voce quer comecar pela tese metodologica
+### Se você quer começar pela tese metodológica
 
 1. Por que RiskBands
-2. Por que nao usar apenas OptimalBinning
+2. Por que não usar apenas OptimalBinning
 3. Benchmark PD vintage
 4. Como ler os graficos

--- a/docs-site/src/content/docs/technical/outputs.md
+++ b/docs-site/src/content/docs/technical/outputs.md
@@ -1,11 +1,11 @@
 ---
-title: "Outputs e diagnostico"
+title: "Outputs e diagnóstico"
 description: "Como interpretar os principais outputs do Binner depois do fit, com foco em auditoria, score e leitura temporal."
 ---
 
 ## O que aparece depois do `fit`
 
-Depois de ajustar um `Binner`, a API publica expoe artefatos amigaveis:
+Depois de ajustar um `Binner`, a API pública expõe artefatos amigáveis:
 
 - `binning_table()`
 - `feature_binning_table()` e `get_binning_table()`
@@ -21,9 +21,10 @@ Depois de ajustar um `Binner`, a API publica expoe artefatos amigaveis:
 - `plot_bin_share_over_time()`
 - `plot_score_components()`
 - `export_binnings_json()`
+- `export_audit_report()`
 - `export_bundle()`
 
-Tambem ficam disponiveis atributos pos-fit como:
+Também ficam disponíveis atributos pós-fit como:
 
 - `binning_table_`
 - `summary_`
@@ -37,17 +38,17 @@ Tambem ficam disponiveis atributos pos-fit como:
 
 ## Tabelas principais
 
-`binning_table()` mostra cortes ou bins finais. `score_table()` e a tabela curta
+`binning_table()` mostra cortes ou bins finais. `score_table()` é a tabela curta
 para explicar objective, pesos, componentes normalizados e componentes raw.
 `audit_table()` combina cortes, IV, score temporal, penalidades, cobertura,
-bins raros, reversoes e rationale resumido.
+bins raros, reversões e rationale resumido.
 
-## Diagnostico temporal
+## Diagnóstico temporal
 
-Use `diagnostics(kind="bin")` para abrir detalhe por bin e periodo. Use
-`diagnostics(kind="variable")` para resumo temporal agregado por variavel.
+Use `diagnostics(kind="bin")` para abrir detalhe por bin e período. Use
+`diagnostics(kind="variable")` para resumo temporal agregado por variável.
 
-Essa e a melhor porta para investigar:
+Essa é a melhor porta para investigar:
 
 - cobertura
 - volatilidade de event rate
@@ -58,41 +59,59 @@ Essa e a melhor porta para investigar:
 
 ## Metadata
 
-`metadata_` inclui versao do `riskbands`, estrategia, `score_strategy`,
+`metadata_` inclui versão do `riskbands`, estratégia, `score_strategy`,
 `normalization_strategy`, `woe_shrinkage_strength`, pesos, `target_name`,
 `time_col` e features ajustadas.
 
-## Export auditavel
+## Export auditável
 
-`export_binnings_json(path)` gera um JSON unico com metadata, pesos do score,
+`export_binnings_json(path)` gera um JSON único com metadata, pesos do score,
 bins por feature, resumo, score details e auditoria por feature.
 
-`export_bundle(path)` gera JSON legivel, CSVs, tabelas por feature e Parquet
-opcional quando houver engine disponivel.
+`export_audit_report(path)` gera `audit_report.html`: um relatório narrativo
+HTML standalone, com CSS embutido, sem assets externos, print-friendly e
+orientado a auditoria/model risk.
 
-Bundles tambem persistem a trilha de missing values quando disponivel:
+`export_bundle(path)` gera JSON legível, CSVs, tabelas por feature, Parquet
+opcional quando houver engine disponível e `audit_report.html` por padrão.
+Use `export_bundle(path, include_audit_report=False)` apenas quando precisar
+manter o bundle sem o HTML narrativo.
+
+Bundles também persistem a trilha de missing values quando disponível:
 `missing_policy`, `effective_missing_policy`, `missing_profile`,
 `missing_decision_log`, `missing_merge_criterion`, `missing_merge_fallback`,
 `missing_merge_candidates` e `missing_merge_map`.
 
-Esses campos registram a decisao de tratamento de missing values. Eles nao
-representam imputacao opaca.
+Esses campos registram a decisão de tratamento de missing values. Eles não
+representam imputação opaca.
 
 Use `missing_profile_` para revisar volume, share e event rate dos missing por
-variavel. Use `missing_decision_log_` para ver se a acao foi preservar
+variável. Use `missing_decision_log_` para ver se a ação foi preservar
 `standard`, criar bin `Missing` com `separate_bin`, bloquear com `forbid` ou
 rotear missing com `merge`. Para merge, use `missing_merge_candidates_` para
-revisar candidatos e distancias e `missing_merge_map_` para ver o destino
+revisar candidatos e distâncias e `missing_merge_map_` para ver o destino
 aprendido.
 
 Guia dedicado: [Missing policy](../missing-policy/).
 
-## Leitura rapida do score
+## Relatório de Auditoria do Binning
+
+O `audit_report.html` explica configuração, variáveis, políticas de missing,
+decisões de merge, candidatos avaliados, validação, alertas, inventário do
+bundle e limitações. Para merge, o texto deixa claro que a decisão foi aprendida
+no `fit` e reutilizada no `transform`, sem recalcular event rate/WoE na base de
+aplicacao.
+
+O HTML é autocontido e pode ser impresso ou exportado para PDF pelo navegador.
+Ele organiza evidências técnicas, mas não substitui validação formal
+independente nem constitui certificação regulatória.
+
+## Leitura rápida do score
 
 - `standard`: score bruto maior e melhor
 - `stable`: score bruto menor e melhor
 
-Para uma regua consolidada entre estrategias, veja `objective_preference_score`.
+Para uma régua consolidada entre estratégias, veja `objective_preference_score`.
 
 ## Exemplo
 
@@ -104,5 +123,6 @@ score_table = binner.score_table()
 audit_table = binner.audit_table()
 
 binner.export_binnings_json("artifacts/riskbands_binnings.json")
+binner.export_audit_report("artifacts/audit_report.html")
 binner.export_bundle("artifacts/run_2026_04_14")
 ```

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -65,7 +65,8 @@ Common methods:
 - `feature_binning_table(column=None, feature=None)`
 - `get_binning_table(column=None, feature=None)`
 - `export_binnings_json(path)`
-- `export_bundle(path)`
+- `export_audit_report(path, title=None, dataset_name=None)`
+- `export_bundle(path, include_audit_report=True)`
 - `plot_event_rate_stability(pivot=None, **kwargs)`
 - `plot_bad_rate_over_time(X=None, y=None, time_col=None, column=None, ...)`
 - `plot_bad_rate_heatmap(X=None, y=None, time_col=None, column=None, ...)`
@@ -206,8 +207,19 @@ Main attributes after `fit`:
 - friendly CSV outputs such as `summary.csv`, `score_table.csv`, `audit_table.csv`, and `report.csv`
 - missing audit outputs such as `missing_profile.csv` and `missing_decision_log.csv` when available
 - merge audit outputs such as `missing_merge_candidates.csv` when available
+- `audit_report.html` by default, unless `include_audit_report=False`
 - per-feature tables under `feature_tables/`
 - parquet artifacts when the environment has parquet support available
+
+`export_audit_report(path, title=None, dataset_name=None)` creates a standalone
+HTML narrative report with embedded CSS and no external assets. It explains the
+model configuration, variables, missing policies, missing merge decisions,
+merge candidates, validation alerts, bundle inventory, and known limitations.
+
+The report is print-friendly and can be exported to PDF by the browser. Native
+PDF export is not part of the public API in this release. The report organizes
+evidence and technical decisions, but it does not replace independent formal
+validation or constitute regulatory certification.
 
 ## Credit-Oriented Optimization
 

--- a/docs/audit_bundle_narrative_report.md
+++ b/docs/audit_bundle_narrative_report.md
@@ -1,0 +1,103 @@
+# Audit Bundle Narrative Report
+
+RiskBands can generate a standalone HTML narrative report for audit, model risk,
+governance, data science, credit analysts, and technical business users.
+
+The report is written as:
+
+```text
+audit_report.html
+```
+
+It is self-contained, uses embedded CSS, does not require internet access, and
+does not use external JavaScript or CDN assets.
+
+## How to Generate
+
+Standalone report:
+
+```python
+binner.export_audit_report(
+    "audit_report.html",
+    title="Relatório de Auditoria do Binning",
+    dataset_name="train",
+)
+```
+
+Full bundle with report:
+
+```python
+binner.export_bundle("riskbands_bundle")
+```
+
+`export_bundle(...)` includes `riskbands_bundle/audit_report.html` by default.
+Use `include_audit_report=False` only when the bundle must stay limited to the
+previous JSON/CSV artifacts:
+
+```python
+binner.export_bundle("riskbands_bundle", include_audit_report=False)
+```
+
+## What It Contains
+
+The HTML report includes:
+
+- executive summary;
+- how to read the report;
+- model configuration;
+- variable summary;
+- missing value policies;
+- missing merge decisions;
+- merge candidates evaluated during fit;
+- final binning by variable;
+- validation and alerts;
+- bundle inventory;
+- known limitations;
+- technical appendix.
+
+For `missing_policy="merge"`, the report explains the learned fit-time decision,
+the selected destination bin, the criterion (`nearest_event_rate` or
+`nearest_woe`), candidate distances, and the fact that `transform(...)` reuses
+the learned decision instead of recalculating event rate or WoE on application
+data.
+
+## Bundle Inventory
+
+The report explains common bundle files, including:
+
+- `metadata.json`;
+- `binnings.json`;
+- `summary.csv`;
+- `score_details.csv`;
+- `score_table.csv`;
+- `audit_table.csv`;
+- `report.csv`;
+- `missing_profile.csv`;
+- `missing_decision_log.csv`;
+- `missing_merge_candidates.csv`;
+- `feature_tables/`;
+- `audit_report.html`.
+
+When generated inside a bundle, the report marks files that are physically
+present. Optional files are described only as available when present or when the
+bundle manifest lists them.
+
+## PDF Boundary
+
+Native PDF export is not required in this sprint and no heavy PDF dependency is
+added. Use the browser print dialog to print or export the HTML report to PDF.
+
+The report organizes evidence and technical decisions, but it does not replace
+independent formal validation and does not constitute regulatory certification.
+
+## Example
+
+See:
+
+```text
+examples/audit_report/audit_bundle_report_demo.py
+```
+
+The example creates a small synthetic dataset, fits `missing_policy="merge"`
+with `missing_merge_criterion="nearest_event_rate"`, writes a standalone
+`audit_report.html`, and exports a bundle containing `audit_report.html`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,8 @@ Entry point for the project documentation.
 4. Inspect the detailed diagnostics with `temporal_bin_diagnostics(...)`.
 5. Summarize stability with `temporal_variable_summary(...)`.
 6. Consolidate the rationale with `variable_audit_report(...)`.
-7. Compare candidates with `BinComparator` when doing champion/challenger.
+7. Export the narrative audit HTML with `export_audit_report(...)` or the full bundle with `export_bundle(...)`.
+8. Compare candidates with `BinComparator` when doing champion/challenger.
 
 ## Quick Navigation
 
@@ -24,6 +25,8 @@ Entry point for the project documentation.
   Dedicated guide for `standard`, `separate_bin`, `forbid`, `merge`, pandas/PySpark examples, audit fields, and bundle reporting.
 - [docs/missing_policy_methodological_guide.md](missing_policy_methodological_guide.md)
   Methodological guidance for choosing missing policies and reviewing merge decisions.
+- [docs/audit_bundle_narrative_report.md](audit_bundle_narrative_report.md)
+  Guide for the standalone narrative audit report generated as `audit_report.html`.
 - [docs/releases/2.3.0.md](releases/2.3.0.md)
   v2.3.0 release-prep notes for auditable missing merge policies.
 - [docs/missing_merge_nearest_event_rate_design.md](missing_merge_nearest_event_rate_design.md)
@@ -48,6 +51,8 @@ Entry point for the project documentation.
   Comparative diagnostic for `standard`, `separate_bin`, `forbid`, and both merge criteria.
 - [examples/missing_policy/credit_risk_missing_merge_demo.py](../examples/missing_policy/credit_risk_missing_merge_demo.py)
   Synthetic credit-risk example with informative missingness and auditable merge decisions.
+- [examples/audit_report/audit_bundle_report_demo.py](../examples/audit_report/audit_bundle_report_demo.py)
+  Small synthetic example that exports `audit_report.html` and a bundle containing the same narrative report.
 - [examples/pd_vintage_champion_challenger/pd_vintage_champion_challenger.py](../examples/pd_vintage_champion_challenger/pd_vintage_champion_challenger.py)
   Credit-risk / PD anchor example with vintages.
 

--- a/examples/audit_report/audit_bundle_report_demo.py
+++ b/examples/audit_report/audit_bundle_report_demo.py
@@ -1,0 +1,70 @@
+"""Generate a standalone audit report and bundle for a small synthetic dataset."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from riskbands import RiskBands
+
+
+def make_audit_report_demo_dataset() -> pd.DataFrame:
+    score = []
+    target = []
+    for value, event_rate in [(-5.0, 0.05), (-3.0, 0.20), (0.0, 0.50), (3.0, 0.80), (5.0, 0.95)]:
+        n = 30
+        events = int(n * event_rate)
+        score.extend([value] * n)
+        target.extend([1] * events + [0] * (n - events))
+
+    score.extend([np.nan] * 30)
+    target.extend([1] * 15 + [0] * 15)
+    return pd.DataFrame({"score": score, "target": target})
+
+
+def run_audit_bundle_report_demo(output_dir: str | Path | None = None) -> dict[str, Path | pd.DataFrame]:
+    if output_dir is None:
+        output_dir = Path(__file__).resolve().parents[1] / "_tmp_riskbands_bundle_smoke" / "audit_report_demo"
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    df = make_audit_report_demo_dataset()
+    binner = RiskBands(
+        max_bins=5,
+        min_event_rate_diff=0.0,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    )
+    binner.fit(df, y="target", column="score")
+
+    audit_report_path = output_dir / "audit_report.html"
+    bundle_dir = output_dir / "bundle"
+
+    binner.export_audit_report(
+        audit_report_path,
+        title="Relatório de Auditoria do Binning",
+        dataset_name="synthetic_credit_demo",
+    )
+    binner.export_bundle(bundle_dir)
+
+    return {
+        "dataset": df,
+        "audit_report_path": audit_report_path,
+        "bundle_dir": bundle_dir,
+        "bundle_audit_report_path": bundle_dir / "audit_report.html",
+        "missing_decision_log": binner.missing_decision_log_,
+        "missing_merge_candidates": binner.missing_merge_candidates_,
+    }
+
+
+def main() -> None:
+    results = run_audit_bundle_report_demo()
+    print(f"audit_report: {results['audit_report_path']}")
+    print(f"bundle_dir: {results['bundle_dir']}")
+    print(f"bundle_audit_report: {results['bundle_audit_report_path']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/riskbands/audit_report.py
+++ b/riskbands/audit_report.py
@@ -283,7 +283,7 @@ def _validation_context(binner: Any) -> dict[str, Any]:
     }
 
 
-def _inventory_specs() -> list[dict[str, str]]:
+def _inventory_specs(report_filename: str = REPORT_FILENAME) -> list[dict[str, str]]:
     return [
         {
             "file": "metadata.json",
@@ -337,7 +337,7 @@ def _inventory_specs() -> list[dict[str, str]]:
             "file": "missing_decision_log.csv",
             "purpose": "Trilha de decisão da política de missing por variável.",
             "audience": "auditoria, model risk",
-            "when": "confirmar acao tomada para missing values",
+            "when": "confirmar ação tomada para missing values",
         },
         {
             "file": "missing_merge_candidates.csv",
@@ -358,7 +358,7 @@ def _inventory_specs() -> list[dict[str, str]]:
             "when": "revisar cortes e métricas de uma variável específica",
         },
         {
-            "file": REPORT_FILENAME,
+            "file": report_filename,
             "purpose": "Relatório HTML narrativo e autocontido para auditoria do bundle.",
             "audience": "auditoria, model risk, governança, negócio técnico",
             "when": "ler a explicação executiva, imprimir ou exportar para PDF pelo navegador",
@@ -369,9 +369,15 @@ def _inventory_specs() -> list[dict[str, str]]:
 def _bundle_inventory(
     path: str | Path | None = None,
     *,
+    current_report_path: str | Path | None = None,
     current_report_name: str | None = None,
 ) -> list[dict[str, Any]]:
     bundle_path = Path(path) if path is not None else None
+    if current_report_path is not None:
+        active_report_name = Path(current_report_path).name
+    else:
+        active_report_name = current_report_name
+    report_filename = active_report_name or REPORT_FILENAME
     manifest_artifacts: dict[str, Any] = {}
     if bundle_path is not None and (bundle_path / "metadata.json").exists():
         try:
@@ -382,14 +388,14 @@ def _bundle_inventory(
             manifest_artifacts = {}
 
     inventory = []
-    for spec in _inventory_specs():
+    for spec in _inventory_specs(report_filename=report_filename):
         filename = spec["file"]
         file_path = bundle_path / filename if bundle_path is not None else None
         is_directory_spec = filename.endswith("/")
         exists = False
         if file_path is not None:
             exists = file_path.exists() if not is_directory_spec else file_path.is_dir()
-        if current_report_name and filename == current_report_name:
+        if active_report_name and filename == active_report_name:
             exists = True
 
         manifest_key_present = any(value == filename.rstrip("/") for value in manifest_artifacts.values())
@@ -398,7 +404,7 @@ def _bundle_inventory(
             manifest_key_present = True
 
         status = "presente" if exists else "quando disponível"
-        if bundle_path is None and filename != REPORT_FILENAME:
+        if bundle_path is None and filename != report_filename:
             status = "esperado no bundle"
         if not exists and not manifest_key_present and bundle_path is not None:
             status = "não encontrado"
@@ -423,6 +429,7 @@ def build_audit_report_context(
     title: str | None = None,
     dataset_name: str | None = None,
     bundle_path: str | Path | None = None,
+    current_report_path: str | Path | None = None,
 ) -> dict[str, Any]:
     """Build a JSON-safe context for the standalone audit narrative report."""
     warnings: list[str] = []
@@ -502,7 +509,7 @@ def build_audit_report_context(
         "validation": _validation_context(binner),
         "bundle_inventory": _bundle_inventory(
             bundle_path,
-            current_report_name=REPORT_FILENAME if bundle_path is not None else None,
+            current_report_path=current_report_path,
         ),
         "limitations": _limitations(),
         "warnings": warnings,
@@ -1147,6 +1154,7 @@ def export_audit_report_html(
         title=title,
         dataset_name=dataset_name,
         bundle_path=resolved_bundle_path,
+        current_report_path=target,
     )
     target.write_text(render_audit_report_html(context), encoding="utf-8")
     return target

--- a/riskbands/audit_report.py
+++ b/riskbands/audit_report.py
@@ -1,0 +1,1152 @@
+"""Standalone narrative audit report for fitted RiskBands binners."""
+
+from __future__ import annotations
+
+import html
+import json
+import math
+from collections.abc import Mapping
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+try:
+    from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+except ImportError:  # pragma: no cover - Python < 3.9 fallback
+    ZoneInfo = None
+    ZoneInfoNotFoundError = Exception
+
+import numpy as np
+import pandas as pd
+
+from .reporting import build_binner_metadata
+
+REPORT_FILENAME = "audit_report.html"
+DEFAULT_TITLE = "Relatório de Auditoria do Binning"
+DEFAULT_SUBTITLE = (
+    "Documento executivo para revisão das configurações, variáveis, decisões sobre valores "
+    "ausentes, validações e artefatos do bundle."
+)
+MAX_CONTEXT_ROWS = 200
+AUDIT_LIMITATION_TEXT = (
+    "O relatório organiza evidências e decisões técnicas, mas não substitui validação formal "
+    "independente nem constitui certificação regulatória."
+)
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, pd.DataFrame):
+        return _safe_records(value)
+    if isinstance(value, pd.Series):
+        return _json_safe(value.to_dict())
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, (pd.Timestamp, datetime)):
+        if pd.isna(value):
+            return None
+        return value.isoformat()
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, np.generic):
+        return _json_safe(value.item())
+    if value is pd.NA or value is pd.NaT:
+        return None
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, (int, str, bool)) or value is None:
+        return value
+    try:
+        if pd.isna(value):
+            return None
+    except (TypeError, ValueError):
+        pass
+    return str(value)
+
+
+def _safe_records(df: Any, max_rows: int | None = None) -> list[dict[str, Any]]:
+    """Return JSON-safe records from a tabular object without non-finite scalars."""
+    if df is None:
+        return []
+    if isinstance(df, pd.DataFrame):
+        table = df
+    else:
+        try:
+            table = pd.DataFrame(df)
+        except (TypeError, ValueError):
+            return []
+    if table.empty:
+        return []
+    if max_rows is not None:
+        table = table.head(max_rows)
+    return [_json_safe(record) for record in table.to_dict(orient="records")]
+
+
+def _records_with_warning(
+    df: Any,
+    *,
+    table_name: str,
+    warnings: list[str],
+    max_rows: int = MAX_CONTEXT_ROWS,
+) -> list[dict[str, Any]]:
+    length = len(df) if isinstance(df, pd.DataFrame) else 0
+    if length > max_rows:
+        warnings.append(
+            f"Tabela '{table_name}' truncada para {max_rows} linhas no relatório narrativo."
+        )
+    return _safe_records(df, max_rows=max_rows)
+
+
+def _safe_table_call(binner: Any, method_name: str, warnings: list[str]) -> pd.DataFrame:
+    method = getattr(binner, method_name, None)
+    if method is None:
+        return pd.DataFrame()
+    try:
+        result = method()
+    except Exception as exc:  # pragma: no cover - defensive best effort
+        warnings.append(f"Não foi possível montar '{method_name}': {exc}")
+        return pd.DataFrame()
+    return result if isinstance(result, pd.DataFrame) else pd.DataFrame()
+
+
+def _feature_names(binner: Any, binning_table: pd.DataFrame) -> list[str]:
+    for attr in ("feature_names_in_", "selected_columns_"):
+        value = getattr(binner, attr, None)
+        if value:
+            return [str(item) for item in value]
+    if not binning_table.empty and "variable" in binning_table.columns:
+        return [str(item) for item in binning_table["variable"].drop_duplicates().tolist()]
+    return []
+
+
+def _model_config_from_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+    keys = [
+        "riskbands_version",
+        "strategy",
+        "score_strategy",
+        "missing_policy",
+        "effective_missing_policy",
+        "missing_merge_criterion",
+        "missing_merge_fallback",
+        "objective_direction",
+        "normalization_strategy",
+        "woe_shrinkage_strength",
+        "target_name",
+        "time_col",
+        "features",
+        "selected_columns",
+        "n_features",
+        "input_type",
+        "iv_total",
+    ]
+    return {key: metadata.get(key) for key in keys if key in metadata}
+
+
+def _merge_criterion_text(criterion: Any) -> str:
+    if criterion == "nearest_woe":
+        return "WoE mais próximo"
+    if criterion == "nearest_event_rate":
+        return "event rate mais próximo"
+    return str(criterion or "critério configurado")
+
+
+def _format_distance(row: Mapping[str, Any]) -> str:
+    metric = row.get("distance_metric") or row.get("metric") or "distância"
+    for key in ("distance", "distance_value", "distance_event_rate", "distance_woe"):
+        value = row.get(key)
+        if isinstance(value, (int, float)) and math.isfinite(float(value)):
+            return f"{metric} = {float(value):.6g}"
+    return str(metric)
+
+
+def _decision_action_label(action: str) -> str:
+    labels = {
+        "missing_merged": "Missing fundido a bin regular",
+        "missing_kept_separate": "Fallback para bin separado",
+        "no_missing_detected": "Sem missing no fit",
+        "separate_bin_created": "Bin separado criado",
+        "separate_bin_requested": "Bin separado solicitado",
+        "forbidden_missing_detected": "Missing bloqueado",
+        "standard_behavior_preserved": "Comportamento standard preservado",
+    }
+    return labels.get(action, action.replace("_", " ") if action else "Não informado")
+
+
+def _missing_decision_narrative(row: Mapping[str, Any]) -> str:
+    variable = str(row.get("variable") or "variavel")
+    action = str(row.get("action") or "")
+    criterion = row.get("missing_merge_criterion") or row.get("merge_criterion") or row.get("criterion")
+    selected_bin = row.get("selected_bin_label") or row.get("selected_bin")
+    fallback = row.get("missing_merge_fallback") or row.get("fallback")
+
+    if action == "missing_merged":
+        criterion_text = _merge_criterion_text(criterion)
+        return (
+            f"Os registros com valor ausente em {variable} foram fundidos ao bin {selected_bin}, "
+            f"pois este foi o bin regular com {criterion_text} do grupo missing no conjunto de treino. "
+            f"A decisão foi aprendida no fit e reutilizada no transform; o transform não recalcula "
+            f"event rate/WoE. Distância registrada: {_format_distance(row)}."
+        )
+    if action == "missing_kept_separate":
+        return (
+            f"Os registros ausentes em {variable} permaneceram em bin separado por fallback "
+            f"'{fallback or 'separate_bin'}'. A decisão foi aprendida no fit e reaplicada no transform."
+        )
+    if action == "no_missing_detected":
+        return (
+            f"Não foram encontrados valores ausentes em {variable} no conjunto de fit. "
+            "Nenhum merge de missing foi necessário."
+        )
+    if action in {"separate_bin_created", "separate_bin_requested"}:
+        return (
+            f"Valores ausentes em {variable} foram tratados como um grupo separado para manter "
+            "a trilha auditável sem imputação opaca."
+        )
+    if action == "forbidden_missing_detected":
+        return (
+            f"A política 'forbid' bloqueou valores ausentes em {variable}; a execução deve falhar "
+            "quando missing values aparecem nesse contexto."
+        )
+    if action == "standard_behavior_preserved":
+        return (
+            f"A política standard preservou o comportamento histórico para {variable}; valores "
+            "ausentes seguem a regra padrão aprendida no fit."
+        )
+    return (
+        f"Decisão de missing registrada para {variable}. Consulte os campos técnicos da linha "
+        "para detalhes completos."
+    )
+
+
+def _summarize_missing_decisions(binner: Any) -> list[dict[str, Any]]:
+    decisions = _safe_records(getattr(binner, "missing_decision_log_", pd.DataFrame()))
+    if not decisions:
+        return [
+            {
+                "variable": "todas",
+                "action": "no_decision_log",
+                "action_label": "Sem trilha de missing registrada",
+                "narrative": (
+                    "Não há linhas em missing_decision_log_. Isso pode ocorrer quando o modelo "
+                    "foi ajustado sem trilha de missing persistida ou quando não houve missing relevante."
+                ),
+            }
+        ]
+
+    enriched = []
+    for row in decisions:
+        record = dict(row)
+        action = str(record.get("action") or "")
+        record["action_label"] = _decision_action_label(action)
+        record["narrative"] = _missing_decision_narrative(record)
+        enriched.append(record)
+    return enriched
+
+
+def _summarize_missing(binner: Any, decisions: list[dict[str, Any]]) -> dict[str, Any]:
+    profile = getattr(binner, "missing_profile_", pd.DataFrame())
+    candidates = getattr(binner, "missing_merge_candidates_", pd.DataFrame())
+    actions = [str(row.get("action") or "") for row in decisions]
+    return {
+        "missing_policy": getattr(binner, "missing_policy_", getattr(binner, "missing_policy", None)),
+        "effective_missing_policy": getattr(binner, "effective_missing_policy_", None),
+        "missing_merge_criterion": getattr(binner, "missing_merge_criterion_", None),
+        "missing_merge_fallback": getattr(binner, "missing_merge_fallback_", None),
+        "profile_rows": int(len(profile)) if isinstance(profile, pd.DataFrame) else 0,
+        "decision_rows": len(decisions),
+        "candidate_rows": int(len(candidates)) if isinstance(candidates, pd.DataFrame) else 0,
+        "merged_decisions": actions.count("missing_merged"),
+        "fallback_decisions": actions.count("missing_kept_separate"),
+        "no_missing_decisions": actions.count("no_missing_detected"),
+    }
+
+
+def _validation_context(binner: Any) -> dict[str, Any]:
+    reports = {
+        "fit_validation_report": getattr(binner, "fit_validation_report_", None),
+        "transform_validation_report": getattr(binner, "transform_validation_report_", None),
+        "validation_report": getattr(binner, "validation_report_", None),
+    }
+    safe_reports = {key: _json_safe(value) for key, value in reports.items() if value is not None}
+    alerts: list[dict[str, Any]] = []
+    for report_name, report in safe_reports.items():
+        if isinstance(report, Mapping):
+            for key, value in report.items():
+                key_text = str(key).lower()
+                if "warning" in key_text or "alert" in key_text or "error" in key_text:
+                    alerts.append({"source": report_name, "field": key, "value": value})
+    return {
+        "reports": safe_reports,
+        "alerts": alerts,
+        "has_validation": bool(safe_reports),
+    }
+
+
+def _inventory_specs() -> list[dict[str, str]]:
+    return [
+        {
+            "file": "metadata.json",
+            "purpose": "Manifest do bundle, versão, configuração e lista de artefatos.",
+            "audience": "governança, auditoria, data science",
+            "when": "primeiro arquivo para revisar rastreabilidade do pacote",
+        },
+        {
+            "file": "binnings.json",
+            "purpose": "Artefato JSON com metadados e tabelas de binning por variável.",
+            "audience": "data science, model risk",
+            "when": "comparar ou versionar a configuração técnica",
+        },
+        {
+            "file": "summary.csv",
+            "purpose": "Resumo curto por variável.",
+            "audience": "negócio técnico, data science",
+            "when": "entender rapidamente quais variáveis foram aceitas",
+        },
+        {
+            "file": "score_details.csv",
+            "purpose": "Componentes detalhados do score objetivo.",
+            "audience": "data science, model risk",
+            "when": "explicar por que uma configuração foi selecionada",
+        },
+        {
+            "file": "score_table.csv",
+            "purpose": "Tabela de score pronta para revisão.",
+            "audience": "data science, auditoria",
+            "when": "revisar pesos, score e componentes principais",
+        },
+        {
+            "file": "audit_table.csv",
+            "purpose": "Tabela consolidada com cortes, score, penalidades e racional.",
+            "audience": "auditoria, model risk",
+            "when": "fazer revisão técnica consolidada por variável",
+        },
+        {
+            "file": "report.csv",
+            "purpose": "Relatório tabular completo por variável.",
+            "audience": "data science",
+            "when": "investigar detalhes além do resumo executivo",
+        },
+        {
+            "file": "missing_profile.csv",
+            "purpose": "Perfil de volume, evento, event rate e WoE dos missing values.",
+            "audience": "model risk, data science",
+            "when": "avaliar impacto dos valores ausentes no fit",
+        },
+        {
+            "file": "missing_decision_log.csv",
+            "purpose": "Trilha de decisão da política de missing por variável.",
+            "audience": "auditoria, model risk",
+            "when": "confirmar acao tomada para missing values",
+        },
+        {
+            "file": "missing_merge_candidates.csv",
+            "purpose": "Candidatos avaliados quando missing values são fundidos a bins regulares.",
+            "audience": "model risk, data science",
+            "when": "explicar por que um bin foi escolhido no merge",
+        },
+        {
+            "file": "missing_transform_fallback_log.csv",
+            "purpose": "Eventos de fallback no transform quando aplicável.",
+            "audience": "data science, auditoria",
+            "when": "investigar missing values novos em transformação",
+        },
+        {
+            "file": "feature_tables/",
+            "purpose": "Tabelas individuais de binning por variável.",
+            "audience": "data science, analistas de crédito",
+            "when": "revisar cortes e métricas de uma variável específica",
+        },
+        {
+            "file": REPORT_FILENAME,
+            "purpose": "Relatório HTML narrativo e autocontido para auditoria do bundle.",
+            "audience": "auditoria, model risk, governança, negócio técnico",
+            "when": "ler a explicação executiva, imprimir ou exportar para PDF pelo navegador",
+        },
+    ]
+
+
+def _bundle_inventory(
+    path: str | Path | None = None,
+    *,
+    current_report_name: str | None = None,
+) -> list[dict[str, Any]]:
+    bundle_path = Path(path) if path is not None else None
+    manifest_artifacts: dict[str, Any] = {}
+    if bundle_path is not None and (bundle_path / "metadata.json").exists():
+        try:
+            manifest = json.loads((bundle_path / "metadata.json").read_text(encoding="utf-8"))
+            artifacts = manifest.get("artifacts", {})
+            manifest_artifacts = artifacts if isinstance(artifacts, dict) else {}
+        except (OSError, json.JSONDecodeError):
+            manifest_artifacts = {}
+
+    inventory = []
+    for spec in _inventory_specs():
+        filename = spec["file"]
+        file_path = bundle_path / filename if bundle_path is not None else None
+        is_directory_spec = filename.endswith("/")
+        exists = False
+        if file_path is not None:
+            exists = file_path.exists() if not is_directory_spec else file_path.is_dir()
+        if current_report_name and filename == current_report_name:
+            exists = True
+
+        manifest_key_present = any(value == filename.rstrip("/") for value in manifest_artifacts.values())
+        manifest_key_present = manifest_key_present or any(value == filename for value in manifest_artifacts.values())
+        if filename == REPORT_FILENAME and manifest_artifacts.get("audit_report_html") == REPORT_FILENAME:
+            manifest_key_present = True
+
+        status = "presente" if exists else "quando disponível"
+        if bundle_path is None and filename != REPORT_FILENAME:
+            status = "esperado no bundle"
+        if not exists and not manifest_key_present and bundle_path is not None:
+            status = "não encontrado"
+
+        inventory.append({**spec, "status": status})
+    return inventory
+
+
+def _limitations() -> list[str]:
+    return [
+        AUDIT_LIMITATION_TEXT,
+        "O HTML é autocontido e print-friendly, mas PDF nativo não é obrigatório nesta sprint.",
+        "O relatório usa apenas artefatos e atributos já aprendidos; ele não recalcula o modelo.",
+        "Validações independentes, políticas internas e revisão regulatória continuam fora deste artefato.",
+        "Dados sensíveis ou reais não devem ser inseridos manualmente no relatório.",
+    ]
+
+
+def build_audit_report_context(
+    binner: Any,
+    *,
+    title: str | None = None,
+    dataset_name: str | None = None,
+    bundle_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Build a JSON-safe context for the standalone audit narrative report."""
+    warnings: list[str] = []
+    if hasattr(binner, "_ensure_fitted"):
+        binner._ensure_fitted()
+
+    try:
+        metadata = build_binner_metadata(binner)
+    except Exception as exc:  # pragma: no cover - defensive best effort
+        metadata = {}
+        warnings.append(f"Não foi possível montar metadados completos: {exc}")
+
+    binning_table = _safe_table_call(binner, "binning_table", warnings)
+    summary = _safe_table_call(binner, "summary", warnings)
+    score_table = _safe_table_call(binner, "score_table", warnings)
+    audit_table = _safe_table_call(binner, "audit_table", warnings)
+    report_table = _safe_table_call(binner, "report", warnings)
+    features = _feature_names(binner, binning_table)
+
+    binning_tables: dict[str, list[dict[str, Any]]] = {}
+    for feature in features:
+        try:
+            table = binner.binning_table(column=feature)
+        except Exception as exc:  # pragma: no cover - defensive best effort
+            warnings.append(f"Não foi possível montar binning de '{feature}': {exc}")
+            table = pd.DataFrame()
+        binning_tables[feature] = _records_with_warning(
+            table,
+            table_name=f"binning_tables.{feature}",
+            warnings=warnings,
+        )
+
+    missing_decisions = _summarize_missing_decisions(binner)
+    merge_candidates = _records_with_warning(
+        getattr(binner, "missing_merge_candidates_", pd.DataFrame()),
+        table_name="missing_merge_candidates",
+        warnings=warnings,
+    )
+
+    context = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "title": title or DEFAULT_TITLE,
+        "dataset_name": dataset_name,
+        "language": "pt-BR",
+        "metadata": _json_safe(metadata),
+        "model_config": _json_safe(_model_config_from_metadata(metadata)),
+        "variable_summary": _records_with_warning(
+            summary,
+            table_name="summary",
+            warnings=warnings,
+        ),
+        "score_table": _records_with_warning(
+            score_table,
+            table_name="score_table",
+            warnings=warnings,
+        ),
+        "audit_table": _records_with_warning(
+            audit_table,
+            table_name="audit_table",
+            warnings=warnings,
+        ),
+        "report_table": _records_with_warning(
+            report_table,
+            table_name="report",
+            warnings=warnings,
+        ),
+        "missing_summary": _json_safe(_summarize_missing(binner, missing_decisions)),
+        "missing_profile": _records_with_warning(
+            getattr(binner, "missing_profile_", pd.DataFrame()),
+            table_name="missing_profile",
+            warnings=warnings,
+        ),
+        "missing_decisions": _json_safe(missing_decisions),
+        "merge_candidates": _json_safe(merge_candidates),
+        "missing_merge_map": _json_safe(getattr(binner, "missing_merge_map_", {})),
+        "binning_tables": _json_safe(binning_tables),
+        "validation": _validation_context(binner),
+        "bundle_inventory": _bundle_inventory(
+            bundle_path,
+            current_report_name=REPORT_FILENAME if bundle_path is not None else None,
+        ),
+        "limitations": _limitations(),
+        "warnings": warnings,
+        "appendix": {
+            "context_contract": [
+                "metadata",
+                "model_config",
+                "variable_summary",
+                "missing_summary",
+                "missing_decisions",
+                "merge_candidates",
+                "binning_tables",
+                "validation",
+                "bundle_inventory",
+                "limitations",
+            ],
+            "data_sources": [
+                "binner fitted attributes",
+                "public reporting tables",
+                "bundle path inventory when provided",
+            ],
+        },
+    }
+    return _json_safe(context)
+
+
+def _e(value: Any) -> str:
+    if value is None:
+        return ""
+    return html.escape(str(value), quote=True)
+
+
+def _format_value(value: Any) -> str:
+    if value is None:
+        return "Não informado"
+    if isinstance(value, bool):
+        return "sim" if value else "não"
+    if isinstance(value, float):
+        return f"{value:.6g}"
+    if isinstance(value, (list, dict)):
+        text = json.dumps(value, ensure_ascii=False, sort_keys=True)
+        return text if len(text) <= 180 else f"{text[:177]}..."
+    return str(value)
+
+
+def _sao_paulo_timezone() -> timezone:
+    if ZoneInfo is not None:
+        try:
+            return ZoneInfo("America/Sao_Paulo")
+        except ZoneInfoNotFoundError:
+            pass
+    return timezone(timedelta(hours=-3), "São Paulo")
+
+
+def _format_generated_at(value: Any) -> str:
+    if value is None:
+        return "Não informado"
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        text = str(value)
+        try:
+            parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        except ValueError:
+            return text
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    parsed = parsed.astimezone(_sao_paulo_timezone()).replace(microsecond=0)
+    return parsed.strftime("%d/%m/%Y %H:%M São Paulo")
+
+
+def _render_brand_mark() -> str:
+    logo_path = (
+        Path(__file__).resolve().parents[1]
+        / "docs-site"
+        / "public"
+        / "brand"
+        / "riskbands_horizontal_monochrome.svg"
+    )
+    try:
+        svg = logo_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return '<span class="brand-fallback">Gerado por RiskBands</span>'
+    svg = svg.replace(' xmlns="http://www.w3.org/2000/svg"', "")
+    svg = svg.replace("\ufeff", "")
+    if svg.startswith("<?xml"):
+        svg = svg[svg.find("?>") + 2 :].lstrip()
+    if not svg.startswith("<svg"):
+        return '<span class="brand-fallback">Gerado por RiskBands</span>'
+    svg = svg.replace(
+        "<svg ",
+        '<svg class="riskbands-logo" role="img" aria-label="RiskBands" data-riskbands-logo="inline-svg" ',
+        1,
+    )
+    return svg
+
+
+def _columns(records: list[dict[str, Any]], preferred: list[str] | None = None, *, limit: int = 10) -> list[str]:
+    if not records:
+        return []
+    preferred = preferred or []
+    discovered: list[str] = []
+    for record in records:
+        for key in record:
+            if key not in discovered:
+                discovered.append(key)
+    ordered = [key for key in preferred if key in discovered]
+    ordered.extend(key for key in discovered if key not in ordered)
+    return ordered[:limit]
+
+
+def _render_table(
+    records: list[dict[str, Any]],
+    *,
+    preferred: list[str] | None = None,
+    empty_message: str = "Sem dados disponíveis.",
+    css_class: str = "data-table",
+    max_columns: int = 10,
+) -> str:
+    if not records:
+        return f'<p class="muted">{_e(empty_message)}</p>'
+    cols = _columns(records, preferred, limit=max_columns)
+    head = "".join(f"<th>{_e(col)}</th>" for col in cols)
+    rows = []
+    for record in records:
+        cells = "".join(f"<td>{_e(_format_value(record.get(col)))}</td>" for col in cols)
+        row_class = ' class="selected-row"' if record.get("selected") is True else ""
+        rows.append(f"<tr{row_class}>{cells}</tr>")
+    return (
+        '<div class="table-wrap">'
+        f'<table class="{css_class}"><thead><tr>{head}</tr></thead><tbody>{"".join(rows)}</tbody></table>'
+        "</div>"
+    )
+
+
+def _render_key_values(data: Mapping[str, Any]) -> str:
+    items = []
+    for key, value in data.items():
+        items.append(
+            '<div class="kv-item">'
+            f'<dt>{_e(key.replace("_", " "))}</dt>'
+            f"<dd>{_e(_format_value(value))}</dd>"
+            "</div>"
+        )
+    return f'<dl class="kv-grid">{"".join(items)}</dl>'
+
+
+def _badge(text: Any, tone: str = "neutral") -> str:
+    return f'<span class="badge badge-{_e(tone)}">{_e(_format_value(text))}</span>'
+
+
+def _render_missing_decisions(records: list[dict[str, Any]]) -> str:
+    cards = []
+    for record in records:
+        tone = "success" if record.get("action") == "missing_merged" else "neutral"
+        cards.append(
+            '<article class="decision-card">'
+            f'<div class="decision-title">{_e(record.get("variable"))} {_badge(record.get("action_label"), tone)}</div>'
+            f'<p>{_e(record.get("narrative"))}</p>'
+            "</article>"
+        )
+    table = _render_table(
+        records,
+        preferred=[
+            "variable",
+            "action",
+            "status",
+            "selected_bin_label",
+            "distance_metric",
+            "distance",
+            "fallback_used",
+        ],
+        max_columns=8,
+    )
+    return "".join(cards) + table
+
+
+def _render_binning_tables(tables: Mapping[str, list[dict[str, Any]]]) -> str:
+    if not tables:
+        return '<p class="muted">Sem tabelas de binning disponíveis.</p>'
+    sections = []
+    for variable, rows in tables.items():
+        sections.append(
+            '<section class="subsection">'
+            f"<h3>{_e(variable)}</h3>"
+            + _render_table(
+                rows,
+                preferred=[
+                    "variable",
+                    "bin",
+                    "bin_label",
+                    "count",
+                    "event_count",
+                    "non_event_count",
+                    "event_rate",
+                    "woe",
+                    "iv",
+                ],
+                max_columns=9,
+            )
+            + "</section>"
+        )
+    return "".join(sections)
+
+
+def _render_validation(validation: Mapping[str, Any]) -> str:
+    if not validation.get("has_validation"):
+        return (
+            '<div class="callout">'
+            "Não há relatório de validação persistido. Use fit/transform com validação quando "
+            "precisar registrar checks formais no bundle."
+            "</div>"
+        )
+    alerts = validation.get("alerts") or []
+    reports = validation.get("reports") or {}
+    return (
+        _render_table(alerts, preferred=["source", "field", "value"], empty_message="Sem alertas registrados.")
+        + '<details class="technical-details"><summary>Payloads de validação</summary>'
+        + f"<pre>{_e(json.dumps(reports, ensure_ascii=False, indent=2))}</pre>"
+        + "</details>"
+    )
+
+
+def render_audit_report_html(context: dict[str, Any]) -> str:
+    """Render a standalone HTML audit narrative with embedded CSS."""
+    title = context.get("title") or DEFAULT_TITLE
+    metadata = context.get("metadata") or {}
+    model_config = context.get("model_config") or {}
+    missing_summary = context.get("missing_summary") or {}
+    generated_at = context.get("generated_at")
+    dataset_name = context.get("dataset_name")
+    variable_summary = context.get("variable_summary") or []
+    missing_decisions = context.get("missing_decisions") or []
+    merge_candidates = context.get("merge_candidates") or []
+    limitations = context.get("limitations") or []
+    warnings = context.get("warnings") or []
+    inventory = context.get("bundle_inventory") or []
+    binning_tables = context.get("binning_tables") or {}
+    validation = context.get("validation") or {}
+    dataset_display = dataset_name if dataset_name else "Não informada"
+    generated_display = _format_generated_at(generated_at)
+    version_display = metadata.get("riskbands_version", "não informada")
+    missing_policy_display = missing_summary.get("missing_policy", "não informada")
+    brand_mark = _render_brand_mark()
+
+    sections = [
+        ("summary", "Capa / Resumo executivo"),
+        ("how-to-read", "Como ler este relatório"),
+        ("config", "Configuração do modelo"),
+        ("variables", "Resumo das variáveis"),
+        ("missing-policy", "Políticas de missing values"),
+        ("missing-merge", "Decisões de merge de missing"),
+        ("merge-candidates", "Candidatos avaliados no merge"),
+        ("binning", "Binning final por variável"),
+        ("validation", "Validação e alertas"),
+        ("inventory", "Inventário do bundle"),
+        ("limitations", "Limitações conhecidas"),
+        ("appendix", "Apêndice técnico"),
+    ]
+    toc = "".join(f'<li><a href="#{section_id}">{_e(label)}</a></li>' for section_id, label in sections)
+    warning_html = "".join(f"<li>{_e(item)}</li>" for item in warnings)
+    limitation_html = "".join(f"<li>{_e(item)}</li>" for item in limitations)
+
+    return f"""<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{_e(title)}</title>
+  <style>
+    :root {{
+      --ink: #1f2933;
+      --muted: #5d6b7a;
+      --line: #d8dee6;
+      --panel: #ffffff;
+      --soft: #f5f7fa;
+      --accent: #176b87;
+      --accent-2: #b45309;
+      --success: #166534;
+      --warning: #92400e;
+    }}
+    * {{ box-sizing: border-box; }}
+    body {{
+      margin: 0;
+      background: var(--soft);
+      color: var(--ink);
+      font-family: Arial, Helvetica, sans-serif;
+      font-size: 15px;
+      line-height: 1.55;
+    }}
+    .page {{ max-width: 1320px; margin: 0 auto; padding: 28px; box-sizing: border-box; }}
+    .hero {{
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 28px;
+      margin-bottom: 20px;
+      max-width: 100%;
+      overflow: hidden;
+      box-sizing: border-box;
+    }}
+    .hero-top {{
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 24px;
+    }}
+    .hero-copy {{ min-width: 0; flex: 1 1 auto; }}
+    .hero-copy p {{ max-width: 780px; margin: 0; color: var(--muted); }}
+    .hero-brand {{
+      flex: 0 0 auto;
+      display: flex;
+      align-items: flex-start;
+      justify-content: flex-end;
+      min-width: 128px;
+    }}
+    .riskbands-logo {{
+      display: block;
+      width: 128px;
+      max-width: 100%;
+      height: auto;
+    }}
+    .brand-fallback {{
+      display: inline-block;
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 700;
+      white-space: nowrap;
+    }}
+    h1, h2, h3 {{ color: #18212f; line-height: 1.2; margin: 0 0 12px; }}
+    h1 {{ font-size: 30px; }}
+    h2 {{ font-size: 22px; border-bottom: 2px solid var(--line); padding-bottom: 8px; }}
+    h3 {{ font-size: 17px; margin-top: 18px; }}
+    a {{ color: var(--accent); text-decoration: none; }}
+    .meta-row {{ display: flex; flex-wrap: wrap; gap: 8px; margin-top: 16px; }}
+    .badge {{
+      display: inline-block;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 3px 10px;
+      font-size: 12px;
+      font-weight: 700;
+      background: #eef4f7;
+    }}
+    .badge-success {{ color: var(--success); background: #ecfdf3; border-color: #bbf7d0; }}
+    .badge-neutral {{ color: var(--ink); background: #eef2f7; }}
+    .section {{
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 22px;
+      margin: 18px 0;
+      break-inside: avoid;
+      max-width: 100%;
+      overflow: hidden;
+      box-sizing: border-box;
+    }}
+    .subsection {{ margin-top: 18px; max-width: 100%; box-sizing: border-box; }}
+    .toc {{
+      columns: 2;
+      padding-left: 22px;
+      margin: 10px 0 0;
+    }}
+    .cards {{
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 12px;
+      margin: 16px 0;
+    }}
+    .metric-card {{
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 14px;
+      background: #fbfcfe;
+    }}
+    .metric-label {{
+      display: block;
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 700;
+      text-transform: uppercase;
+    }}
+    .metric-card strong {{ display: block; font-size: 30px; color: var(--accent); margin-top: 4px; }}
+    .metric-helper {{ display: block; color: var(--muted); font-size: 12px; margin-top: 4px; }}
+    .kv-grid {{
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 10px;
+      margin: 0;
+    }}
+    .kv-item {{
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 10px 12px;
+      background: #fbfcfe;
+    }}
+    dt {{ color: var(--muted); font-size: 12px; font-weight: 700; text-transform: uppercase; }}
+    dd {{ margin: 3px 0 0; overflow-wrap: anywhere; }}
+    .table-wrap {{
+      width: 100%;
+      max-width: 100%;
+      overflow-x: auto;
+      box-sizing: border-box;
+      margin-top: 12px;
+    }}
+    .data-table {{
+      width: max-content;
+      min-width: 100%;
+      max-width: none;
+      border-collapse: collapse;
+      font-size: 13px;
+      table-layout: auto;
+      box-sizing: border-box;
+    }}
+    th {{
+      border: 1px solid var(--line);
+      padding: 8px;
+      text-align: left;
+      vertical-align: top;
+      white-space: nowrap;
+      word-break: normal;
+      overflow-wrap: normal;
+    }}
+    td {{
+      border: 1px solid var(--line);
+      padding: 8px;
+      text-align: left;
+      vertical-align: top;
+      white-space: normal;
+      word-break: normal;
+      overflow-wrap: anywhere;
+    }}
+    th {{ background: #eef2f7; font-weight: 700; }}
+    tr.selected-row td {{ background: #fff7ed; border-color: #fed7aa; }}
+    .decision-card {{
+      border-left: 5px solid var(--accent);
+      background: #f8fbfd;
+      padding: 12px 14px;
+      margin: 12px 0;
+    }}
+    .decision-title {{ font-weight: 700; margin-bottom: 6px; }}
+    .callout {{
+      border: 1px solid #f1c27d;
+      border-left: 5px solid var(--accent-2);
+      background: #fff8ed;
+      border-radius: 8px;
+      padding: 12px 14px;
+      margin: 12px 0;
+    }}
+    .muted {{ color: var(--muted); }}
+    .technical-details summary {{ cursor: pointer; font-weight: 700; margin-top: 10px; }}
+    pre {{
+      white-space: pre-wrap;
+      border: 1px solid var(--line);
+      background: #f8fafc;
+      padding: 12px;
+      overflow-wrap: anywhere;
+    }}
+    .report-footer {{
+      color: var(--muted);
+      font-size: 12px;
+      text-align: center;
+      padding: 18px 8px 4px;
+    }}
+    @media (max-width: 720px) {{
+      .hero-top {{ flex-direction: column; }}
+      .hero-brand {{ justify-content: flex-start; min-width: 0; }}
+      .riskbands-logo {{ width: 118px; }}
+    }}
+    @media print {{
+      body {{ background: #ffffff; color: #000000; font-size: 11pt; }}
+      .page {{ max-width: none; padding: 0; }}
+      .hero, .section {{ border-color: #bbbbbb; box-shadow: none; break-inside: avoid; }}
+      .hero-top {{ display: flex; align-items: flex-start; justify-content: space-between; }}
+      .riskbands-logo {{ width: 120px; }}
+      .table-wrap {{ overflow: visible; max-width: 100%; }}
+      .data-table {{ width: 100%; min-width: 0; font-size: 9.5pt; table-layout: auto; }}
+      th, td {{ padding: 5px; white-space: normal; word-break: normal; overflow-wrap: anywhere; }}
+      a {{ color: #000000; text-decoration: none; }}
+      table {{ break-inside: auto; page-break-inside: auto; }}
+      tr {{ break-inside: avoid; page-break-inside: avoid; }}
+      h2, h3 {{ break-after: avoid; page-break-after: avoid; }}
+      .toc {{ columns: 1; }}
+    }}
+  </style>
+</head>
+<body>
+  <main class="page">
+    <header id="summary" class="hero">
+      <div class="hero-top">
+        <div class="hero-copy">
+          <h1>{_e(title)}</h1>
+          <p>{_e(DEFAULT_SUBTITLE)}</p>
+        </div>
+        <div class="hero-brand">{brand_mark}</div>
+      </div>
+      <div class="meta-row">
+        {_badge("Base: " + str(dataset_display))}
+        {_badge("Gerado em: " + str(generated_display))}
+        {_badge("Versão RiskBands: " + str(version_display))}
+        {_badge("Política de missing: " + str(missing_policy_display))}
+      </div>
+      <div class="cards">
+        <div class="metric-card">
+          <span class="metric-label">Variáveis analisadas</span>
+          <strong>{_e(len(binning_tables))}</strong>
+          <span class="metric-helper">Total de variáveis ajustadas no fit</span>
+        </div>
+        <div class="metric-card">
+          <span class="metric-label">Decisões sobre ausentes</span>
+          <strong>{_e(len(missing_decisions))}</strong>
+          <span class="metric-helper">Registros de política ou merge de missing</span>
+        </div>
+        <div class="metric-card">
+          <span class="metric-label">Candidatos avaliados</span>
+          <strong>{_e(len(merge_candidates))}</strong>
+          <span class="metric-helper">Bins regulares considerados para merge</span>
+        </div>
+      </div>
+      <div class="callout">{_e(AUDIT_LIMITATION_TEXT)}</div>
+    </header>
+
+    <section id="how-to-read" class="section">
+      <h2>Como ler este relatório</h2>
+      <p>
+        Comece pelo resumo executivo, revise a configuração do modelo e avance para as seções de
+        missing values quando houver valores ausentes. Linhas destacadas em candidatos de merge indicam
+        o bin selecionado no fit. Este HTML é adequado para impressão/exportação para PDF pelo navegador.
+      </p>
+      <ol class="toc">{toc}</ol>
+    </section>
+
+    <section id="config" class="section">
+      <h2>Configuração do modelo</h2>
+      {_render_key_values(model_config)}
+    </section>
+
+    <section id="variables" class="section">
+      <h2>Resumo das variáveis</h2>
+      {_render_table(variable_summary, preferred=["variable", "n_bins", "iv", "score", "objective_score"])}
+    </section>
+
+    <section id="missing-policy" class="section">
+      <h2>Políticas de missing values</h2>
+      <p>
+        Missing policy define como valores ausentes são tratados. Event rate é a proporção de eventos
+        em um bin. WoE mede a separação entre eventos e não eventos. IV resume poder informativo.
+        Fallback é a regra usada quando a decisão principal não pode ser aplicada.
+      </p>
+      {_render_key_values(missing_summary)}
+      <h3>Perfil de missing</h3>
+      {_render_table(
+        context.get("missing_profile") or [],
+        preferred=["variable", "bin_label", "n_missing_fit", "event_rate", "woe", "merge_status"],
+      )}
+    </section>
+
+    <section id="missing-merge" class="section">
+      <h2>Decisões de merge de missing</h2>
+      {_render_missing_decisions(missing_decisions)}
+    </section>
+
+    <section id="merge-candidates" class="section">
+      <h2>Candidatos avaliados no merge</h2>
+      <p>
+        Esta tabela mostra os bins regulares avaliados para receber o grupo missing. A linha destacada
+        representa o candidato selecionado no fit.
+      </p>
+      {_render_table(
+        merge_candidates,
+        preferred=[
+            "variable",
+            "criterion",
+            "candidate_rank",
+            "candidate_bin_label",
+            "candidate_event_rate",
+            "candidate_woe",
+            "distance_event_rate",
+            "distance_woe",
+            "selected",
+        ],
+      )}
+    </section>
+
+    <section id="binning" class="section">
+      <h2>Binning final por variável</h2>
+      {_render_binning_tables(binning_tables)}
+    </section>
+
+    <section id="validation" class="section">
+      <h2>Validação e alertas</h2>
+      {_render_validation(validation)}
+      {"<ul>" + warning_html + "</ul>" if warning_html else '<p class="muted">Sem avisos internos de renderização.</p>'}
+    </section>
+
+    <section id="inventory" class="section">
+      <h2>Inventário do bundle</h2>
+      {_render_table(inventory, preferred=["file", "status", "purpose", "audience", "when"], max_columns=5)}
+    </section>
+
+    <section id="limitations" class="section">
+      <h2>Limitações conhecidas</h2>
+      <ul>{limitation_html}</ul>
+    </section>
+
+    <section id="appendix" class="section">
+      <h2>Apêndice técnico</h2>
+      <p>
+        Binning é o agrupamento de valores em faixas ou categorias. O relatório usa contexto JSON-safe
+        derivado do binner fitted e dos artefatos de bundle quando disponíveis.
+      </p>
+      <details class="technical-details">
+        <summary>Metadados completos</summary>
+        <pre>{_e(json.dumps(metadata, ensure_ascii=False, indent=2))}</pre>
+      </details>
+    </section>
+    <footer class="report-footer">
+      Relatório gerado automaticamente. Revise as evidências e políticas internas antes de uso em processos formais.
+    </footer>
+  </main>
+</body>
+</html>
+"""
+
+
+def export_audit_report_html(
+    binner: Any,
+    path: str | Path,
+    *,
+    title: str | None = None,
+    dataset_name: str | None = None,
+    bundle_path: str | Path | None = None,
+) -> Path:
+    """Write the standalone audit narrative HTML report as UTF-8."""
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    resolved_bundle_path = bundle_path
+    if resolved_bundle_path is None and (target.parent / "metadata.json").exists():
+        resolved_bundle_path = target.parent
+    context = build_audit_report_context(
+        binner,
+        title=title,
+        dataset_name=dataset_name,
+        bundle_path=resolved_bundle_path,
+    )
+    target.write_text(render_audit_report_html(context), encoding="utf-8")
+    return target

--- a/riskbands/binning_engine.py
+++ b/riskbands/binning_engine.py
@@ -4459,12 +4459,26 @@ class Binner(BaseEstimator, TransformerMixin):
         export_binnings_json(self, path)
 
     # ------------------------------------------------------------------
-    def export_bundle(self, path: str) -> None:
+    def export_bundle(self, path: str, *, include_audit_report: bool = True) -> None:
         """Export a complete audit bundle with JSON and tabular artifacts."""
         from .reporting import export_binner_bundle
 
         self._ensure_fitted()
-        export_binner_bundle(self, path)
+        export_binner_bundle(self, path, include_audit_report=include_audit_report)
+
+    # ------------------------------------------------------------------
+    def export_audit_report(
+        self,
+        path: str,
+        *,
+        title: str | None = None,
+        dataset_name: str | None = None,
+    ) -> None:
+        """Export a standalone narrative audit report as self-contained HTML."""
+        from .audit_report import export_audit_report_html
+
+        self._ensure_fitted()
+        export_audit_report_html(self, path, title=title, dataset_name=dataset_name)
 
     # ------------------------------------------------------------------
     def save_report(self, path: str) -> None:

--- a/riskbands/reporting.py
+++ b/riskbands/reporting.py
@@ -1230,7 +1230,12 @@ def _try_write_parquet(df: pd.DataFrame, path: Path) -> bool:
         return False
 
 
-def export_binner_bundle(binner: Binner, path: PathLike) -> Path:
+def export_binner_bundle(
+    binner: Binner,
+    path: PathLike,
+    *,
+    include_audit_report: bool = True,
+) -> Path:
     target_dir = Path(path)
     target_dir.mkdir(parents=True, exist_ok=True)
 
@@ -1335,6 +1340,7 @@ def export_binner_bundle(binner: Binner, path: PathLike) -> Path:
                 if missing_transform_fallback_log is not None and not missing_transform_fallback_log.empty
                 else None
             ),
+            "audit_report_html": "audit_report.html" if include_audit_report else None,
             "feature_tables": feature_artifacts,
             "optional_parquet": written_optional,
         },
@@ -1345,6 +1351,14 @@ def export_binner_bundle(binner: Binner, path: PathLike) -> Path:
         json.dumps(_json_safe(manifest), indent=2, ensure_ascii=False),
         encoding="utf-8",
     )
+    if include_audit_report:
+        from .audit_report import export_audit_report_html
+
+        export_audit_report_html(
+            binner,
+            target_dir / "audit_report.html",
+            bundle_path=target_dir,
+        )
     return target_dir
 
 

--- a/tests/test_audit_report_bundle_integration.py
+++ b/tests/test_audit_report_bundle_integration.py
@@ -27,6 +27,18 @@ def test_public_export_audit_report_generates_html(tmp_path):
     assert "Decisões de merge de missing" in text
 
 
+def test_public_export_audit_report_uses_custom_inventory_filename(tmp_path):
+    binner = fit_merge_binner()
+    path = tmp_path / "custom_report.html"
+
+    binner.export_audit_report(path)
+
+    text = path.read_text(encoding="utf-8")
+    assert "<td>custom_report.html</td><td>presente</td>" in text
+    assert "audit_report.html" not in text
+    assert str(tmp_path) not in text
+
+
 def test_export_bundle_old_call_includes_audit_report_and_existing_files(tmp_path):
     binner = fit_merge_binner()
     bundle_dir = tmp_path / "bundle"
@@ -34,6 +46,8 @@ def test_export_bundle_old_call_includes_audit_report_and_existing_files(tmp_pat
     binner.export_bundle(bundle_dir)
 
     assert (bundle_dir / "audit_report.html").exists()
+    html = (bundle_dir / "audit_report.html").read_text(encoding="utf-8")
+    assert "<td>audit_report.html</td><td>presente</td>" in html
     for name in [
         "metadata.json",
         "binnings.json",

--- a/tests/test_audit_report_bundle_integration.py
+++ b/tests/test_audit_report_bundle_integration.py
@@ -1,0 +1,62 @@
+import json
+
+import pytest
+
+from riskbands import Binner, RiskBands
+from tests.test_audit_report_context import fit_merge_binner
+
+
+def test_public_export_audit_report_method_exists_and_requires_fitted(tmp_path):
+    assert hasattr(Binner, "export_audit_report")
+    assert hasattr(RiskBands, "export_audit_report")
+
+    with pytest.raises(RuntimeError, match="fitted"):
+        RiskBands().export_audit_report(tmp_path / "audit_report.html")
+
+
+def test_public_export_audit_report_generates_html(tmp_path):
+    binner = fit_merge_binner()
+    path = tmp_path / "audit_report.html"
+
+    binner.export_audit_report(path, title="Bundle Audit", dataset_name="train")
+
+    text = path.read_text(encoding="utf-8")
+    assert "<!doctype html>" in text
+    assert "Bundle Audit" in text
+    assert "train" in text
+    assert "Decisões de merge de missing" in text
+
+
+def test_export_bundle_old_call_includes_audit_report_and_existing_files(tmp_path):
+    binner = fit_merge_binner()
+    bundle_dir = tmp_path / "bundle"
+
+    binner.export_bundle(bundle_dir)
+
+    assert (bundle_dir / "audit_report.html").exists()
+    for name in [
+        "metadata.json",
+        "binnings.json",
+        "summary.csv",
+        "score_details.csv",
+        "score_table.csv",
+        "audit_table.csv",
+        "report.csv",
+        "missing_profile.csv",
+        "missing_decision_log.csv",
+        "missing_merge_candidates.csv",
+    ]:
+        assert (bundle_dir / name).exists()
+    manifest = json.loads((bundle_dir / "metadata.json").read_text(encoding="utf-8"))
+    assert manifest["artifacts"]["audit_report_html"] == "audit_report.html"
+
+
+def test_export_bundle_can_disable_audit_report(tmp_path):
+    binner = fit_merge_binner()
+    bundle_dir = tmp_path / "bundle"
+
+    binner.export_bundle(bundle_dir, include_audit_report=False)
+
+    assert not (bundle_dir / "audit_report.html").exists()
+    manifest = json.loads((bundle_dir / "metadata.json").read_text(encoding="utf-8"))
+    assert manifest["artifacts"]["audit_report_html"] is None

--- a/tests/test_audit_report_bundle_inventory.py
+++ b/tests/test_audit_report_bundle_inventory.py
@@ -1,0 +1,48 @@
+from riskbands.audit_report import _bundle_inventory, build_audit_report_context, render_audit_report_html
+from tests.test_audit_report_context import fit_merge_binner
+
+
+def test_bundle_inventory_contains_audit_report_and_missing_artifact_explanations():
+    context = build_audit_report_context(fit_merge_binner())
+    inventory = {row["file"]: row for row in context["bundle_inventory"]}
+
+    assert "audit_report.html" in inventory
+    assert "missing_decision_log.csv" in inventory
+    assert "missing_merge_candidates.csv" in inventory
+    assert "Trilha de decisão" in inventory["missing_decision_log.csv"]["purpose"]
+    assert "Candidatos avaliados" in inventory["missing_merge_candidates.csv"]["purpose"]
+
+
+def test_bundle_inventory_does_not_break_before_bundle_is_exported():
+    inventory = _bundle_inventory(None)
+
+    assert any(row["file"] == "audit_report.html" for row in inventory)
+    assert {row["status"] for row in inventory} <= {"esperado no bundle", "quando disponível"}
+
+
+def test_bundle_inventory_marks_present_files_when_report_is_inside_bundle(tmp_path):
+    binner = fit_merge_binner()
+    bundle_dir = tmp_path / "bundle"
+
+    binner.export_bundle(bundle_dir)
+    context = build_audit_report_context(binner, bundle_path=bundle_dir)
+    inventory = {row["file"]: row for row in context["bundle_inventory"]}
+    html = render_audit_report_html(context)
+
+    assert inventory["metadata.json"]["status"] == "presente"
+    assert inventory["binnings.json"]["status"] == "presente"
+    assert inventory["audit_report.html"]["status"] == "presente"
+    assert "metadata.json" in html
+    assert "audit_report.html" in html
+
+
+def test_bundle_inventory_omits_existence_claims_for_missing_optional_files(tmp_path):
+    binner = fit_merge_binner()
+    bundle_dir = tmp_path / "bundle"
+    binner.export_bundle(bundle_dir)
+    (bundle_dir / "missing_merge_candidates.csv").unlink()
+
+    context = build_audit_report_context(binner, bundle_path=bundle_dir)
+    inventory = {row["file"]: row for row in context["bundle_inventory"]}
+
+    assert inventory["missing_merge_candidates.csv"]["status"] != "presente"

--- a/tests/test_audit_report_bundle_inventory.py
+++ b/tests/test_audit_report_bundle_inventory.py
@@ -1,4 +1,9 @@
-from riskbands.audit_report import _bundle_inventory, build_audit_report_context, render_audit_report_html
+from riskbands.audit_report import (
+    _bundle_inventory,
+    build_audit_report_context,
+    export_audit_report_html,
+    render_audit_report_html,
+)
 from tests.test_audit_report_context import fit_merge_binner
 
 
@@ -18,6 +23,29 @@ def test_bundle_inventory_does_not_break_before_bundle_is_exported():
 
     assert any(row["file"] == "audit_report.html" for row in inventory)
     assert {row["status"] for row in inventory} <= {"esperado no bundle", "quando disponível"}
+
+
+def test_export_audit_report_inventory_uses_custom_output_filename(tmp_path):
+    path = tmp_path / "custom_report.html"
+
+    export_audit_report_html(fit_merge_binner(), path)
+    html = path.read_text(encoding="utf-8")
+
+    assert "<td>custom_report.html</td><td>presente</td>" in html
+    assert "audit_report.html" not in html
+    assert str(tmp_path) not in html
+    assert "http://" not in html
+    assert "https://" not in html
+
+
+def test_export_audit_report_inventory_keeps_default_output_filename(tmp_path):
+    path = tmp_path / "audit_report.html"
+
+    export_audit_report_html(fit_merge_binner(), path)
+    html = path.read_text(encoding="utf-8")
+
+    assert "<td>audit_report.html</td><td>presente</td>" in html
+    assert str(tmp_path) not in html
 
 
 def test_bundle_inventory_marks_present_files_when_report_is_inside_bundle(tmp_path):

--- a/tests/test_audit_report_context.py
+++ b/tests/test_audit_report_context.py
@@ -1,0 +1,130 @@
+import json
+
+import numpy as np
+import pandas as pd
+
+from riskbands import RiskBands
+from riskbands.audit_report import _safe_records, build_audit_report_context
+
+
+def make_merge_frame(*, with_missing=True):
+    score = []
+    target = []
+    for value, event_rate in [(-5.0, 0.05), (-3.0, 0.20), (0.0, 0.50), (3.0, 0.80), (5.0, 0.95)]:
+        n = 30
+        events = int(n * event_rate)
+        score.extend([value] * n)
+        target.extend([1] * events + [0] * (n - events))
+    if with_missing:
+        score.extend([np.nan] * 30)
+        target.extend([1] * 15 + [0] * 15)
+    return pd.DataFrame({"score": score, "target": target})
+
+
+def fit_merge_binner(*, criterion="nearest_event_rate", with_missing=True):
+    df = make_merge_frame(with_missing=with_missing)
+    binner = RiskBands(
+        max_bins=5,
+        min_event_rate_diff=0.0,
+        missing_policy="merge",
+        missing_merge_criterion=criterion,
+    )
+    return binner.fit(df, y="target", column="score")
+
+
+def test_audit_report_context_has_required_json_safe_fields():
+    binner = fit_merge_binner()
+
+    context = build_audit_report_context(binner, title="Audit", dataset_name="synthetic")
+
+    assert {
+        "metadata",
+        "model_config",
+        "variable_summary",
+        "missing_summary",
+        "missing_decisions",
+        "merge_candidates",
+        "binning_tables",
+        "validation",
+        "bundle_inventory",
+        "limitations",
+    } <= set(context)
+    assert context["title"] == "Audit"
+    assert context["dataset_name"] == "synthetic"
+    assert context["language"] == "pt-BR"
+    json.dumps(context, ensure_ascii=False)
+
+
+def test_audit_report_context_summarizes_missing_merge_event_rate():
+    binner = fit_merge_binner(criterion="nearest_event_rate")
+
+    context = build_audit_report_context(binner)
+    decision = context["missing_decisions"][0]
+
+    assert context["missing_summary"]["missing_policy"] == "merge"
+    assert decision["action"] == "missing_merged"
+    assert "event rate mais próximo" in decision["narrative"]
+    assert "aprendida no fit" in decision["narrative"]
+    assert "transform não recalcula event rate/WoE" in decision["narrative"]
+    assert any(row["selected"] is True for row in context["merge_candidates"])
+
+
+def test_audit_report_context_summarizes_missing_merge_nearest_woe():
+    binner = fit_merge_binner(criterion="nearest_woe")
+
+    context = build_audit_report_context(binner)
+    decision = context["missing_decisions"][0]
+
+    assert decision["action"] == "missing_merged"
+    assert "WoE mais próximo" in decision["narrative"]
+
+
+def test_audit_report_context_handles_no_missing_and_empty_decision_log():
+    binner = fit_merge_binner(with_missing=False)
+    context = build_audit_report_context(binner)
+
+    assert context["missing_decisions"][0]["action"] == "no_missing_detected"
+
+    binner.missing_decision_log_ = pd.DataFrame()
+    context = build_audit_report_context(binner)
+
+    assert context["missing_decisions"][0]["action"] == "no_decision_log"
+    json.dumps(context, ensure_ascii=False)
+
+
+def test_audit_report_context_fallback_narrative_is_explicit():
+    binner = fit_merge_binner()
+    binner.missing_decision_log_ = pd.DataFrame(
+        [
+            {
+                "variable": "score",
+                "action": "missing_kept_separate",
+                "status": "kept_separate",
+                "missing_merge_fallback": "separate_bin",
+                "fallback_used": True,
+            }
+        ]
+    )
+
+    context = build_audit_report_context(binner)
+
+    assert "fallback" in context["missing_decisions"][0]["narrative"].lower()
+    assert context["missing_summary"]["fallback_decisions"] == 1
+
+
+def test_safe_records_normalizes_empty_and_non_finite_values():
+    records = _safe_records(
+        pd.DataFrame(
+            {
+                "a": [1.0, np.nan, np.inf, -np.inf],
+                "b": [pd.NA, "ok", pd.Timestamp("2026-05-19"), None],
+            }
+        ),
+        max_rows=3,
+    )
+
+    assert len(records) == 3
+    assert records[1]["a"] is None
+    assert records[2]["a"] is None
+    assert records[0]["b"] is None
+    json.dumps(records, ensure_ascii=False)

--- a/tests/test_audit_report_html.py
+++ b/tests/test_audit_report_html.py
@@ -1,0 +1,128 @@
+import re
+from pathlib import Path
+
+from riskbands.audit_report import (
+    AUDIT_LIMITATION_TEXT,
+    build_audit_report_context,
+    export_audit_report_html,
+    render_audit_report_html,
+)
+from tests.test_audit_report_context import fit_merge_binner
+
+
+def test_audit_report_html_contains_contract_sections_and_embedded_css():
+    html = render_audit_report_html(build_audit_report_context(fit_merge_binner()))
+
+    assert html.startswith("<!doctype html>")
+    assert '<meta charset="utf-8">' in html
+    assert "<style>" in html
+    assert "@media print" in html
+    assert "Relatório de Auditoria do Binning" in html
+    for section in [
+        "Capa / Resumo executivo",
+        "Como ler este relatório",
+        "Configuração do modelo",
+        "Resumo das variáveis",
+        "Políticas de missing values",
+        "Decisões de merge de missing",
+        "Candidatos avaliados no merge",
+        "Binning final por variável",
+        "Validação e alertas",
+        "Inventário do bundle",
+        "Limitações conhecidas",
+        "Apêndice técnico",
+    ]:
+        assert section in html
+
+
+def test_audit_report_html_is_standalone_and_contains_required_limitations():
+    html = render_audit_report_html(build_audit_report_context(fit_merge_binner()))
+
+    assert "D:\\" not in html
+    assert "http://" not in html
+    assert "https://" not in html
+    assert AUDIT_LIMITATION_TEXT in html
+    assert "certificação regulatória" in html
+    assert "não promete conformidade regulatória" not in html.lower()
+    assert "adequado para impressão/exportação para PDF pelo navegador" in html
+    assert "data-riskbands-logo=\"inline-svg\"" in html or "Gerado por RiskBands" in html
+
+
+def test_audit_report_html_uses_executive_header_cards_and_friendly_metadata():
+    context = build_audit_report_context(fit_merge_binner())
+    context["generated_at"] = "2026-05-19T19:41:21.821661+00:00"
+    html = render_audit_report_html(context)
+
+    assert "Relatório de Auditoria do Binning" in html
+    assert "Documento executivo para revisão das configurações" in html
+    assert "Variáveis analisadas" in html
+    assert "Total de variáveis ajustadas no fit" in html
+    assert "Decisões sobre ausentes" in html
+    assert "Candidatos avaliados" in html
+    assert "Base: Não informada" in html
+    generated_badge = re.search(r"Gerado em: ([^<]+)</span>", html)
+    assert generated_badge is not None
+    assert generated_badge.group(1) == "19/05/2026 16:41 São Paulo"
+    assert "UTC" not in generated_badge.group(1)
+    assert "2026-05-19T19:41:21.821661+00:00" not in html
+    assert "821661" not in html
+    assert "Versão RiskBands:" in html
+    assert "Política de missing: merge" in html
+
+
+def test_audit_report_html_contains_missing_merge_narrative_and_selected_candidate():
+    html = render_audit_report_html(build_audit_report_context(fit_merge_binner()))
+
+    assert "aprendida no fit" in html
+    assert "transform não recalcula event rate/WoE" in html
+    assert "selected-row" in html
+    assert "Candidatos avaliados no merge" in html
+
+
+def test_audit_report_tables_are_wrapped_for_responsive_layout():
+    html = render_audit_report_html(build_audit_report_context(fit_merge_binner()))
+
+    table_count = html.count("<table")
+    wrapped_table_count = len(re.findall(r'<div class="table-wrap"><table', html))
+
+    assert table_count >= 5
+    assert wrapped_table_count == table_count
+    assert ".table-wrap" in html
+    assert "overflow-x: auto" in html
+    assert "max-width: 1320px" in html
+    assert "max-width: 100%" in html
+    assert "width: max-content" in html
+    assert "min-width: 100%" in html
+    assert "box-sizing: border-box" in html
+    assert "white-space: nowrap" in html
+    assert "word-break: normal" in html
+    assert "overflow-wrap: anywhere" in html
+    assert "@media print" in html
+    assert "http://" not in html
+    assert "https://" not in html
+
+
+def test_export_audit_report_html_writes_utf8_without_mojibake(tmp_path):
+    path = tmp_path / "audit_report.html"
+
+    export_audit_report_html(fit_merge_binner(), path)
+    text = path.read_text(encoding="utf-8")
+
+    assert "Relatório de Auditoria do Binning" in text
+    assert "Configuração" in text
+    assert "variáveis" in text
+    assert "Decisões" in text
+    assert "Validação" in text
+    assert "Limitações" in text
+    assert "O relatório organiza evidências" in text
+    for bad in ("\u00c3", "\u00c2", "\ufffd"):
+        assert bad not in text
+
+
+def test_export_audit_report_html_accepts_path_objects(tmp_path):
+    path = Path(tmp_path) / "nested" / "audit_report.html"
+
+    returned = export_audit_report_html(fit_merge_binner(), path)
+
+    assert returned == path
+    assert path.exists()

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -251,6 +251,31 @@ def test_credit_risk_missing_merge_example_flow_smoke():
     assert len(results["method_notes"]) >= 3
 
 
+def test_audit_bundle_report_example_flow_smoke(tmp_path):
+    module = _load_example_module(
+        "examples/audit_report/audit_bundle_report_demo.py"
+    )
+
+    results = module.run_audit_bundle_report_demo(output_dir=tmp_path)
+
+    audit_report = results["audit_report_path"]
+    bundle_dir = results["bundle_dir"]
+    bundle_audit_report = results["bundle_audit_report_path"]
+
+    assert audit_report.exists()
+    assert bundle_dir.exists()
+    assert bundle_audit_report.exists()
+    assert (bundle_dir / "metadata.json").exists()
+    assert (bundle_dir / "missing_merge_candidates.csv").exists()
+    assert not results["missing_decision_log"].empty
+    assert not results["missing_merge_candidates"].empty
+
+    html = audit_report.read_text(encoding="utf-8")
+    assert "<!doctype html>" in html
+    assert "Relatório de Auditoria do Binning" in html
+    assert "Decisões de merge de missing" in html
+
+
 def test_missing_policy_pyspark_example_optional_guard(monkeypatch):
     module = _load_example_module(
         "examples/missing_policy/missing_policy_pyspark_demo.py"

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -26,6 +26,8 @@ def test_public_api_exports_are_importable():
     assert ks_over_time is KsFromSubmodule
     assert psi_over_time is not None
     assert temporal_separability_score is not None
+    assert hasattr(Binner, "export_audit_report")
+    assert hasattr(RiskBands, "export_audit_report")
 
 
 def test_riskbands_preferred_import_styles_construct_equivalent_objects():


### PR DESCRIPTION
Adds a standalone, print-friendly HTML audit report for fitted RiskBands binners and audit bundles, including missing policy narratives, merge decision explanations, bundle inventory, examples, documentation, and tests. This does not change package version, add PDF dependencies, or publish a release.