### PR TITLE
Add Spark sampled fit support for missing merge

### DIFF
--- a/docs/pyspark_missing_merge_sampled_fit_design.md
+++ b/docs/pyspark_missing_merge_sampled_fit_design.md
@@ -1,0 +1,103 @@
+# PySpark Missing Merge Sampled Fit Design
+
+## G2 scope
+
+Sprint G2 allows the controlled path:
+
+```text
+Spark DataFrame -> bounded sample -> pandas core fit -> Spark transform
+```
+
+This is not a Spark-native missing merge fit. The fitted merge destination for
+`missing_policy="merge"` is learned by the existing pandas core on the sampled
+fit rows. Transform then applies the learned `missing_merge_map_` with native
+Spark expressions.
+
+## Allowed
+
+- `RiskBands(..., missing_policy="merge", missing_merge_criterion="nearest_event_rate").fit(spark_df, y="target")`
+- `RiskBands(..., missing_policy="merge", missing_merge_criterion="nearest_woe").fit(spark_df, y="target")`
+- `missing_merge_fallback="separate_bin"` when the sample has no learned missing decision
+- `missing_merge_fallback="raise"` when transform data contains missing values but no decision was learned
+- `fit(..., validate=True)` with Spark aggregate source profiles
+- `transform(spark_df, return_woe=False)` after Spark sampled fit
+- `export_bundle(...)`, `load_bundle(...)`, and `audit_report.html` for reviewing sampled-fit metadata
+
+## Still blocked
+
+- Spark-native learning of missing merge decisions
+- Spark `return_woe=True`
+- New merge criteria beyond `nearest_event_rate` and `nearest_woe`
+- `temporal_stable` and `monotonic_neighbor`
+- Rehydrating a callable fitted estimator from `load_bundle(...)`
+- New dependencies, version changes, publication, tags, or automatic push
+
+## Sampling contract
+
+`sample_size` controls how many Spark rows may be collected into pandas for fit.
+Integer values are treated as an absolute cap; float values in `(0, 1]` are
+treated as a sampling fraction. The sampled Spark frame is converted with
+`toPandas()` and passed to the pandas core fit.
+
+If the random sample is empty while the source Spark frame is not empty, one
+bounded row is collected as a fallback so fit can fail or proceed deterministically
+through the normal pandas validation path.
+
+## Caveat and metadata
+
+For Spark fit with `missing_policy="merge"`, metadata records that the merge
+decision was learned from the sample:
+
+- `merge_decision_learned_on_sample`
+- `merge_decision_fit_mode`
+- `merge_decision_n_rows_source`
+- `merge_decision_n_rows_fit`
+- `merge_decision_sample_size_requested`
+- `merge_decision_sample_size_type`
+- `merge_decision_sample_fraction_effective`
+- `sampling_caveat`
+
+The same scalar fields are copied into `missing_profile_`,
+`missing_decision_log_`, and `missing_merge_candidates_` when those tables are
+available. Bundle metadata and `audit_report.html` include the caveat so review
+artifacts do not imply that the missing merge decision was learned on the full
+Spark source.
+
+## Fallback when the sample misses missing values
+
+The full Spark source can contain missing values even when the sampled pandas fit
+does not. In that case pandas core records `action == "no_missing_detected"` and
+`missing_merge_map_` has no destination for that feature.
+
+At Spark transform time:
+
+- `missing_merge_fallback="separate_bin"` routes missing values to `"Missing"`.
+- `missing_merge_fallback="raise"` performs a Spark aggregate missing-count check
+  for features without a learned decision and raises a clear `ValueError` only
+  when missing values are present.
+- Non-missing transform data does not fail under `raise`.
+
+## Validation
+
+`fit(spark_df, validate=True, missing_policy="merge")` keeps the pandas fit
+profile from the sample and builds an optional Spark source profile through
+bounded aggregate collection. When the source profile is available,
+`reference_profile_` uses it and `fit_validation_report_` records the sampled fit
+row count, source row count, and sample/source representativeness status.
+
+## Static safety rules
+
+The direct Spark transform path must not use Python UDFs, pandas UDFs, direct
+full-data `.collect()`, or direct full-data `.toPandas()`. Collection remains
+allowed only for:
+
+- the controlled sampled-to-pandas fit frame;
+- the one-row empty-sample fallback;
+- aggregate missing-count/profile helpers with row guards.
+
+## G3 candidates
+
+- Decide whether Spark-native missing merge fit is needed.
+- Decide whether bundle loading should reconstruct a callable estimator.
+- Consider stratified or representativeness-aware sampling controls without
+  changing the G2 merge criteria.

--- a/docs/pyspark_missing_merge_transform_design.md
+++ b/docs/pyspark_missing_merge_transform_design.md
@@ -14,10 +14,22 @@ The missing merge decision is still learned only during pandas fit. Spark transf
 
 Sprint G1B does not add API surface. It hardens the same G1 path with adversarial tests and regression gates around pandas/Spark equivalence, multi-feature transforms, missing detection, validation, bundle metadata, and static source guards.
 
+## G2 sampled-fit status
+
+Sprint G2 adds a narrow fit boundary:
+
+```text
+Spark fit -> controlled sample -> pandas core missing merge -> Spark transform
+```
+
+The missing merge decision is learned on sampled pandas rows, not on the full Spark DataFrame. See `docs/pyspark_missing_merge_sampled_fit_design.md` for the fit-side contract, metadata fields, and caveats.
+
 ## Allowed
 
 - `RiskBands(..., missing_policy="merge").fit(pandas_df, y=...)`
+- `RiskBands(..., missing_policy="merge").fit(spark_df, y=...)` through sampled-to-pandas only
 - `binner.transform(spark_df, return_woe=False)` after the pandas fit
+- `binner.transform(spark_df, return_woe=False)` after the Spark sampled fit
 - `missing_merge_criterion="nearest_event_rate"`
 - `missing_merge_criterion="nearest_woe"`
 - `missing_merge_fallback="separate_bin"`
@@ -28,10 +40,9 @@ Sprint G1B does not add API surface. It hardens the same G1 path with adversaria
 
 ## Still blocked
 
-- Spark fit with `missing_policy="merge"`
 - Spark `return_woe=True`
-- PySpark learning of merge decisions
-- Spark sampled-to-pandas fit with merge enabled
+- Spark-native learning of merge decisions
+- Any implication that sampled merge decisions were learned on the full Spark DataFrame
 
 ## Spark transform semantics
 
@@ -72,6 +83,7 @@ The audit bundle persists:
 - `missing_merge_criterion`
 - `missing_merge_fallback`
 - `missing_merge_map`
+- sampled-fit caveat metadata when Spark fit used sampled-to-pandas
 - missing profile and decision logs
 - missing merge candidate tables
 - Spark transform fallback logs when a fallback error is observed before export
@@ -91,6 +103,5 @@ Collection remains allowed only in named aggregate/profile helpers, such as miss
 
 ## Next steps
 
-- G2: design Spark sampled-to-pandas fit support for merge, if still desired.
-- G3: decide whether a reconstructed callable estimator from bundle is required, separate from the current audit-only `load_bundle(...)` contract.
+- G3: decide whether Spark-native missing merge fit or reconstructed callable estimators from bundle are required.
 - G4: update public docs and release notes only after functional gates are accepted.

--- a/riskbands/audit_report.py
+++ b/riskbands/audit_report.py
@@ -129,6 +129,13 @@ def _model_config_from_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
         "effective_missing_policy",
         "missing_merge_criterion",
         "missing_merge_fallback",
+        "merge_decision_learned_on_sample",
+        "merge_decision_fit_mode",
+        "merge_decision_n_rows_source",
+        "merge_decision_n_rows_fit",
+        "merge_decision_sample_size_requested",
+        "merge_decision_sample_fraction_effective",
+        "sampling_caveat",
         "objective_direction",
         "normalization_strategy",
         "woe_shrinkage_strength",
@@ -247,8 +254,14 @@ def _summarize_missing_decisions(binner: Any) -> list[dict[str, Any]]:
 def _summarize_missing(binner: Any, decisions: list[dict[str, Any]]) -> dict[str, Any]:
     profile = getattr(binner, "missing_profile_", pd.DataFrame())
     candidates = getattr(binner, "missing_merge_candidates_", pd.DataFrame())
+    sampling_metadata = getattr(binner, "sampling_metadata_", None)
+    sampling_caveat = None
+    merge_decision_learned_on_sample = None
+    if isinstance(sampling_metadata, Mapping):
+        sampling_caveat = sampling_metadata.get("sampling_caveat")
+        merge_decision_learned_on_sample = sampling_metadata.get("merge_decision_learned_on_sample")
     actions = [str(row.get("action") or "") for row in decisions]
-    return {
+    summary = {
         "missing_policy": getattr(binner, "missing_policy_", getattr(binner, "missing_policy", None)),
         "effective_missing_policy": getattr(binner, "effective_missing_policy_", None),
         "missing_merge_criterion": getattr(binner, "missing_merge_criterion_", None),
@@ -260,6 +273,11 @@ def _summarize_missing(binner: Any, decisions: list[dict[str, Any]]) -> dict[str
         "fallback_decisions": actions.count("missing_kept_separate"),
         "no_missing_decisions": actions.count("no_missing_detected"),
     }
+    if merge_decision_learned_on_sample is not None:
+        summary["merge_decision_learned_on_sample"] = merge_decision_learned_on_sample
+    if sampling_caveat:
+        summary["sampling_caveat"] = sampling_caveat
+    return summary
 
 
 def _validation_context(binner: Any) -> dict[str, Any]:
@@ -423,6 +441,19 @@ def _limitations() -> list[str]:
     ]
 
 
+def _sampling_caveats_from_metadata(metadata: Mapping[str, Any]) -> list[str]:
+    caveats = []
+    sampling_caveat = metadata.get("sampling_caveat")
+    if sampling_caveat:
+        caveats.append(str(sampling_caveat))
+    sampling_metadata = metadata.get("sampling_metadata")
+    if isinstance(sampling_metadata, Mapping):
+        nested_caveat = sampling_metadata.get("sampling_caveat")
+        if nested_caveat and str(nested_caveat) not in caveats:
+            caveats.append(str(nested_caveat))
+    return caveats
+
+
 def build_audit_report_context(
     binner: Any,
     *,
@@ -468,6 +499,10 @@ def build_audit_report_context(
         table_name="missing_merge_candidates",
         warnings=warnings,
     )
+    limitations = _limitations()
+    for caveat in _sampling_caveats_from_metadata(metadata):
+        if caveat not in limitations:
+            limitations.append(caveat)
 
     context = {
         "generated_at": datetime.now(timezone.utc).isoformat(),
@@ -511,7 +546,7 @@ def build_audit_report_context(
             bundle_path,
             current_report_path=current_report_path,
         ),
-        "limitations": _limitations(),
+        "limitations": limitations,
         "warnings": warnings,
         "appendix": {
             "context_contract": [

--- a/riskbands/audit_report.py
+++ b/riskbands/audit_report.py
@@ -130,6 +130,8 @@ def _model_config_from_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
         "missing_merge_criterion",
         "missing_merge_fallback",
         "merge_decision_learned_on_sample",
+        "merge_decision_count",
+        "merge_decision_variables",
         "merge_decision_fit_mode",
         "merge_decision_n_rows_source",
         "merge_decision_n_rows_fit",
@@ -203,7 +205,8 @@ def _missing_decision_narrative(row: Mapping[str, Any]) -> str:
     if action == "no_missing_detected":
         return (
             f"Não foram encontrados valores ausentes em {variable} no conjunto de fit. "
-            "Nenhum merge de missing foi necessário."
+            "Nenhum destino de merge foi aprendido; se valores ausentes aparecerem no transform, "
+            f"será usado o fallback '{fallback or 'configurado'}'."
         )
     if action in {"separate_bin_created", "separate_bin_requested"}:
         return (
@@ -257,9 +260,13 @@ def _summarize_missing(binner: Any, decisions: list[dict[str, Any]]) -> dict[str
     sampling_metadata = getattr(binner, "sampling_metadata_", None)
     sampling_caveat = None
     merge_decision_learned_on_sample = None
+    merge_decision_count = None
+    merge_decision_variables = None
     if isinstance(sampling_metadata, Mapping):
         sampling_caveat = sampling_metadata.get("sampling_caveat")
         merge_decision_learned_on_sample = sampling_metadata.get("merge_decision_learned_on_sample")
+        merge_decision_count = sampling_metadata.get("merge_decision_count")
+        merge_decision_variables = sampling_metadata.get("merge_decision_variables")
     actions = [str(row.get("action") or "") for row in decisions]
     summary = {
         "missing_policy": getattr(binner, "missing_policy_", getattr(binner, "missing_policy", None)),
@@ -275,6 +282,10 @@ def _summarize_missing(binner: Any, decisions: list[dict[str, Any]]) -> dict[str
     }
     if merge_decision_learned_on_sample is not None:
         summary["merge_decision_learned_on_sample"] = merge_decision_learned_on_sample
+    if merge_decision_count is not None:
+        summary["merge_decision_count"] = merge_decision_count
+    if merge_decision_variables is not None:
+        summary["merge_decision_variables"] = merge_decision_variables
     if sampling_caveat:
         summary["sampling_caveat"] = sampling_caveat
     return summary

--- a/riskbands/binning_engine.py
+++ b/riskbands/binning_engine.py
@@ -46,7 +46,7 @@ _VALID_MISSING_MERGE_FALLBACKS = {
 }
 _PYSPARK_MISSING_MERGE_SAMPLED_FIT_CAVEAT = (
     "missing_policy='merge' Spark fit uses a controlled sampled-to-pandas path; "
-    "the missing merge decision is learned on the sampled fit rows, not on the full Spark DataFrame."
+    "any missing merge destination is learned only from the sampled fit rows, not from the full Spark DataFrame."
 )
 
 
@@ -594,8 +594,13 @@ class Binner(BaseEstimator, TransformerMixin):
         fit_rows: int,
         sampling_plan: dict[str, Any],
     ) -> dict[str, Any]:
+        merge_map = getattr(self, "missing_merge_map_", {}) or {}
+        merge_decision_variables = sorted(str(variable) for variable in merge_map)
+        merge_decision_count = len(merge_decision_variables)
         return {
-            "merge_decision_learned_on_sample": True,
+            "merge_decision_learned_on_sample": merge_decision_count > 0,
+            "merge_decision_count": merge_decision_count,
+            "merge_decision_variables": merge_decision_variables,
             "merge_decision_fit_mode": "sampled_to_pandas",
             "merge_decision_n_rows_source": int(source_rows),
             "merge_decision_n_rows_fit": int(fit_rows),
@@ -626,6 +631,14 @@ class Binner(BaseEstimator, TransformerMixin):
             annotated = table.copy()
             for key, value in scalar_metadata.items():
                 annotated[key] = value
+            if "variable" in annotated.columns and "merge_decision_learned_on_sample" in annotated.columns:
+                learned_variables = {
+                    str(variable)
+                    for variable in merge_metadata.get("merge_decision_variables", [])
+                }
+                annotated["merge_decision_learned_on_sample"] = (
+                    annotated["variable"].astype(str).isin(learned_variables)
+                )
             if "notes" in annotated.columns and caveat:
                 annotated["notes"] = annotated["notes"].map(
                     lambda value: (

--- a/riskbands/binning_engine.py
+++ b/riskbands/binning_engine.py
@@ -44,9 +44,9 @@ _VALID_MISSING_MERGE_FALLBACKS = {
     _SEPARATE_BIN_MISSING_MERGE_FALLBACK,
     _RAISE_MISSING_MERGE_FALLBACK,
 }
-_PYSPARK_MISSING_MERGE_UNIMPLEMENTED_MESSAGE = (
-    'missing_policy="merge" with PySpark fit is not implemented in this release. '
-    "Fit with pandas first, then use Spark transform with return_woe=False."
+_PYSPARK_MISSING_MERGE_SAMPLED_FIT_CAVEAT = (
+    "missing_policy='merge' Spark fit uses a controlled sampled-to-pandas path; "
+    "the missing merge decision is learned on the sampled fit rows, not on the full Spark DataFrame."
 )
 
 
@@ -466,7 +466,7 @@ class Binner(BaseEstimator, TransformerMixin):
     ) -> None:
         if self.missing_policy == _MERGE_MISSING_POLICY:
             if context == "fit":
-                raise NotImplementedError(_PYSPARK_MISSING_MERGE_UNIMPLEMENTED_MESSAGE)
+                return
             fit_backend = getattr(self, "fit_backend_", None)
             if fit_backend not in {"pandas", "pandas_core"}:
                 raise NotImplementedError(
@@ -587,6 +587,56 @@ class Binner(BaseEstimator, TransformerMixin):
         return sampled, plan
 
     # ------------------------------------------------------------------
+    def _sampled_missing_merge_metadata(
+        self,
+        *,
+        source_rows: int,
+        fit_rows: int,
+        sampling_plan: dict[str, Any],
+    ) -> dict[str, Any]:
+        return {
+            "merge_decision_learned_on_sample": True,
+            "merge_decision_fit_mode": "sampled_to_pandas",
+            "merge_decision_n_rows_source": int(source_rows),
+            "merge_decision_n_rows_fit": int(fit_rows),
+            "merge_decision_sample_size_requested": sampling_plan.get("sample_size_requested"),
+            "merge_decision_sample_size_type": sampling_plan.get("sample_size_type"),
+            "merge_decision_sample_fraction_effective": sampling_plan.get("sample_fraction_effective"),
+            "sampling_caveat": _PYSPARK_MISSING_MERGE_SAMPLED_FIT_CAVEAT,
+        }
+
+    # ------------------------------------------------------------------
+    def _annotate_sampled_missing_merge_artifacts(self, merge_metadata: dict[str, Any]) -> None:
+        if self.missing_policy != _MERGE_MISSING_POLICY:
+            return
+        caveat = str(merge_metadata.get("sampling_caveat") or "")
+        scalar_metadata = {
+            key: value
+            for key, value in merge_metadata.items()
+            if not isinstance(value, (dict, list, tuple, set))
+        }
+        for attr_name in (
+            "missing_profile_",
+            "missing_decision_log_",
+            "missing_merge_candidates_",
+        ):
+            table = getattr(self, attr_name, None)
+            if not isinstance(table, pd.DataFrame) or table.empty:
+                continue
+            annotated = table.copy()
+            for key, value in scalar_metadata.items():
+                annotated[key] = value
+            if "notes" in annotated.columns and caveat:
+                annotated["notes"] = annotated["notes"].map(
+                    lambda value: (
+                        f"{value} Sampling caveat: {caveat}"
+                        if pd.notna(value) and caveat not in str(value)
+                        else value
+                    )
+                )
+            setattr(self, attr_name, annotated)
+
+    # ------------------------------------------------------------------
     def _fit_pyspark(
         self,
         X,
@@ -636,6 +686,9 @@ class Binner(BaseEstimator, TransformerMixin):
 
         sampling_metadata = {
             **sampling_plan,
+            "input_backend": "pyspark",
+            "fit_backend": "pandas_core",
+            "fit_mode": "sampled_to_pandas",
             "sampling_applied": True,
             "sampling_strategy": "random",
             "stratified": False,
@@ -654,6 +707,15 @@ class Binner(BaseEstimator, TransformerMixin):
             "target_name": target_name,
             "time_col": time_col,
         }
+        if self.missing_policy == _MERGE_MISSING_POLICY:
+            merge_metadata = self._sampled_missing_merge_metadata(
+                source_rows=source_rows,
+                fit_rows=fit_rows,
+                sampling_plan=sampling_plan,
+            )
+            sampling_metadata.update(merge_metadata)
+            backend_metadata.update(merge_metadata)
+            self._annotate_sampled_missing_merge_artifacts(merge_metadata)
         self.input_backend_ = "pyspark"
         self.fit_backend_ = "pandas_core"
         self.backend_metadata_ = backend_metadata

--- a/riskbands/reporting.py
+++ b/riskbands/reporting.py
@@ -1011,6 +1011,8 @@ def build_binner_metadata(
         if isinstance(sampling_metadata, dict):
             for key in (
                 "merge_decision_learned_on_sample",
+                "merge_decision_count",
+                "merge_decision_variables",
                 "merge_decision_fit_mode",
                 "merge_decision_n_rows_source",
                 "merge_decision_n_rows_fit",

--- a/riskbands/reporting.py
+++ b/riskbands/reporting.py
@@ -1008,6 +1008,19 @@ def build_binner_metadata(
     sampling_metadata = getattr(binner, "sampling_metadata_", None)
     if sampling_metadata is not None:
         metadata["sampling_metadata"] = _json_safe(sampling_metadata)
+        if isinstance(sampling_metadata, dict):
+            for key in (
+                "merge_decision_learned_on_sample",
+                "merge_decision_fit_mode",
+                "merge_decision_n_rows_source",
+                "merge_decision_n_rows_fit",
+                "merge_decision_sample_size_requested",
+                "merge_decision_sample_size_type",
+                "merge_decision_sample_fraction_effective",
+                "sampling_caveat",
+            ):
+                if key in sampling_metadata:
+                    metadata[key] = _json_safe(sampling_metadata[key])
     backend_metadata = getattr(binner, "backend_metadata_", None)
     if backend_metadata is not None:
         metadata["backend_metadata"] = _json_safe(backend_metadata)

--- a/tests/test_audit_report_context.py
+++ b/tests/test_audit_report_context.py
@@ -81,9 +81,32 @@ def test_audit_report_context_summarizes_missing_merge_nearest_woe():
 
 def test_audit_report_context_handles_no_missing_and_empty_decision_log():
     binner = fit_merge_binner(with_missing=False)
+    binner.sampling_metadata_ = {
+        "fit_mode": "sampled_to_pandas",
+        "sampling_applied": True,
+        "merge_decision_learned_on_sample": False,
+        "merge_decision_count": 0,
+        "merge_decision_variables": [],
+        "sampling_caveat": (
+            "missing_policy='merge' Spark fit uses a controlled sampled-to-pandas path; "
+            "any missing merge destination is learned only from the sampled fit rows, "
+            "not from the full Spark DataFrame."
+        ),
+    }
+    binner.missing_decision_log_ = binner.missing_decision_log_.assign(
+        merge_decision_learned_on_sample=False,
+        merge_decision_count=0,
+    )
     context = build_audit_report_context(binner)
 
     assert context["missing_decisions"][0]["action"] == "no_missing_detected"
+    assert context["missing_decisions"][0]["merge_decision_learned_on_sample"] is False
+    assert context["missing_summary"]["merge_decision_learned_on_sample"] is False
+    assert context["missing_summary"]["merge_decision_count"] == 0
+    assert context["missing_summary"]["merge_decision_variables"] == []
+    assert context["model_config"]["merge_decision_learned_on_sample"] is False
+    assert context["model_config"]["merge_decision_count"] == 0
+    assert "Nenhum destino de merge foi aprendido" in context["missing_decisions"][0]["narrative"]
 
     binner.missing_decision_log_ = pd.DataFrame()
     context = build_audit_report_context(binner)

--- a/tests/test_missing_merge_pyspark_boundary.py
+++ b/tests/test_missing_merge_pyspark_boundary.py
@@ -8,9 +8,6 @@ from tests.test_missing_values_pyspark_current_behavior import install_to_pandas
 pytestmark = pytest.mark.spark
 pytest_plugins = ["tests.test_missing_values_pyspark_current_behavior"]
 
-SPARK_MERGE_MESSAGE = 'missing_policy="merge" with PySpark fit is not implemented in this release'
-
-
 def _numeric_spark_frame(spark_session, rows):
     from pyspark.sql import types as T
 
@@ -23,45 +20,61 @@ def _numeric_spark_frame(spark_session, rows):
     return spark_session.createDataFrame(rows, schema=schema)
 
 
-def test_merge_spark_fit_fails_explicitly(spark_session):
-    sdf = _numeric_spark_frame(spark_session, [(1.0, 0), (None, 1), (3.0, 0), (4.0, 1)])
+def test_merge_spark_fit_nearest_event_rate_is_sampled_to_pandas(spark_session):
+    rows = [(float(idx % 7), int(idx % 2 == 0)) for idx in range(28)]
+    rows.extend([(None, 1), (float("nan"), 0)])
+    sdf = _numeric_spark_frame(spark_session, rows)
 
-    with pytest.raises(NotImplementedError, match=SPARK_MERGE_MESSAGE):
-        RiskBands(
-            missing_policy="merge",
-            missing_merge_criterion="nearest_event_rate",
-        ).fit(sdf, y="target", column="score")
+    binner = RiskBands(
+        sample_size=len(rows),
+        min_event_rate_diff=0.0,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    ).fit(sdf, y="target", column="score")
+
+    assert binner.input_backend_ == "pyspark"
+    assert binner.fit_backend_ == "pandas_core"
+    assert binner.backend_metadata_["fit_mode"] == "sampled_to_pandas"
+    assert binner.sampling_metadata_["merge_decision_learned_on_sample"] is True
+    assert binner.missing_merge_map_["score"]
 
 
-def test_merge_nearest_woe_spark_fit_fails_explicitly(spark_session):
-    sdf = _numeric_spark_frame(spark_session, [(1.0, 0), (None, 1), (3.0, 0), (4.0, 1)])
+def test_merge_spark_fit_nearest_woe_is_sampled_to_pandas(spark_session):
+    rows = [(float(idx % 7), int(idx % 3 == 0)) for idx in range(28)]
+    rows.extend([(None, 1), (float("nan"), 0)])
+    sdf = _numeric_spark_frame(spark_session, rows)
 
-    with pytest.raises(NotImplementedError, match=SPARK_MERGE_MESSAGE):
-        RiskBands(
-            missing_policy="merge",
-            missing_merge_criterion="nearest_woe",
-        ).fit(sdf, y="target", column="score")
+    binner = RiskBands(
+        sample_size=len(rows),
+        min_event_rate_diff=0.0,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_woe",
+    ).fit(sdf, y="target", column="score")
+
+    assert binner.input_backend_ == "pyspark"
+    assert binner.fit_backend_ == "pandas_core"
+    assert binner.backend_metadata_["fit_mode"] == "sampled_to_pandas"
+    assert binner.sampling_metadata_["merge_decision_learned_on_sample"] is True
+    assert binner.missing_merge_map_["score"]
 
 
 @pytest.mark.parametrize("criterion", ["nearest_event_rate", "nearest_woe"])
-def test_merge_spark_boundary_fails_before_collecting_data(spark_session, monkeypatch, criterion):
-    sdf = _numeric_spark_frame(spark_session, [(1.0, 0), (None, 1), (3.0, 0), (4.0, 1)])
-    from pyspark.sql import DataFrame as SparkDataFrame
+def test_merge_spark_boundary_records_sampling_caveat(spark_session, criterion):
+    rows = [(float(idx % 5), int(idx % 2 == 0)) for idx in range(18)]
+    rows.extend([(None, 1), (float("nan"), 0)])
+    sdf = _numeric_spark_frame(spark_session, rows)
 
-    def fail_collect(self, *args, **kwargs):
-        raise AssertionError("missing_policy='merge' PySpark boundary should fail before collect")
+    binner = RiskBands(
+        sample_size=len(rows),
+        min_event_rate_diff=0.0,
+        missing_policy="merge",
+        missing_merge_criterion=criterion,
+    ).fit(sdf, y="target", column="score")
 
-    def fail_to_pandas(self, *args, **kwargs):
-        raise AssertionError("missing_policy='merge' PySpark boundary should fail before toPandas")
-
-    monkeypatch.setattr(SparkDataFrame, "collect", fail_collect)
-    monkeypatch.setattr(SparkDataFrame, "toPandas", fail_to_pandas)
-
-    with pytest.raises(NotImplementedError, match=SPARK_MERGE_MESSAGE):
-        RiskBands(
-            missing_policy="merge",
-            missing_merge_criterion=criterion,
-        ).fit(sdf, y="target", column="score")
+    caveat = binner.sampling_metadata_["sampling_caveat"]
+    assert "sampled-to-pandas" in caveat
+    assert binner.missing_decision_log_["merge_decision_learned_on_sample"].eq(True).all()
+    assert binner.missing_decision_log_["sampling_caveat"].eq(caveat).all()
 
 
 def test_merge_pandas_fit_spark_transform_is_allowed(spark_session):

--- a/tests/test_missing_merge_pyspark_bundle_sampled.py
+++ b/tests/test_missing_merge_pyspark_bundle_sampled.py
@@ -1,0 +1,95 @@
+import json
+
+import pytest
+
+from riskbands import RiskBands
+from riskbands.reporting import load_bundle
+
+pytestmark = pytest.mark.spark
+pytest_plugins = ["tests.test_missing_values_pyspark_current_behavior"]
+
+
+def _numeric_spark_frame(spark_session, rows):
+    from pyspark.sql import types as T
+
+    schema = T.StructType(
+        [
+            T.StructField("score", T.DoubleType(), True),
+            T.StructField("target", T.IntegerType(), True),
+        ]
+    )
+    return spark_session.createDataFrame(rows, schema=schema)
+
+
+def _fit_rows():
+    rows = []
+    for _ in range(6):
+        rows.extend(
+            [
+                (-5.0, 0),
+                (-3.0, 0),
+                (0.0, 1),
+                (3.0, 1),
+                (None, 0),
+                (float("nan"), 1),
+            ]
+        )
+    return rows
+
+
+def test_bundle_load_and_audit_report_preserve_sampled_fit_caveat(spark_session, tmp_path):
+    rows = _fit_rows()
+    binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        sample_size=len(rows),
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    ).fit(_numeric_spark_frame(spark_session, rows), y="target", column="score")
+    learned_label = binner.missing_merge_map_["score"]
+
+    bundle_dir = tmp_path / "bundle"
+    binner.export_bundle(bundle_dir)
+    loaded = load_bundle(bundle_dir)
+    manifest = json.loads((bundle_dir / "metadata.json").read_text(encoding="utf-8"))
+    html = (bundle_dir / "audit_report.html").read_text(encoding="utf-8")
+
+    assert (bundle_dir / "missing_decision_log.csv").exists()
+    assert (bundle_dir / "missing_profile.csv").exists()
+    assert (bundle_dir / "missing_merge_candidates.csv").exists()
+    assert manifest["metadata"]["backend_metadata"]["fit_mode"] == "sampled_to_pandas"
+    assert manifest["metadata"]["sampling_metadata"]["merge_decision_learned_on_sample"] is True
+    assert manifest["metadata"]["sampling_caveat"] == binner.sampling_metadata_["sampling_caveat"]
+    assert loaded["manifest"]["metadata"]["sampling_metadata"]["sampling_caveat"] == binner.sampling_metadata_[
+        "sampling_caveat"
+    ]
+    assert loaded["missing_decision_log"][0]["sampling_caveat"] == binner.sampling_metadata_["sampling_caveat"]
+    assert "sampled-to-pandas" in html
+    assert "full Spark DataFrame" in html
+
+    output = binner.transform(
+        _numeric_spark_frame(spark_session, [(None, 1), (float("nan"), 0), (-5.0, 0)]),
+        column="score",
+    )
+    observed = [row["score"] for row in output.select("score").collect()]
+    assert observed.count(learned_label) >= 2
+
+
+def test_bundle_boundary_loaded_payload_is_metadata_not_rehydrated_model(spark_session, tmp_path):
+    rows = _fit_rows()
+    binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        sample_size=len(rows),
+        missing_policy="merge",
+        missing_merge_criterion="nearest_woe",
+    ).fit(_numeric_spark_frame(spark_session, rows), y="target", column="score")
+
+    bundle_dir = tmp_path / "bundle"
+    binner.export_bundle(bundle_dir)
+    loaded = load_bundle(bundle_dir)
+
+    assert isinstance(loaded, dict)
+    assert "transform" not in loaded
+    assert loaded["missing_merge_map"] == binner.missing_merge_map_
+    assert loaded["manifest"]["metadata"]["merge_decision_fit_mode"] == "sampled_to_pandas"

--- a/tests/test_missing_merge_pyspark_bundle_sampled.py
+++ b/tests/test_missing_merge_pyspark_bundle_sampled.py
@@ -1,9 +1,12 @@
 import json
 
+import pandas as pd
 import pytest
 
 from riskbands import RiskBands
 from riskbands.reporting import load_bundle
+from riskbands.utils import dataframe_backend
+from tests.test_fit_validate_true import ValidatingFakeSparkDataFrame
 
 pytestmark = pytest.mark.spark
 pytest_plugins = ["tests.test_missing_values_pyspark_current_behavior"]
@@ -73,6 +76,50 @@ def test_bundle_load_and_audit_report_preserve_sampled_fit_caveat(spark_session,
     )
     observed = [row["score"] for row in output.select("score").collect()]
     assert observed.count(learned_label) >= 2
+
+
+def test_bundle_and_audit_report_do_not_claim_merge_learned_when_sample_has_no_missing(
+    monkeypatch, tmp_path
+):
+    pdf = pd.DataFrame(
+        {
+            "score": [-4.0, -3.0, -2.0, -1.0, 1.0, 2.0, None, float("nan")],
+            "target": [0, 0, 0, 0, 1, 1, 1, 0],
+        }
+    )
+    monkeypatch.setattr(dataframe_backend, "_pyspark_dataframe_class", lambda: ValidatingFakeSparkDataFrame)
+    fake_spark = ValidatingFakeSparkDataFrame(pdf, sample_mode="head")
+    binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        sample_size=0.75,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        missing_merge_fallback="separate_bin",
+    ).fit(fake_spark, y="target", column="score")
+
+    bundle_dir = tmp_path / "bundle"
+    binner.export_bundle(bundle_dir)
+    loaded = load_bundle(bundle_dir)
+    manifest = json.loads((bundle_dir / "metadata.json").read_text(encoding="utf-8"))
+    html = (bundle_dir / "audit_report.html").read_text(encoding="utf-8")
+
+    sampling_metadata = manifest["metadata"]["sampling_metadata"]
+    assert binner.missing_merge_map_ == {}
+    assert sampling_metadata["fit_mode"] == "sampled_to_pandas"
+    assert sampling_metadata["sampling_applied"] is True
+    assert sampling_metadata["merge_decision_learned_on_sample"] is False
+    assert sampling_metadata["merge_decision_count"] == 0
+    assert sampling_metadata["merge_decision_variables"] == []
+    assert manifest["metadata"]["merge_decision_learned_on_sample"] is False
+    assert manifest["metadata"]["merge_decision_count"] == 0
+    assert loaded["missing_merge_map"] == {}
+    assert loaded["missing_decision_log"][0]["action"] == "no_missing_detected"
+    assert loaded["missing_decision_log"][0]["merge_decision_learned_on_sample"] is False
+    assert "sampled-to-pandas" in html
+    assert "merge decision learned on sample" in html
+    assert "Nenhum destino de merge foi aprendido" in html
+    assert "A decisão foi aprendida no fit" not in html
 
 
 def test_bundle_boundary_loaded_payload_is_metadata_not_rehydrated_model(spark_session, tmp_path):

--- a/tests/test_missing_merge_pyspark_fit_sampled.py
+++ b/tests/test_missing_merge_pyspark_fit_sampled.py
@@ -1,0 +1,165 @@
+from collections import Counter
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from riskbands import RiskBands
+from riskbands.utils import dataframe_backend
+from tests.test_fit_validate_true import ValidatingFakeSparkDataFrame
+from tests.test_pyspark_fit_sampling import FakeSparkDataFrame, patch_fake_pyspark
+
+pytestmark = pytest.mark.spark
+pytest_plugins = ["tests.test_missing_values_pyspark_current_behavior"]
+
+
+def _sampled_merge_frame(n=140):
+    rows = []
+    for idx in range(n):
+        if idx % 4 == 0:
+            score = np.nan
+        else:
+            score = float((idx % 9) - 4)
+        target = int((score if pd.notna(score) else idx % 2) >= 0)
+        if idx % 8 == 0:
+            target = 1
+        rows.append({"score": score, "target": target})
+    return pd.DataFrame(rows)
+
+
+def _assert_sampled_merge_metadata(binner, *, source_rows, sample_size):
+    assert binner.input_backend_ == "pyspark"
+    assert binner.fit_backend_ == "pandas_core"
+    assert binner.backend_metadata_["input_backend"] == "pyspark"
+    assert binner.backend_metadata_["fit_backend"] == "pandas_core"
+    assert binner.backend_metadata_["fit_mode"] == "sampled_to_pandas"
+    assert binner.sampling_metadata_["input_backend"] == "pyspark"
+    assert binner.sampling_metadata_["fit_backend"] == "pandas_core"
+    assert binner.sampling_metadata_["fit_mode"] == "sampled_to_pandas"
+    assert binner.sampling_metadata_["sampling_applied"] is True
+    assert binner.sampling_metadata_["n_rows_source"] == source_rows
+    assert binner.sampling_metadata_["n_rows_fit"] <= sample_size
+    assert binner.sampling_metadata_["sample_size_requested"] == sample_size
+    assert binner.sampling_metadata_["merge_decision_learned_on_sample"] is True
+    assert binner.sampling_metadata_["merge_decision_fit_mode"] == "sampled_to_pandas"
+    assert binner.sampling_metadata_["merge_decision_n_rows_source"] == source_rows
+    assert binner.sampling_metadata_["merge_decision_n_rows_fit"] == binner.sampling_metadata_["n_rows_fit"]
+    assert binner.sampling_metadata_["merge_decision_sample_size_requested"] == sample_size
+    assert "sampled-to-pandas" in binner.sampling_metadata_["sampling_caveat"]
+    assert binner.metadata_["merge_decision_learned_on_sample"] is True
+    assert binner.metadata_["sampling_caveat"] == binner.sampling_metadata_["sampling_caveat"]
+
+
+@pytest.mark.parametrize("criterion", ["nearest_event_rate", "nearest_woe"])
+def test_fit_spark_merge_uses_sampled_pandas_core_and_respects_sample_size(monkeypatch, criterion):
+    patch_fake_pyspark(monkeypatch)
+    pdf = _sampled_merge_frame()
+    spark_df = FakeSparkDataFrame(pdf)
+    sample_size = 50
+
+    binner = RiskBands(
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        sample_size=sample_size,
+        missing_policy="merge",
+        missing_merge_criterion=criterion,
+    ).fit(spark_df, y="target", column="score")
+
+    _assert_sampled_merge_metadata(binner, source_rows=len(pdf), sample_size=sample_size)
+    assert spark_df.ops["limits"] == [sample_size]
+    assert spark_df.ops["to_pandas_columns"] == [["score", "target"]]
+    assert binner.missing_merge_map_["score"]
+    assert binner.missing_decision_log_["merge_decision_learned_on_sample"].eq(True).all()
+    assert binner.missing_decision_log_["sampling_caveat"].eq(binner.sampling_metadata_["sampling_caveat"]).all()
+
+
+def test_sampled_fit_fractional_sample_size_records_effective_fraction(monkeypatch):
+    patch_fake_pyspark(monkeypatch)
+    pdf = _sampled_merge_frame(n=120)
+    spark_df = FakeSparkDataFrame(pdf)
+
+    binner = RiskBands(
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        sample_size=0.5,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    ).fit(spark_df, y="target", column="score")
+
+    assert binner.sampling_metadata_["sample_size_type"] == "fraction"
+    assert binner.sampling_metadata_["sample_fraction_effective"] == 0.5
+    assert binner.sampling_metadata_["merge_decision_sample_fraction_effective"] == 0.5
+    assert binner.sampling_metadata_["n_rows_fit"] == 60
+
+
+def test_sample_misses_missing_separate_bin_fallback_routes_spark_missing(spark_session, monkeypatch):
+    pdf = pd.DataFrame(
+        {
+            "score": [-4.0, -3.0, -2.0, -1.0, 1.0, 2.0, None, np.nan],
+            "target": [0, 0, 0, 0, 1, 1, 1, 0],
+        }
+    )
+    monkeypatch.setattr(dataframe_backend, "_pyspark_dataframe_class", lambda: ValidatingFakeSparkDataFrame)
+    fake_spark = ValidatingFakeSparkDataFrame(pdf, sample_mode="head")
+    binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        sample_size=0.75,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        missing_merge_fallback="separate_bin",
+    ).fit(fake_spark, y="target", column="score")
+
+    from pyspark.sql import DataFrame as SparkDataFrame
+    from pyspark.sql import types as T
+
+    monkeypatch.setattr(dataframe_backend, "_pyspark_dataframe_class", lambda: SparkDataFrame)
+    schema = T.StructType(
+        [
+            T.StructField("score", T.DoubleType(), True),
+            T.StructField("target", T.IntegerType(), True),
+        ]
+    )
+    transform_sdf = spark_session.createDataFrame([(None, 1), (float("nan"), 0), (-4.0, 0)], schema=schema)
+
+    observed = [row["score"] for row in binner.transform(transform_sdf, column="score").select("score").collect()]
+
+    assert binner.missing_merge_map_ == {}
+    assert binner.missing_decision_log_.iloc[0]["action"] == "no_missing_detected"
+    assert Counter(observed)["Missing"] == 2
+
+
+def test_sample_misses_missing_raise_fallback_fails_only_when_transform_has_missing(spark_session, monkeypatch):
+    pdf = pd.DataFrame(
+        {
+            "score": [-4.0, -3.0, -2.0, -1.0, 1.0, 2.0, None, np.nan],
+            "target": [0, 0, 0, 0, 1, 1, 1, 0],
+        }
+    )
+    monkeypatch.setattr(dataframe_backend, "_pyspark_dataframe_class", lambda: ValidatingFakeSparkDataFrame)
+    fake_spark = ValidatingFakeSparkDataFrame(pdf, sample_mode="head")
+    binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        sample_size=0.75,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        missing_merge_fallback="raise",
+    ).fit(fake_spark, y="target", column="score")
+
+    from pyspark.sql import DataFrame as SparkDataFrame
+    from pyspark.sql import types as T
+
+    monkeypatch.setattr(dataframe_backend, "_pyspark_dataframe_class", lambda: SparkDataFrame)
+    schema = T.StructType(
+        [
+            T.StructField("score", T.DoubleType(), True),
+            T.StructField("target", T.IntegerType(), True),
+        ]
+    )
+    no_missing_sdf = spark_session.createDataFrame([(-4.0, 0), (1.0, 1)], schema=schema)
+    missing_sdf = spark_session.createDataFrame([(None, 1), (-4.0, 0)], schema=schema)
+
+    assert binner.transform(no_missing_sdf, column="score").__class__.__module__.startswith("pyspark")
+    with pytest.raises(ValueError, match="no merge decision was learned during fit"):
+        binner.transform(missing_sdf, column="score")

--- a/tests/test_missing_merge_pyspark_fit_sampled.py
+++ b/tests/test_missing_merge_pyspark_fit_sampled.py
@@ -41,13 +41,31 @@ def _assert_sampled_merge_metadata(binner, *, source_rows, sample_size):
     assert binner.sampling_metadata_["n_rows_fit"] <= sample_size
     assert binner.sampling_metadata_["sample_size_requested"] == sample_size
     assert binner.sampling_metadata_["merge_decision_learned_on_sample"] is True
+    assert binner.sampling_metadata_["merge_decision_count"] == 1
+    assert binner.sampling_metadata_["merge_decision_variables"] == ["score"]
     assert binner.sampling_metadata_["merge_decision_fit_mode"] == "sampled_to_pandas"
     assert binner.sampling_metadata_["merge_decision_n_rows_source"] == source_rows
     assert binner.sampling_metadata_["merge_decision_n_rows_fit"] == binner.sampling_metadata_["n_rows_fit"]
     assert binner.sampling_metadata_["merge_decision_sample_size_requested"] == sample_size
     assert "sampled-to-pandas" in binner.sampling_metadata_["sampling_caveat"]
     assert binner.metadata_["merge_decision_learned_on_sample"] is True
+    assert binner.metadata_["merge_decision_count"] == 1
+    assert binner.metadata_["merge_decision_variables"] == ["score"]
     assert binner.metadata_["sampling_caveat"] == binner.sampling_metadata_["sampling_caveat"]
+
+
+def _assert_sampled_no_merge_decision_metadata(binner, *, source_rows):
+    assert binner.backend_metadata_["fit_mode"] == "sampled_to_pandas"
+    assert binner.sampling_metadata_["fit_mode"] == "sampled_to_pandas"
+    assert binner.sampling_metadata_["sampling_applied"] is True
+    assert binner.sampling_metadata_["n_rows_source"] == source_rows
+    assert binner.sampling_metadata_["merge_decision_learned_on_sample"] is False
+    assert binner.sampling_metadata_["merge_decision_count"] == 0
+    assert binner.sampling_metadata_["merge_decision_variables"] == []
+    assert binner.metadata_["merge_decision_learned_on_sample"] is False
+    assert binner.metadata_["merge_decision_count"] == 0
+    assert binner.metadata_["merge_decision_variables"] == []
+    assert binner.backend_metadata_["merge_decision_learned_on_sample"] is False
 
 
 @pytest.mark.parametrize("criterion", ["nearest_event_rate", "nearest_woe"])
@@ -70,6 +88,7 @@ def test_fit_spark_merge_uses_sampled_pandas_core_and_respects_sample_size(monke
     assert spark_df.ops["to_pandas_columns"] == [["score", "target"]]
     assert binner.missing_merge_map_["score"]
     assert binner.missing_decision_log_["merge_decision_learned_on_sample"].eq(True).all()
+    assert binner.missing_decision_log_["merge_decision_count"].eq(1).all()
     assert binner.missing_decision_log_["sampling_caveat"].eq(binner.sampling_metadata_["sampling_caveat"]).all()
 
 
@@ -125,7 +144,10 @@ def test_sample_misses_missing_separate_bin_fallback_routes_spark_missing(spark_
     observed = [row["score"] for row in binner.transform(transform_sdf, column="score").select("score").collect()]
 
     assert binner.missing_merge_map_ == {}
+    _assert_sampled_no_merge_decision_metadata(binner, source_rows=len(pdf))
     assert binner.missing_decision_log_.iloc[0]["action"] == "no_missing_detected"
+    assert bool(binner.missing_decision_log_.iloc[0]["merge_decision_learned_on_sample"]) is False
+    assert binner.missing_decision_log_.iloc[0]["merge_decision_count"] == 0
     assert Counter(observed)["Missing"] == 2
 
 
@@ -160,6 +182,10 @@ def test_sample_misses_missing_raise_fallback_fails_only_when_transform_has_miss
     no_missing_sdf = spark_session.createDataFrame([(-4.0, 0), (1.0, 1)], schema=schema)
     missing_sdf = spark_session.createDataFrame([(None, 1), (-4.0, 0)], schema=schema)
 
+    assert binner.missing_merge_map_ == {}
+    _assert_sampled_no_merge_decision_metadata(binner, source_rows=len(pdf))
+    assert binner.missing_decision_log_.iloc[0]["action"] == "no_missing_detected"
+    assert bool(binner.missing_decision_log_.iloc[0]["merge_decision_learned_on_sample"]) is False
     assert binner.transform(no_missing_sdf, column="score").__class__.__module__.startswith("pyspark")
     with pytest.raises(ValueError, match="no merge decision was learned during fit"):
         binner.transform(missing_sdf, column="score")

--- a/tests/test_missing_merge_pyspark_fit_sampled_static_guards.py
+++ b/tests/test_missing_merge_pyspark_fit_sampled_static_guards.py
@@ -1,0 +1,53 @@
+import inspect
+
+import pytest
+
+from riskbands.binning_engine import Binner
+
+
+def test_sampled_fit_to_pandas_is_limited_to_sample_or_empty_sample_fallback():
+    source = inspect.getsource(Binner._fit_pyspark)
+
+    assert "sampled_spark.toPandas()" in source
+    assert "selected_spark.limit(1).toPandas()" in source
+    assert "X.toPandas(" not in source
+    assert "selected_spark.toPandas(" not in source
+
+
+def test_sampled_fit_does_not_use_spark_native_missing_merge_or_udf():
+    fit_source = inspect.getsource(Binner._fit_pyspark)
+    transform_sources = "\n".join(
+        inspect.getsource(getattr(Binner, method_name))
+        for method_name in (
+            "_transform_pyspark",
+            "_spark_transform_expression",
+            "_numeric_supervised_spark_expression",
+            "_numeric_unsupervised_spark_expression",
+            "_categorical_spark_expression",
+        )
+    )
+
+    assert "self.fit(" in fit_source
+    assert "sample_pdf" in fit_source
+    assert "groupBy(" not in fit_source
+    for token in ("udf(", "pandas_udf", "UserDefinedFunction"):
+        assert token not in fit_source
+        assert token not in transform_sources
+
+
+@pytest.mark.parametrize(
+    "method_name,allowed_token",
+    [
+        ("_pyspark_missing_counts", ".collect("),
+        ("_collect_pyspark_profile_aggregate", ".toPandas("),
+    ],
+)
+def test_collect_and_to_pandas_are_confined_to_named_aggregate_or_sampling_helpers(
+    method_name,
+    allowed_token,
+):
+    source = inspect.getsource(getattr(Binner, method_name))
+
+    assert allowed_token in source
+    assert ".toPandas(" not in inspect.getsource(Binner._pyspark_missing_counts)
+    assert ".collect(" not in inspect.getsource(Binner._collect_pyspark_profile_aggregate)

--- a/tests/test_missing_merge_pyspark_fit_sampled_validation.py
+++ b/tests/test_missing_merge_pyspark_fit_sampled_validation.py
@@ -1,0 +1,61 @@
+import pytest
+
+from riskbands import RiskBands
+from tests.test_missing_values_pyspark_current_behavior import install_to_pandas_guard
+
+pytestmark = pytest.mark.spark
+pytest_plugins = ["tests.test_missing_values_pyspark_current_behavior"]
+
+
+def _numeric_spark_frame(spark_session, rows):
+    from pyspark.sql import types as T
+
+    schema = T.StructType(
+        [
+            T.StructField("score", T.DoubleType(), True),
+            T.StructField("target", T.IntegerType(), True),
+        ]
+    )
+    return spark_session.createDataFrame(rows, schema=schema)
+
+
+def _rows():
+    rows = []
+    for idx in range(72):
+        if idx % 9 == 0:
+            score = None
+        elif idx % 10 == 0:
+            score = float("nan")
+        else:
+            score = float((idx % 11) - 5)
+        target = int((idx % 11) >= 5 or score is None)
+        rows.append((score, target))
+    return rows
+
+
+@pytest.mark.parametrize("criterion", ["nearest_event_rate", "nearest_woe"])
+def test_fit_spark_merge_validate_true_builds_minimal_reports(spark_session, monkeypatch, criterion):
+    rows = _rows()
+    sdf = _numeric_spark_frame(spark_session, rows).repartition(2)
+    calls = install_to_pandas_guard(monkeypatch, max_rows=len(rows))
+
+    binner = RiskBands(
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        sample_size=len(rows),
+        missing_policy="merge",
+        missing_merge_criterion=criterion,
+    ).fit(sdf, y="target", column="score", validate=True)
+
+    assert binner.fit_validation_report_ is binner.validation_report_
+    assert binner.fit_validation_report_["validation_type"] == "fit"
+    assert binner.fit_validation_report_["summary"]["n_rows_source"] == len(rows)
+    assert binner.fit_validation_report_["summary"]["n_rows_fit"] == len(rows)
+    assert binner.fit_validation_report_["summary"]["source_profile_status"] == "computed"
+    assert binner.source_profile_ is not None
+    assert not binner.source_profile_.empty
+    assert binner.reference_profile_ is not None
+    assert binner.reference_profile_source_ == "source_profile"
+    assert binner.sampling_metadata_["merge_decision_learned_on_sample"] is True
+    assert calls
+    assert max(call["rows"] for call in calls) <= len(rows)

--- a/tests/test_missing_merge_pyspark_fit_transform_e2e.py
+++ b/tests/test_missing_merge_pyspark_fit_transform_e2e.py
@@ -1,0 +1,173 @@
+import math
+
+import pytest
+
+from riskbands import RiskBands
+
+pytestmark = pytest.mark.spark
+pytest_plugins = ["tests.test_missing_values_pyspark_current_behavior"]
+
+
+def _numeric_spark_frame(spark_session, rows):
+    from pyspark.sql import types as T
+
+    schema = T.StructType(
+        [
+            T.StructField("score", T.DoubleType(), True),
+            T.StructField("target", T.IntegerType(), True),
+        ]
+    )
+    return spark_session.createDataFrame(rows, schema=schema)
+
+
+def _categorical_spark_frame(spark_session, rows):
+    from pyspark.sql import types as T
+
+    schema = T.StructType(
+        [
+            T.StructField("rating", T.StringType(), True),
+            T.StructField("target", T.IntegerType(), True),
+        ]
+    )
+    return spark_session.createDataFrame(rows, schema=schema)
+
+
+def _mixed_spark_frame(spark_session, rows):
+    from pyspark.sql import types as T
+
+    schema = T.StructType(
+        [
+            T.StructField("score", T.DoubleType(), True),
+            T.StructField("rating", T.StringType(), True),
+            T.StructField("target", T.IntegerType(), True),
+        ]
+    )
+    return spark_session.createDataFrame(rows, schema=schema)
+
+
+def _values(spark_df, column):
+    return [row[column] for row in spark_df.select(column).collect()]
+
+
+def _numeric_fit_rows():
+    rows = []
+    for _ in range(5):
+        rows.extend(
+            [
+                (-5.0, 0),
+                (-4.0, 0),
+                (-2.0, 0),
+                (0.0, 1),
+                (2.0, 1),
+                (4.0, 1),
+                (None, 0),
+                (float("nan"), 1),
+            ]
+        )
+    return rows
+
+
+def _categorical_fit_rows():
+    rows = []
+    for _ in range(6):
+        rows.extend(
+            [
+                ("A", 0),
+                ("A", 0),
+                ("B", 0),
+                ("B", 1),
+                ("C", 1),
+                ("C", 1),
+                (None, 0),
+                (None, 1),
+            ]
+        )
+    return rows
+
+
+@pytest.mark.parametrize("criterion", ["nearest_event_rate", "nearest_woe"])
+def test_numeric_fit_spark_transform_same_and_new_spark_df(spark_session, criterion):
+    fit_rows = _numeric_fit_rows()
+    fit_sdf = _numeric_spark_frame(spark_session, fit_rows)
+    binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        sample_size=len(fit_rows),
+        missing_policy="merge",
+        missing_merge_criterion=criterion,
+    ).fit(fit_sdf, y="target", column="score")
+    learned_label = binner.missing_merge_map_["score"]
+
+    same_output = binner.transform(fit_sdf, column="score")
+    new_sdf = _numeric_spark_frame(spark_session, [(None, 1), (float("nan"), 0), (-5.0, 0), (4.0, 1)])
+    new_output = binner.transform(new_sdf, column="score")
+    observed = _values(new_output, "score")
+
+    assert same_output.__class__.__module__.startswith("pyspark")
+    assert new_output.__class__.__module__.startswith("pyspark")
+    assert observed.count(learned_label) >= 2
+    assert "Missing" not in observed
+    assert not any(isinstance(value, float) and math.isnan(value) for value in observed)
+
+
+@pytest.mark.parametrize("criterion", ["nearest_event_rate", "nearest_woe"])
+def test_categorical_fit_spark_transform_routes_null_and_keeps_unknown_distinct(spark_session, criterion):
+    fit_rows = _categorical_fit_rows()
+    fit_sdf = _categorical_spark_frame(spark_session, fit_rows)
+    binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        force_categorical=["rating"],
+        sample_size=len(fit_rows),
+        missing_policy="merge",
+        missing_merge_criterion=criterion,
+    ).fit(fit_sdf, y="target", column="rating")
+    learned_label = str(binner.missing_merge_map_["rating"])
+
+    output = binner.transform(
+        _categorical_spark_frame(spark_session, [(None, 1), ("Z", 0), ("A", 0)]),
+        column="rating",
+    )
+    observed = [str(value) for value in _values(output, "rating")]
+
+    assert output.__class__.__module__.startswith("pyspark")
+    assert observed[0] == learned_label
+    assert observed[1] != learned_label
+    assert observed[1] != "Missing"
+
+
+def test_fit_spark_transform_spark_multiple_features(spark_session):
+    rows = []
+    for _ in range(5):
+        rows.extend(
+            [
+                (-5.0, "A", 0),
+                (-3.0, "A", 0),
+                (0.0, "B", 1),
+                (3.0, "C", 1),
+                (None, None, 1),
+                (float("nan"), None, 0),
+            ]
+        )
+    fit_sdf = _mixed_spark_frame(spark_session, rows)
+    binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        force_categorical=["rating"],
+        sample_size=len(rows),
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    ).fit(fit_sdf, y="target", columns=["score", "rating"])
+
+    output = binner.transform(
+        _mixed_spark_frame(spark_session, [(None, None, 1), (float("nan"), "C", 0), (-5.0, "A", 0)]),
+        columns=["score", "rating"],
+    )
+    score_values = [str(value) for value in _values(output, "score")]
+    rating_values = [str(value) for value in _values(output, "rating")]
+
+    assert output.__class__.__module__.startswith("pyspark")
+    assert score_values[0] == str(binner.missing_merge_map_["score"])
+    assert score_values[1] == str(binner.missing_merge_map_["score"])
+    assert rating_values[0] == str(binner.missing_merge_map_["rating"])
+    assert "Missing" not in rating_values

--- a/tests/test_missing_merge_pyspark_fit_transform_e2e.py
+++ b/tests/test_missing_merge_pyspark_fit_transform_e2e.py
@@ -1,8 +1,11 @@
 import math
 
+import pandas as pd
 import pytest
 
 from riskbands import RiskBands
+from riskbands.utils import dataframe_backend
+from tests.test_fit_validate_true import ValidatingFakeSparkDataFrame
 
 pytestmark = pytest.mark.spark
 pytest_plugins = ["tests.test_missing_values_pyspark_current_behavior"]
@@ -171,3 +174,59 @@ def test_fit_spark_transform_spark_multiple_features(spark_session):
     assert score_values[1] == str(binner.missing_merge_map_["score"])
     assert rating_values[0] == str(binner.missing_merge_map_["rating"])
     assert "Missing" not in rating_values
+
+
+def test_sampled_fit_without_missing_decision_keeps_metadata_and_fallbacks(
+    spark_session, monkeypatch
+):
+    pdf = pd.DataFrame(
+        {
+            "score": [-4.0, -3.0, -2.0, -1.0, 1.0, 2.0, None, float("nan")],
+            "target": [0, 0, 0, 0, 1, 1, 1, 0],
+        }
+    )
+
+    def fit_with_fallback(fallback):
+        monkeypatch.setattr(dataframe_backend, "_pyspark_dataframe_class", lambda: ValidatingFakeSparkDataFrame)
+        fake_spark = ValidatingFakeSparkDataFrame(pdf, sample_mode="head")
+        return RiskBands(
+            max_bins=3,
+            min_event_rate_diff=0.0,
+            sample_size=0.75,
+            missing_policy="merge",
+            missing_merge_criterion="nearest_event_rate",
+            missing_merge_fallback=fallback,
+        ).fit(fake_spark, y="target", column="score")
+
+    from pyspark.sql import DataFrame as SparkDataFrame
+    from pyspark.sql import types as T
+
+    schema = T.StructType(
+        [
+            T.StructField("score", T.DoubleType(), True),
+            T.StructField("target", T.IntegerType(), True),
+        ]
+    )
+    monkeypatch.setattr(dataframe_backend, "_pyspark_dataframe_class", lambda: SparkDataFrame)
+    transform_sdf = spark_session.createDataFrame([(None, 1), (float("nan"), 0), (-4.0, 0)], schema=schema)
+    no_missing_sdf = spark_session.createDataFrame([(-4.0, 0), (1.0, 1)], schema=schema)
+
+    separate_binner = fit_with_fallback("separate_bin")
+    monkeypatch.setattr(dataframe_backend, "_pyspark_dataframe_class", lambda: SparkDataFrame)
+    observed = _values(separate_binner.transform(transform_sdf, column="score"), "score")
+
+    assert separate_binner.missing_merge_map_ == {}
+    assert separate_binner.sampling_metadata_["fit_mode"] == "sampled_to_pandas"
+    assert separate_binner.sampling_metadata_["sampling_applied"] is True
+    assert separate_binner.sampling_metadata_["merge_decision_learned_on_sample"] is False
+    assert separate_binner.sampling_metadata_["merge_decision_count"] == 0
+    assert observed.count("Missing") == 2
+
+    raise_binner = fit_with_fallback("raise")
+    monkeypatch.setattr(dataframe_backend, "_pyspark_dataframe_class", lambda: SparkDataFrame)
+
+    assert raise_binner.missing_merge_map_ == {}
+    assert raise_binner.sampling_metadata_["merge_decision_learned_on_sample"] is False
+    assert raise_binner.transform(no_missing_sdf, column="score").__class__.__module__.startswith("pyspark")
+    with pytest.raises(ValueError, match="no merge decision was learned during fit"):
+        raise_binner.transform(transform_sdf, column="score")

--- a/tests/test_missing_merge_pyspark_transform.py
+++ b/tests/test_missing_merge_pyspark_transform.py
@@ -16,7 +16,6 @@ from tests.test_missing_merge_nearest_woe_pandas import (
 pytestmark = pytest.mark.spark
 pytest_plugins = ["tests.test_missing_values_pyspark_current_behavior"]
 
-SPARK_MERGE_FIT_MESSAGE = 'missing_policy="merge" with PySpark fit is not implemented'
 SPARK_WOE_MESSAGE = "PySpark transform currently supports return_woe=False only"
 
 
@@ -175,24 +174,26 @@ def test_categorical_nearest_woe_merge_routes_null_and_keeps_unknown_distinct(sp
     assert str(unknown_value) != str(missing_value)
 
 
-def test_merge_spark_fit_still_fails_before_collection(spark_session, monkeypatch):
-    sdf = _numeric_spark_frame(spark_session, [(1.0, 0), (None, 1), (3.0, 0), (4.0, 1)])
-    from pyspark.sql import DataFrame as SparkDataFrame
+def test_merge_spark_fit_uses_sampled_to_pandas_boundary(spark_session):
+    rows = [(float(idx % 6), int(idx % 3 == 0)) for idx in range(18)]
+    rows.extend([(None, 1), (float("nan"), 0)])
+    sdf = _numeric_spark_frame(spark_session, rows)
 
-    def fail_collect(self, *args, **kwargs):
-        raise AssertionError("missing_policy='merge' PySpark fit should fail before collect")
+    binner = RiskBands(
+        max_bins=3,
+        min_event_rate_diff=0.0,
+        sample_size=len(rows),
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    ).fit(sdf, y="target", column="score")
 
-    def fail_to_pandas(self, *args, **kwargs):
-        raise AssertionError("missing_policy='merge' PySpark fit should fail before toPandas")
-
-    monkeypatch.setattr(SparkDataFrame, "collect", fail_collect)
-    monkeypatch.setattr(SparkDataFrame, "toPandas", fail_to_pandas)
-
-    with pytest.raises(NotImplementedError, match=SPARK_MERGE_FIT_MESSAGE):
-        RiskBands(
-            missing_policy="merge",
-            missing_merge_criterion="nearest_event_rate",
-        ).fit(sdf, y="target", column="score")
+    assert binner.input_backend_ == "pyspark"
+    assert binner.fit_backend_ == "pandas_core"
+    assert binner.backend_metadata_["fit_mode"] == "sampled_to_pandas"
+    assert binner.sampling_metadata_["merge_decision_learned_on_sample"] is True
+    assert binner.sampling_metadata_["n_rows_source"] == len(rows)
+    assert binner.sampling_metadata_["n_rows_fit"] == len(rows)
+    assert binner.missing_merge_map_["score"]
 
 
 def test_merge_spark_transform_return_woe_still_fails(spark_session):


### PR DESCRIPTION
Adds controlled PySpark fit support for missing_policy='merge' via sampled-to-pandas fitting. The missing merge decision is learned on the sampled pandas fit data and preserved in metadata, bundle artifacts, and the narrative audit report. Covers nearest_event_rate, nearest_woe, fallbacks, validate=True, Spark transform after sampled fit, and static guards against unintended full collect. This does not implement Spark-native full fit, Spark return_woe=True, new merge criteria, or a version bump.