### PR TITLE
Refine Spark missing merge validation reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,5 @@ docs/presentations/
 docs/goals/
 examples/_tmp_riskbands_bundle_smoke/
 examples/exemplo0.ipynb
+.agents/
+.codex/

--- a/docs/pyspark_missing_merge_validation_reporting_design.md
+++ b/docs/pyspark_missing_merge_validation_reporting_design.md
@@ -1,0 +1,115 @@
+# PySpark Missing Merge Validation and Reporting Design
+
+This internal note documents the G3 validation/reporting layer for the Spark missing-merge flow:
+
+```text
+fit Spark -> sampled-to-pandas -> missing merge learned on sample -> transform Spark
+```
+
+G3 does not add Spark-native full fit, Spark `return_woe=True`, or a new missing merge criterion. It makes the existing sampled fit path more auditable.
+
+## What G3 Improves
+
+G3 adds explicit diagnostics for the gap between the sampled pandas-core fit and the full Spark source data used to draw that sample. The main additions are:
+
+- aggregated Spark `source_profile_` when `fit(validate=True)` is used;
+- sample-vs-source bin diagnostics in `fit_validation_report_["sample_representativeness"]`;
+- per-variable `missing_sampling_diagnostics`;
+- richer `fit_validation_report_` metadata for Spark sampled fit;
+- richer `transform_validation_report_` comparison payloads;
+- bundle and audit report caveats for sampled-to-pandas missing merge;
+- static guards that keep profile collection limited to guarded aggregate rows.
+
+## Source Profile
+
+For Spark fit with validation enabled, RiskBands builds `source_profile_` with Spark aggregations by variable and final bin label. The profile is collected only after aggregation and only through the guarded `_collect_pyspark_profile_aggregate` helper.
+
+If the aggregate profile exceeds `max_profile_rows_to_collect`, source profiling is skipped and `fit_validation_report_["summary"]["source_profile_status"]` records `skipped_profile_too_large`.
+
+When missing merge is learned, `source_profile_` reflects final bins after the learned merge decision. It is not a raw missing-value profile and should not be interpreted as proof that source missing values were represented in the sample.
+
+## Sample vs Source
+
+`fit_validation_report_["sample_representativeness"]` compares `fit_profile_` from the sampled fit against `source_profile_` from Spark aggregation. It records:
+
+- `event_rate_abs_diff`;
+- `share_abs_diff`;
+- bins present in source but absent in the sampled fit;
+- bins present in the sampled fit but absent in source;
+- bounded per-bin diagnostics.
+
+These diagnostics can produce warnings such as `sample_event_rate_shift`, `sample_share_shift`, and `profile_too_large`.
+
+## Missing Sampling Diagnostics
+
+`missing_sampling_diagnostics` is a per-variable list with:
+
+- `missing_share_sample_fit`;
+- `missing_share_source_spark`;
+- `missing_share_abs_diff`;
+- `missing_count_sample_fit`;
+- `missing_count_source_spark`;
+- `missing_merge_destination_learned`;
+- `merge_decision_learned_on_sample`;
+- `fallback_risk`;
+- `alert_flags`.
+
+The most important warning is `source_missing_not_seen_in_sample`: the full Spark source has missing values, but the sampled fit did not. If no merge decision was learned while source missing exists, the diagnostic also records `merge_decision_not_learned_but_source_has_missing`.
+
+These warnings are not approvals. They make sampling risk visible so reviewers can decide whether to increase `sample_size`, adjust sampling upstream, or rely on fallback behavior.
+
+## Fit Validation Report
+
+For Spark sampled fit, `fit_validation_report_` now includes:
+
+- `backend="pyspark"`;
+- `fit_mode="sampled_to_pandas"`;
+- source and fit row counts;
+- sampling request/effective fraction fields;
+- `sample_representativeness`;
+- `missing_sampling_diagnostics`;
+- `merge_decision_summary`;
+- consolidated alerts.
+
+`validation_report_` still aliases `fit_validation_report_` immediately after `fit(validate=True)`.
+
+## Transform Validation Report
+
+Spark `transform(validate=True)` still builds `application_profile_` through Spark aggregation. It compares the application profile against `reference_profile_`, which prefers `source_profile_` when available and falls back to `fit_profile_`.
+
+The transform report records:
+
+- target availability and skipped status when target is absent;
+- application-vs-reference event-rate alerts;
+- application-vs-reference share-shift alerts;
+- bins missing on either side of the comparison;
+- bounded per-bin comparison records.
+
+Transform validation does not learn event rates, WoE, or missing merge destinations from application data.
+
+## Bundle and Audit Report
+
+Bundles persist:
+
+- `source_profile`;
+- `reference_profile`;
+- `application_profile`;
+- fit and transform validation reports;
+- `missing_sampling_diagnostics`;
+- sampling metadata and source missing counts in metadata.
+
+The narrative audit report includes caveats for sampled-to-pandas fit, distinguishes whether a merge decision was learned on sample, and calls out source missing values not seen in the sample.
+
+## Remaining Limits
+
+G3 preserves these limits:
+
+- no Spark-native full fit;
+- no Spark `return_woe=True`;
+- no new merge criterion;
+- no full source collect for validation/reporting;
+- no claim that a warning means the sample is representative.
+
+## Release Prep Notes
+
+Before release prep, run the Spark gates, audit report regressions, static guards, and bundle roundtrip tests. Public docs should describe these diagnostics as audit/validation aids, not as representativeness guarantees.

--- a/riskbands/audit_report.py
+++ b/riskbands/audit_report.py
@@ -298,6 +298,9 @@ def _validation_context(binner: Any) -> dict[str, Any]:
         "validation_report": getattr(binner, "validation_report_", None),
     }
     safe_reports = {key: _json_safe(value) for key, value in reports.items() if value is not None}
+    missing_sampling_diagnostics = _json_safe(
+        getattr(binner, "missing_sampling_diagnostics_", None) or []
+    )
     alerts: list[dict[str, Any]] = []
     for report_name, report in safe_reports.items():
         if isinstance(report, Mapping):
@@ -305,9 +308,19 @@ def _validation_context(binner: Any) -> dict[str, Any]:
                 key_text = str(key).lower()
                 if "warning" in key_text or "alert" in key_text or "error" in key_text:
                     alerts.append({"source": report_name, "field": key, "value": value})
+    for row in missing_sampling_diagnostics:
+        if isinstance(row, Mapping) and row.get("alert_flags"):
+            alerts.append(
+                {
+                    "source": "missing_sampling_diagnostics",
+                    "field": row.get("variable"),
+                    "value": row.get("alert_flags"),
+                }
+            )
     return {
         "reports": safe_reports,
         "alerts": alerts,
+        "missing_sampling_diagnostics": missing_sampling_diagnostics,
         "has_validation": bool(safe_reports),
     }
 
@@ -461,8 +474,61 @@ def _sampling_caveats_from_metadata(metadata: Mapping[str, Any]) -> list[str]:
     if isinstance(sampling_metadata, Mapping):
         nested_caveat = sampling_metadata.get("sampling_caveat")
         if nested_caveat and str(nested_caveat) not in caveats:
-            caveats.append(str(nested_caveat))
+                caveats.append(str(nested_caveat))
     return caveats
+
+
+def _sampling_notes_from_metadata(
+    metadata: Mapping[str, Any],
+    missing_sampling_diagnostics: list[dict[str, Any]],
+) -> list[str]:
+    notes = []
+    sampling_metadata = metadata.get("sampling_metadata")
+    if not isinstance(sampling_metadata, Mapping):
+        sampling_metadata = {}
+    fit_mode = metadata.get("fit_mode") or sampling_metadata.get("fit_mode")
+    if fit_mode == "sampled_to_pandas":
+        notes.append(
+            "Fit sampled-to-pandas: Spark fit used a controlled sample for pandas-core fitting; "
+            "source diagnostics are aggregate checks, not a Spark-native full fit."
+        )
+    learned = metadata.get(
+        "merge_decision_learned_on_sample",
+        sampling_metadata.get("merge_decision_learned_on_sample"),
+    )
+    if learned is True:
+        notes.append(
+            "Merge decision learned on sample: missing merge destinations were learned from sampled fit rows."
+        )
+    elif learned is False:
+        notes.append(
+            "No merge decision learned on sample: if source or transform data has missing values, "
+            "review fallback behavior."
+        )
+    source_missing_not_seen = [
+        str(row.get("variable"))
+        for row in missing_sampling_diagnostics
+        if isinstance(row, Mapping)
+        and "source_missing_not_seen_in_sample" in row.get("alert_flags", [])
+    ]
+    if source_missing_not_seen:
+        notes.append(
+            "Source missing not seen in sample: "
+            + ", ".join(source_missing_not_seen)
+            + " had missing values in the Spark source that were absent from the sampled fit."
+        )
+    return notes
+
+
+def _missing_sampling_diagnostics_from_context(
+    binner: Any,
+    metadata: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    diagnostics = getattr(binner, "missing_sampling_diagnostics_", None)
+    if diagnostics is None:
+        diagnostics = metadata.get("missing_sampling_diagnostics")
+    safe = _json_safe(diagnostics or [])
+    return safe if isinstance(safe, list) else []
 
 
 def build_audit_report_context(
@@ -510,10 +576,14 @@ def build_audit_report_context(
         table_name="missing_merge_candidates",
         warnings=warnings,
     )
+    missing_sampling_diagnostics = _missing_sampling_diagnostics_from_context(binner, metadata)
     limitations = _limitations()
     for caveat in _sampling_caveats_from_metadata(metadata):
         if caveat not in limitations:
             limitations.append(caveat)
+    for note in _sampling_notes_from_metadata(metadata, missing_sampling_diagnostics):
+        if note not in limitations:
+            limitations.append(note)
 
     context = {
         "generated_at": datetime.now(timezone.utc).isoformat(),
@@ -550,6 +620,7 @@ def build_audit_report_context(
         ),
         "missing_decisions": _json_safe(missing_decisions),
         "merge_candidates": _json_safe(merge_candidates),
+        "missing_sampling_diagnostics": _json_safe(missing_sampling_diagnostics),
         "missing_merge_map": _json_safe(getattr(binner, "missing_merge_map_", {})),
         "binning_tables": _json_safe(binning_tables),
         "validation": _validation_context(binner),
@@ -567,6 +638,7 @@ def build_audit_report_context(
                 "missing_summary",
                 "missing_decisions",
                 "merge_candidates",
+                "missing_sampling_diagnostics",
                 "binning_tables",
                 "validation",
                 "bundle_inventory",
@@ -771,8 +843,29 @@ def _render_validation(validation: Mapping[str, Any]) -> str:
         )
     alerts = validation.get("alerts") or []
     reports = validation.get("reports") or {}
+    missing_sampling_diagnostics = validation.get("missing_sampling_diagnostics") or []
+    missing_sampling_html = ""
+    if missing_sampling_diagnostics:
+        missing_sampling_html = (
+            "<h3>Missing sampling diagnostics</h3>"
+            + _render_table(
+                missing_sampling_diagnostics,
+                preferred=[
+                    "variable",
+                    "status",
+                    "missing_count_sample_fit",
+                    "missing_count_source_spark",
+                    "missing_share_abs_diff",
+                    "merge_decision_learned_on_sample",
+                    "fallback_risk",
+                    "alert_flags",
+                ],
+                max_columns=8,
+            )
+        )
     return (
         _render_table(alerts, preferred=["source", "field", "value"], empty_message="Sem alertas registrados.")
+        + missing_sampling_html
         + '<details class="technical-details"><summary>Payloads de validação</summary>'
         + f"<pre>{_e(json.dumps(reports, ensure_ascii=False, indent=2))}</pre>"
         + "</details>"

--- a/riskbands/binning_engine.py
+++ b/riskbands/binning_engine.py
@@ -734,8 +734,12 @@ class Binner(BaseEstimator, TransformerMixin):
         self.backend_metadata_ = backend_metadata
         self.sampling_metadata_ = sampling_metadata
         self.source_profile_ = None
+        self.source_missing_counts_ = None
+        self.missing_sampling_diagnostics_ = None
         source_profile_status = None
         if validate:
+            if self.missing_policy == _MERGE_MISSING_POLICY:
+                self.source_missing_counts_ = self._pyspark_missing_counts(X, feature_columns)
             self.source_profile_, source_profile_status = self._try_build_pyspark_source_profile(
                 X,
                 target_name=target_name,
@@ -2764,6 +2768,189 @@ class Binner(BaseEstimator, TransformerMixin):
         return merged
 
     # ------------------------------------------------------------------
+    @staticmethod
+    def _json_number_or_none(value: Any) -> float | None:
+        number = pd.to_numeric(pd.Series([value]), errors="coerce").iloc[0]
+        if pd.isna(number) or not np.isfinite(float(number)):
+            return None
+        return float(number)
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _json_int_or_none(value: Any) -> int | None:
+        number = Binner._json_number_or_none(value)
+        return int(number) if number is not None else None
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _json_label_or_none(value: Any) -> Any:
+        try:
+            if pd.isna(value):
+                return None
+        except (TypeError, ValueError):
+            return value
+        return value
+
+    # ------------------------------------------------------------------
+    def _profile_comparison_records(
+        self,
+        comparison: pd.DataFrame,
+        *,
+        left_name: str,
+        right_name: str,
+    ) -> list[dict[str, Any]]:
+        if comparison is None or comparison.empty:
+            return []
+
+        records = []
+        for _, row in comparison.iterrows():
+            left_label = row.get(f"bin_label_{left_name}")
+            right_label = row.get(f"bin_label_{right_name}")
+            bin_label = left_label
+            if self._json_label_or_none(bin_label) is None:
+                bin_label = right_label
+            n_left = self._json_int_or_none(row.get(f"n_{left_name}"))
+            n_right = self._json_int_or_none(row.get(f"n_{right_name}"))
+            records.append(
+                {
+                    "variable": row.get("variable"),
+                    "bin_label": self._json_label_or_none(bin_label),
+                    f"present_in_{left_name}": n_left is not None,
+                    f"present_in_{right_name}": n_right is not None,
+                    f"n_{left_name}": n_left,
+                    f"n_{right_name}": n_right,
+                    f"event_rate_{left_name}": self._json_number_or_none(row.get(f"event_rate_{left_name}")),
+                    f"event_rate_{right_name}": self._json_number_or_none(row.get(f"event_rate_{right_name}")),
+                    f"share_{left_name}": self._json_number_or_none(row.get(f"share_{left_name}")),
+                    f"share_{right_name}": self._json_number_or_none(row.get(f"share_{right_name}")),
+                    "event_rate_abs_diff": self._json_number_or_none(row.get("event_rate_abs_diff")),
+                    "share_abs_diff": self._json_number_or_none(row.get("share_abs_diff")),
+                }
+            )
+        return records
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _rows_by_variable(table: pd.DataFrame | None) -> dict[str, pd.Series]:
+        if table is None or table.empty or "variable" not in table.columns:
+            return {}
+        rows = {}
+        for _, row in table.iterrows():
+            rows.setdefault(str(row.get("variable")), row)
+        return rows
+
+    # ------------------------------------------------------------------
+    def _build_missing_sampling_diagnostics(
+        self,
+        *,
+        fit_rows: int | None,
+        source_rows: int | None,
+    ) -> list[dict[str, Any]]:
+        if self.missing_policy != _MERGE_MISSING_POLICY:
+            return []
+
+        source_counts = getattr(self, "source_missing_counts_", None)
+        if not isinstance(source_counts, dict):
+            return []
+
+        decision_rows = self._rows_by_variable(getattr(self, "missing_decision_log_", None))
+        profile_rows = self._rows_by_variable(getattr(self, "missing_profile_", None))
+        merge_map = getattr(self, "missing_merge_map_", {}) or {}
+        learned_variables = {str(variable) for variable in merge_map}
+        variables = list(getattr(self, "feature_names_in_", []) or [])
+        for variable in [*source_counts, *decision_rows, *profile_rows, *merge_map]:
+            if str(variable) not in {str(existing) for existing in variables}:
+                variables.append(str(variable))
+
+        settings = self._default_validation_settings()
+        diagnostics = []
+        for variable in variables:
+            variable_key = str(variable)
+            decision = decision_rows.get(variable_key, pd.Series(dtype=object))
+            profile = profile_rows.get(variable_key, pd.Series(dtype=object))
+            sample_count = self._json_int_or_none(decision.get("n_missing_fit"))
+            if sample_count is None:
+                sample_count = self._json_int_or_none(profile.get("n_missing_fit")) or 0
+            source_count = int(source_counts.get(variable_key, 0) or 0)
+            sample_share = self._json_number_or_none(profile.get("share_missing_fit"))
+            if sample_share is None and fit_rows:
+                sample_share = sample_count / int(fit_rows)
+            source_share = source_count / int(source_rows) if source_rows else None
+            share_diff = (
+                abs(sample_share - source_share)
+                if sample_share is not None and source_share is not None
+                else None
+            )
+
+            destination = self._json_label_or_none(decision.get("selected_bin_label"))
+            if destination is None:
+                destination = self._json_label_or_none(profile.get("merged_into_bin_label"))
+            learned = variable_key in learned_variables
+            if "merge_decision_learned_on_sample" in decision.index:
+                learned = bool(decision.get("merge_decision_learned_on_sample"))
+
+            alert_flags = []
+            if source_count > 0 and sample_count == 0:
+                alert_flags.append("source_missing_not_seen_in_sample")
+            if source_count > 0 and not learned:
+                alert_flags.append("merge_decision_not_learned_but_source_has_missing")
+            if share_diff is not None and share_diff >= settings["max_sample_share_abs_diff"]:
+                alert_flags.append("sample_share_shift")
+
+            diagnostics.append(
+                {
+                    "variable": variable_key,
+                    "missing_share_sample_fit": sample_share,
+                    "missing_share_source_spark": source_share,
+                    "missing_share_abs_diff": share_diff,
+                    "missing_count_sample_fit": int(sample_count),
+                    "missing_count_source_spark": int(source_count),
+                    "missing_merge_destination_learned": destination,
+                    "merge_decision_learned_on_sample": learned,
+                    "fallback_risk": bool(source_count > 0 and not learned),
+                    "status": "warning" if alert_flags else "ok",
+                    "alert_flags": alert_flags,
+                }
+            )
+        return diagnostics
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _missing_sampling_summary(diagnostics: list[dict[str, Any]]) -> dict[str, Any]:
+        if not diagnostics:
+            return {
+                "status": "not_available",
+                "n_variables": 0,
+                "n_warnings": 0,
+                "max_missing_share_abs_diff": None,
+            }
+        max_diff = max(
+            (
+                float(row["missing_share_abs_diff"])
+                for row in diagnostics
+                if row.get("missing_share_abs_diff") is not None
+            ),
+            default=None,
+        )
+        warning_rows = [row for row in diagnostics if row.get("status") != "ok"]
+        return {
+            "status": "warning" if warning_rows else "ok",
+            "n_variables": int(len(diagnostics)),
+            "n_warnings": int(len(warning_rows)),
+            "variables_with_source_missing_not_seen_in_sample": [
+                row["variable"]
+                for row in diagnostics
+                if "source_missing_not_seen_in_sample" in row.get("alert_flags", [])
+            ],
+            "variables_with_unlearned_source_missing": [
+                row["variable"]
+                for row in diagnostics
+                if "merge_decision_not_learned_but_source_has_missing" in row.get("alert_flags", [])
+            ],
+            "max_missing_share_abs_diff": max_diff,
+        }
+
+    # ------------------------------------------------------------------
     def _event_rate_profile_alerts(
         self,
         application_profile: pd.DataFrame,
@@ -2927,6 +3114,31 @@ class Binner(BaseEstimator, TransformerMixin):
         sample_size_issue = bool(fit_rows and fit_rows < settings["min_fit_rows"])
         sample_comparison = None
         sample_alerts = []
+        fit_alerts = []
+        missing_sampling_diagnostics = self._build_missing_sampling_diagnostics(
+            fit_rows=fit_rows,
+            source_rows=source_rows,
+        )
+        self.missing_sampling_diagnostics_ = missing_sampling_diagnostics or None
+        missing_sampling_summary = self._missing_sampling_summary(missing_sampling_diagnostics)
+        missing_sampling_alerts = [
+            {
+                "variable": row["variable"],
+                "status": row["status"],
+                "alert_flags": row["alert_flags"],
+                "message": "Source Spark missing behavior differs from the sampled fit.",
+            }
+            for row in missing_sampling_diagnostics
+            if row.get("status") != "ok"
+        ]
+        if source_profile_status == "skipped_profile_too_large":
+            fit_alerts.append(
+                {
+                    "status": "warning",
+                    "alert_flags": ["profile_too_large"],
+                    "message": "Spark source profile aggregation exceeded the configured row guard.",
+                }
+            )
         if source_profile is not None and not source_profile.empty:
             comparison = self._compare_profiles(
                 profile,
@@ -2942,30 +3154,97 @@ class Binner(BaseEstimator, TransformerMixin):
                     reference_name="fit",
                 )
                 sample_alerts = [alert for alert in event_rate_alerts if alert["status"] != "ok"]
+                comparison_records = self._profile_comparison_records(
+                    comparison,
+                    left_name="fit",
+                    right_name="source",
+                )
+                bins_missing_in_sample = [
+                    {"variable": record["variable"], "bin_label": record["bin_label"]}
+                    for record in comparison_records
+                    if not record["present_in_fit"] and record["present_in_source"]
+                ]
+                bins_missing_in_source = [
+                    {"variable": record["variable"], "bin_label": record["bin_label"]}
+                    for record in comparison_records
+                    if record["present_in_fit"] and not record["present_in_source"]
+                ]
+                max_share_abs_diff = (
+                    float(comparison["share_abs_diff"].max())
+                    if comparison["share_abs_diff"].notna().any()
+                    else None
+                )
+                if max_share_abs_diff is not None and max_share_abs_diff >= settings["max_sample_share_abs_diff"]:
+                    fit_alerts.append(
+                        {
+                            "status": "warning",
+                            "alert_flags": ["sample_share_shift"],
+                            "message": (
+                                "At least one sampled fit bin has a large share difference versus "
+                                "the Spark source profile."
+                            ),
+                            "max_share_abs_diff": max_share_abs_diff,
+                        }
+                    )
                 sample_comparison = {
                     "status": (
                         "critical"
                         if any(alert["status"] == "critical" for alert in sample_alerts)
-                        else ("warning" if sample_alerts else "ok")
+                        else (
+                            "warning"
+                            if sample_alerts
+                            or missing_sampling_alerts
+                            or bins_missing_in_sample
+                            or bins_missing_in_source
+                            or any("sample_share_shift" in alert.get("alert_flags", []) for alert in fit_alerts)
+                            else "ok"
+                        )
                     ),
                     "max_event_rate_abs_diff": (
                         float(comparison["event_rate_abs_diff"].max())
                         if comparison["event_rate_abs_diff"].notna().any()
                         else None
                     ),
-                    "max_share_abs_diff": (
-                        float(comparison["share_abs_diff"].max())
-                        if comparison["share_abs_diff"].notna().any()
-                        else None
-                    ),
+                    "max_share_abs_diff": max_share_abs_diff,
+                    "max_missing_share_abs_diff": missing_sampling_summary["max_missing_share_abs_diff"],
+                    "bins_missing_in_sample": bins_missing_in_sample,
+                    "bins_missing_in_source": bins_missing_in_source,
+                    "bin_diagnostics": comparison_records,
+                    "missing_sampling_summary": missing_sampling_summary,
                     "alerts": sample_alerts,
                 }
                 sample_size_issue = sample_size_issue or bool(sample_alerts)
 
-        warning_count = len(bin_alerts) + min_n_bins_warning_count + len(sample_alerts) + int(sample_size_issue)
+        for alert in sample_alerts:
+            normalized_flags = list(alert.get("alert_flags", []))
+            if alert.get("status") in {"warning", "critical"} and "sample_event_rate_shift" not in normalized_flags:
+                normalized_flags.append("sample_event_rate_shift")
+            fit_alerts.append({**alert, "alert_flags": normalized_flags})
+        fit_alerts.extend(missing_sampling_alerts)
+        warning_count = (
+            len(bin_alerts)
+            + min_n_bins_warning_count
+            + len(sample_alerts)
+            + len(missing_sampling_alerts)
+            + len(fit_alerts)
+            + int(sample_size_issue)
+        )
+        status = (
+            "critical"
+            if any(alert.get("status") == "critical" for alert in fit_alerts)
+            else ("warning" if warning_count else "ok")
+        )
+        sampling_payload = sampling_metadata if isinstance(sampling_metadata, dict) else {}
+        backend_payload = backend_metadata if isinstance(backend_metadata, dict) else {}
+        merge_map = getattr(self, "missing_merge_map_", {}) or {}
         return {
             "validation_type": "fit",
-            "status": "warning" if warning_count else "ok",
+            "status": status,
+            "backend": backend_payload.get("input_backend", getattr(self, "input_backend_", None)),
+            "fit_mode": backend_payload.get("fit_mode", sampling_payload.get("fit_mode")),
+            "sampling_applied": sampling_payload.get("sampling_applied"),
+            "sample_size_requested": sampling_payload.get("sample_size_requested"),
+            "sample_fraction_effective": sampling_payload.get("sample_fraction_effective"),
             "missing_policy": self.missing_policy,
             "settings": settings,
             "summary": {
@@ -2987,12 +3266,25 @@ class Binner(BaseEstimator, TransformerMixin):
                 ),
                 "possible_sample_size_issue": sample_size_issue,
                 "source_profile_status": source_profile_status,
+                "sample_representativeness_status": (
+                    sample_comparison.get("status") if sample_comparison else None
+                ),
+                "missing_sampling_status": missing_sampling_summary["status"],
+                "merge_decision_count": int(len(merge_map)),
                 **missing_summary,
             },
             "variable_status": variable_status,
             "bin_alerts": bin_alerts,
+            "alerts": fit_alerts,
             "min_n_bins_metadata": min_n_bins_metadata,
             "sample_representativeness": sample_comparison,
+            "missing_sampling_diagnostics": missing_sampling_diagnostics,
+            "merge_decision_summary": {
+                "merge_decision_learned_on_sample": bool(merge_map),
+                "merge_decision_count": int(len(merge_map)),
+                "merge_decision_variables": sorted(str(variable) for variable in merge_map),
+                "fit_mode": sampling_payload.get("fit_mode") or backend_payload.get("fit_mode"),
+            },
         }
 
     # ------------------------------------------------------------------
@@ -3030,6 +3322,12 @@ class Binner(BaseEstimator, TransformerMixin):
                 "settings": settings,
                 "reason": "target_not_available",
                 "reference_profile_source": getattr(self, "reference_profile_source_", "missing"),
+                "summary": {
+                    "target_available": False,
+                    "n_application_rows": n_application_rows,
+                    "n_application_profile_rows": 0,
+                    "n_alerts": 0,
+                },
             }
         if reference_profile is None or reference_profile.empty:
             return {
@@ -3040,6 +3338,14 @@ class Binner(BaseEstimator, TransformerMixin):
                 "settings": settings,
                 "reason": "reference_profile_missing",
                 "reference_profile_source": getattr(self, "reference_profile_source_", "missing"),
+                "summary": {
+                    "target_available": True,
+                    "n_application_rows": n_application_rows,
+                    "n_application_profile_rows": (
+                        int(len(application_profile)) if application_profile is not None else 0
+                    ),
+                    "n_alerts": 1,
+                },
             }
 
         comparison = self._compare_profiles(
@@ -3054,7 +3360,54 @@ class Binner(BaseEstimator, TransformerMixin):
             application_name="application",
             reference_name="reference",
         )
+        comparison_records = self._profile_comparison_records(
+            comparison,
+            left_name="application",
+            right_name="reference",
+        )
+        bins_missing_in_application = [
+            {"variable": record["variable"], "bin_label": record["bin_label"]}
+            for record in comparison_records
+            if not record["present_in_application"] and record["present_in_reference"]
+        ]
+        bins_missing_in_reference = [
+            {"variable": record["variable"], "bin_label": record["bin_label"]}
+            for record in comparison_records
+            if record["present_in_application"] and not record["present_in_reference"]
+        ]
         alerts = [alert for alert in event_rate_alerts if alert["status"] != "ok"]
+        max_share_abs_diff = (
+            float(comparison["share_abs_diff"].max())
+            if not comparison.empty and comparison["share_abs_diff"].notna().any()
+            else None
+        )
+        if max_share_abs_diff is not None and max_share_abs_diff >= settings["max_sample_share_abs_diff"]:
+            alerts.append(
+                {
+                    "status": "warning",
+                    "alert_flags": ["application_share_shift"],
+                    "max_share_abs_diff": max_share_abs_diff,
+                    "message": "Application bin share differs materially from the reference profile.",
+                }
+            )
+        if bins_missing_in_application:
+            alerts.append(
+                {
+                    "status": "warning",
+                    "alert_flags": ["reference_bins_missing_in_application"],
+                    "bins": bins_missing_in_application,
+                    "message": "Reference bins are absent from the application profile.",
+                }
+            )
+        if bins_missing_in_reference:
+            alerts.append(
+                {
+                    "status": "warning",
+                    "alert_flags": ["application_bins_missing_in_reference"],
+                    "bins": bins_missing_in_reference,
+                    "message": "Application bins are absent from the reference profile.",
+                }
+            )
         status = (
             "critical"
             if any(alert["status"] == "critical" for alert in alerts)
@@ -3086,13 +3439,14 @@ class Binner(BaseEstimator, TransformerMixin):
                     else None
                 ),
                 "max_share_abs_diff": (
-                    float(comparison["share_abs_diff"].max())
-                    if not comparison.empty and comparison["share_abs_diff"].notna().any()
-                    else None
+                    max_share_abs_diff
                 ),
                 **application_missing_summary,
             },
             "event_rate_status": event_rate_alerts,
+            "profile_comparison": comparison_records,
+            "bins_missing_in_application": bins_missing_in_application,
+            "bins_missing_in_reference": bins_missing_in_reference,
             "alerts": alerts,
         }
 
@@ -3373,6 +3727,8 @@ class Binner(BaseEstimator, TransformerMixin):
         self.validation_report_ = None
         self.application_profile_ = None
         self.source_profile_ = None
+        self.source_missing_counts_ = None
+        self.missing_sampling_diagnostics_ = None
         self.missing_profile_ = pd.DataFrame()
         self.missing_decision_log_ = pd.DataFrame()
         self.missing_merge_candidates_ = pd.DataFrame()

--- a/riskbands/reporting.py
+++ b/riskbands/reporting.py
@@ -95,6 +95,7 @@ OPTIONAL_BUNDLE_PROFILE_FIELDS = (
     "fit_validation_report",
     "transform_validation_report",
     "validation_report",
+    "missing_sampling_diagnostics",
     "sampling_metadata",
     "backend_metadata",
     "min_n_bins_metadata",
@@ -1026,6 +1027,12 @@ def build_binner_metadata(
     backend_metadata = getattr(binner, "backend_metadata_", None)
     if backend_metadata is not None:
         metadata["backend_metadata"] = _json_safe(backend_metadata)
+    source_missing_counts = getattr(binner, "source_missing_counts_", None)
+    if source_missing_counts is not None:
+        metadata["source_missing_counts"] = _json_safe(source_missing_counts)
+    missing_sampling_diagnostics = getattr(binner, "missing_sampling_diagnostics_", None)
+    if missing_sampling_diagnostics is not None:
+        metadata["missing_sampling_diagnostics"] = _json_safe(missing_sampling_diagnostics)
     reference_profile_source = getattr(binner, "reference_profile_source_", None)
     if reference_profile_source is not None:
         metadata["reference_profile_source"] = reference_profile_source
@@ -1146,6 +1153,7 @@ def load_bundle(path: PathLike) -> dict[str, Any]:
         "fit_validation_report": manifest.get("fit_validation_report"),
         "transform_validation_report": manifest.get("transform_validation_report"),
         "validation_report": manifest.get("validation_report"),
+        "missing_sampling_diagnostics": manifest.get("missing_sampling_diagnostics"),
         "missing_policy": manifest.get("missing_policy"),
         "effective_missing_policy": manifest.get("effective_missing_policy"),
         "missing_merge_criterion": manifest.get("missing_merge_criterion"),

--- a/tests/test_missing_merge_pyspark_fit_sampled_validation.py
+++ b/tests/test_missing_merge_pyspark_fit_sampled_validation.py
@@ -49,9 +49,22 @@ def test_fit_spark_merge_validate_true_builds_minimal_reports(spark_session, mon
 
     assert binner.fit_validation_report_ is binner.validation_report_
     assert binner.fit_validation_report_["validation_type"] == "fit"
+    assert binner.fit_validation_report_["backend"] == "pyspark"
+    assert binner.fit_validation_report_["fit_mode"] == "sampled_to_pandas"
+    assert binner.fit_validation_report_["sampling_applied"] is True
+    assert binner.fit_validation_report_["sample_size_requested"] == len(rows)
+    assert binner.fit_validation_report_["sample_fraction_effective"] == 1.0
     assert binner.fit_validation_report_["summary"]["n_rows_source"] == len(rows)
     assert binner.fit_validation_report_["summary"]["n_rows_fit"] == len(rows)
     assert binner.fit_validation_report_["summary"]["source_profile_status"] == "computed"
+    assert binner.fit_validation_report_["summary"]["sample_representativeness_status"] in {
+        "ok",
+        "warning",
+        "critical",
+    }
+    assert binner.fit_validation_report_["missing_sampling_diagnostics"]
+    assert binner.fit_validation_report_["merge_decision_summary"]["merge_decision_count"] >= 1
+    assert binner.fit_validation_report_["merge_decision_summary"]["fit_mode"] == "sampled_to_pandas"
     assert binner.source_profile_ is not None
     assert not binner.source_profile_.empty
     assert binner.reference_profile_ is not None

--- a/tests/test_missing_merge_pyspark_g3_audit_report.py
+++ b/tests/test_missing_merge_pyspark_g3_audit_report.py
@@ -1,0 +1,83 @@
+import pytest
+
+from riskbands import RiskBands
+from riskbands.audit_report import build_audit_report_context
+
+pytestmark = pytest.mark.spark
+pytest_plugins = ["tests.test_missing_values_pyspark_current_behavior"]
+
+
+def _numeric_spark_frame(spark_session, rows):
+    from pyspark.sql import types as T
+
+    schema = T.StructType(
+        [
+            T.StructField("score", T.DoubleType(), True),
+            T.StructField("target", T.IntegerType(), True),
+        ]
+    )
+    return spark_session.createDataFrame(rows, schema=schema)
+
+
+def _rows(n_rows=160):
+    rows = []
+    for idx in range(n_rows):
+        if idx % 10 == 0:
+            score = None
+        elif idx % 10 == 1:
+            score = float("nan")
+        else:
+            score = float((idx % 12) - 6)
+        rows.append((score, int(score is None or (score == score and score >= 1.0))))
+    return rows
+
+
+def test_audit_report_context_exposes_missing_sampling_diagnostics(spark_session):
+    rows = _rows()
+    binner = RiskBands(
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        sample_size=len(rows),
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    ).fit(_numeric_spark_frame(spark_session, rows), y="target", column="score", validate=True)
+
+    context = build_audit_report_context(binner)
+
+    assert context["missing_sampling_diagnostics"][0]["variable"] == "score"
+    assert context["validation"]["missing_sampling_diagnostics"][0]["variable"] == "score"
+    assert any("Fit sampled-to-pandas" in item for item in context["limitations"])
+    assert any("Merge decision learned on sample" in item for item in context["limitations"])
+
+
+def test_audit_report_does_not_claim_merge_learned_when_sample_missed_source_missing(
+    spark_session, monkeypatch, tmp_path
+):
+    def sample_without_missing(self, spark_df, *, population_size):
+        from pyspark.sql import functions as F
+
+        plan = self._resolve_sampling_plan(population_size=population_size)
+        sample = spark_df.filter(F.col("score").isNotNull() & ~F.isnan(F.col("score"))).limit(60)
+        plan["sample_size_effective"] = 60
+        plan["sample_fraction_effective"] = 60 / population_size
+        return sample, plan
+
+    monkeypatch.setattr(RiskBands, "_sample_pyspark_dataframe", sample_without_missing)
+    binner = RiskBands(
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        sample_size=60,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        missing_merge_fallback="separate_bin",
+    ).fit(_numeric_spark_frame(spark_session, _rows()), y="target", column="score", validate=True)
+
+    report_path = tmp_path / "custom_g3_audit.html"
+    binner.export_audit_report(report_path, title="Custom G3 Audit")
+    html = report_path.read_text(encoding="utf-8")
+
+    assert report_path.name == "custom_g3_audit.html"
+    assert "Custom G3 Audit" in html
+    assert "No merge decision learned on sample" in html
+    assert "Source missing not seen in sample" in html
+    assert "Merge decision learned on sample:" not in html

--- a/tests/test_missing_merge_pyspark_g3_bundle_reporting.py
+++ b/tests/test_missing_merge_pyspark_g3_bundle_reporting.py
@@ -1,0 +1,77 @@
+import json
+
+import pytest
+
+from riskbands import RiskBands
+from riskbands.reporting import load_bundle
+
+pytestmark = pytest.mark.spark
+pytest_plugins = ["tests.test_missing_values_pyspark_current_behavior"]
+
+
+def _numeric_spark_frame(spark_session, rows):
+    from pyspark.sql import types as T
+
+    schema = T.StructType(
+        [
+            T.StructField("score", T.DoubleType(), True),
+            T.StructField("target", T.IntegerType(), True),
+        ]
+    )
+    return spark_session.createDataFrame(rows, schema=schema)
+
+
+def _rows(n_rows=160):
+    rows = []
+    for idx in range(n_rows):
+        if idx % 10 == 0:
+            score = None
+        elif idx % 10 == 1:
+            score = float("nan")
+        else:
+            score = float((idx % 12) - 6)
+        rows.append((score, int(score is None or (score == score and score >= 1.0))))
+    return rows
+
+
+def test_bundle_preserves_sample_source_metadata_and_missing_diagnostics(spark_session, tmp_path):
+    rows = _rows()
+    binner = RiskBands(
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        sample_size=len(rows),
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    ).fit(_numeric_spark_frame(spark_session, rows), y="target", column="score", validate=True)
+
+    bundle_dir = tmp_path / "bundle"
+    binner.export_bundle(bundle_dir)
+    manifest = json.loads((bundle_dir / "metadata.json").read_text(encoding="utf-8"))
+    loaded = load_bundle(bundle_dir)
+
+    assert manifest["metadata"]["sampling_metadata"]["fit_mode"] == "sampled_to_pandas"
+    assert manifest["metadata"]["source_missing_counts"]["score"] > 0
+    assert manifest["metadata"]["missing_sampling_diagnostics"][0]["variable"] == "score"
+    assert manifest["missing_sampling_diagnostics"][0]["variable"] == "score"
+    assert loaded["missing_sampling_diagnostics"][0]["variable"] == "score"
+    assert loaded["fit_validation_report"]["missing_sampling_diagnostics"][0]["variable"] == "score"
+
+
+def test_bundle_report_html_contains_sampling_caveats_for_learned_merge(spark_session, tmp_path):
+    rows = _rows()
+    binner = RiskBands(
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        sample_size=len(rows),
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    ).fit(_numeric_spark_frame(spark_session, rows), y="target", column="score", validate=True)
+
+    bundle_dir = tmp_path / "bundle"
+    binner.export_bundle(bundle_dir)
+    html = (bundle_dir / "audit_report.html").read_text(encoding="utf-8")
+
+    assert "sampled-to-pandas" in html
+    assert "Fit sampled-to-pandas" in html
+    assert "Merge decision learned on sample" in html
+    assert "Missing sampling diagnostics" in html

--- a/tests/test_missing_merge_pyspark_g3_missing_sampling_diagnostics.py
+++ b/tests/test_missing_merge_pyspark_g3_missing_sampling_diagnostics.py
@@ -1,0 +1,139 @@
+import json
+
+import pytest
+
+from riskbands import RiskBands
+from riskbands.reporting import load_bundle
+
+pytestmark = pytest.mark.spark
+pytest_plugins = ["tests.test_missing_values_pyspark_current_behavior"]
+
+
+def _numeric_spark_frame(spark_session, rows):
+    from pyspark.sql import types as T
+
+    schema = T.StructType(
+        [
+            T.StructField("score", T.DoubleType(), True),
+            T.StructField("target", T.IntegerType(), True),
+        ]
+    )
+    return spark_session.createDataFrame(rows, schema=schema)
+
+
+def _rows_with_missing(n_rows=180):
+    rows = []
+    for idx in range(n_rows):
+        if idx % 10 == 0:
+            score = None
+        elif idx % 10 == 1:
+            score = float("nan")
+        else:
+            score = float((idx % 12) - 6)
+        target = int(score is None or (score == score and score >= 1.0))
+        rows.append((score, target))
+    return rows
+
+
+def _rows_without_missing(n_rows=120):
+    rows = []
+    for idx in range(n_rows):
+        score = float((idx % 12) - 6)
+        rows.append((score, int(score >= 1.0)))
+    return rows
+
+
+def _diagnostic_for_score(binner):
+    diagnostics = binner.fit_validation_report_["missing_sampling_diagnostics"]
+    return next(row for row in diagnostics if row["variable"] == "score")
+
+
+def test_missing_sampling_diagnostics_when_missing_is_in_sample_and_source(spark_session):
+    rows = _rows_with_missing()
+    binner = RiskBands(
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        sample_size=len(rows),
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    ).fit(_numeric_spark_frame(spark_session, rows), y="target", column="score", validate=True)
+
+    diagnostic = _diagnostic_for_score(binner)
+    assert diagnostic["missing_count_sample_fit"] == diagnostic["missing_count_source_spark"]
+    assert diagnostic["missing_share_abs_diff"] == pytest.approx(0.0)
+    assert diagnostic["merge_decision_learned_on_sample"] is True
+    assert diagnostic["missing_merge_destination_learned"] is not None
+    assert diagnostic["fallback_risk"] is False
+    assert diagnostic["status"] == "ok"
+
+
+def test_missing_sampling_diagnostics_warns_when_source_missing_is_not_sampled(
+    spark_session, monkeypatch
+):
+    def sample_without_missing(self, spark_df, *, population_size):
+        from pyspark.sql import functions as F
+
+        plan = self._resolve_sampling_plan(population_size=population_size)
+        sample = spark_df.filter(F.col("score").isNotNull() & ~F.isnan(F.col("score"))).limit(60)
+        plan["sample_size_effective"] = 60
+        plan["sample_fraction_effective"] = 60 / population_size
+        return sample, plan
+
+    monkeypatch.setattr(RiskBands, "_sample_pyspark_dataframe", sample_without_missing)
+    binner = RiskBands(
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        sample_size=60,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        missing_merge_fallback="separate_bin",
+    ).fit(_numeric_spark_frame(spark_session, _rows_with_missing()), y="target", column="score", validate=True)
+
+    diagnostic = _diagnostic_for_score(binner)
+    assert diagnostic["missing_count_sample_fit"] == 0
+    assert diagnostic["missing_count_source_spark"] > 0
+    assert diagnostic["merge_decision_learned_on_sample"] is False
+    assert diagnostic["fallback_risk"] is True
+    assert diagnostic["status"] == "warning"
+    assert "source_missing_not_seen_in_sample" in diagnostic["alert_flags"]
+    assert "merge_decision_not_learned_but_source_has_missing" in diagnostic["alert_flags"]
+    assert binner.fit_validation_report_["summary"]["missing_sampling_status"] == "warning"
+    assert binner.metadata_["missing_sampling_diagnostics"][0]["variable"] == "score"
+
+
+def test_missing_sampling_diagnostics_when_source_has_no_missing(spark_session):
+    rows = _rows_without_missing()
+    binner = RiskBands(
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        sample_size=len(rows),
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    ).fit(_numeric_spark_frame(spark_session, rows), y="target", column="score", validate=True)
+
+    diagnostic = _diagnostic_for_score(binner)
+    assert diagnostic["missing_count_sample_fit"] == 0
+    assert diagnostic["missing_count_source_spark"] == 0
+    assert diagnostic["merge_decision_learned_on_sample"] is False
+    assert diagnostic["fallback_risk"] is False
+    assert diagnostic["status"] == "ok"
+
+
+def test_missing_sampling_diagnostics_are_exported_in_bundle(spark_session, tmp_path):
+    rows = _rows_with_missing()
+    binner = RiskBands(
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        sample_size=len(rows),
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    ).fit(_numeric_spark_frame(spark_session, rows), y="target", column="score", validate=True)
+
+    bundle_dir = tmp_path / "bundle"
+    binner.export_bundle(bundle_dir)
+    manifest = json.loads((bundle_dir / "metadata.json").read_text(encoding="utf-8"))
+    loaded = load_bundle(bundle_dir)
+
+    assert manifest["metadata"]["missing_sampling_diagnostics"][0]["variable"] == "score"
+    assert manifest["missing_sampling_diagnostics"][0]["variable"] == "score"
+    assert loaded["missing_sampling_diagnostics"][0]["variable"] == "score"

--- a/tests/test_missing_merge_pyspark_g3_source_profile.py
+++ b/tests/test_missing_merge_pyspark_g3_source_profile.py
@@ -1,0 +1,109 @@
+import pytest
+
+from riskbands import RiskBands
+from tests.test_missing_values_pyspark_current_behavior import install_to_pandas_guard
+
+pytestmark = pytest.mark.spark
+pytest_plugins = ["tests.test_missing_values_pyspark_current_behavior"]
+
+
+def _numeric_spark_frame(spark_session, rows):
+    from pyspark.sql import types as T
+
+    schema = T.StructType(
+        [
+            T.StructField("score", T.DoubleType(), True),
+            T.StructField("target", T.IntegerType(), True),
+        ]
+    )
+    return spark_session.createDataFrame(rows, schema=schema)
+
+
+def _rows_with_missing(n_rows=240):
+    rows = []
+    for idx in range(n_rows):
+        if idx % 12 == 0:
+            score = None
+        elif idx % 12 == 1:
+            score = float("nan")
+        else:
+            score = float((idx % 10) - 5)
+        target = int(score is None or (score == score and score >= 1.0))
+        rows.append((score, target))
+    return rows
+
+
+def test_source_profile_uses_final_bins_and_sample_representativeness(spark_session, monkeypatch):
+    rows = _rows_with_missing()
+    calls = install_to_pandas_guard(monkeypatch, max_rows=len(rows))
+
+    binner = RiskBands(
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        sample_size=len(rows),
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    ).fit(_numeric_spark_frame(spark_session, rows), y="target", column="score", validate=True)
+
+    assert binner.source_profile_ is not None
+    assert not binner.source_profile_.empty
+    assert not binner.source_profile_["is_missing_bin"].fillna(False).any()
+    assert binner.reference_profile_source_ == "source_profile"
+    assert binner.fit_validation_report_["sample_representativeness"]["status"] in {"ok", "warning"}
+    assert binner.fit_validation_report_["sample_representativeness"]["bin_diagnostics"]
+    assert calls
+    assert max(call["rows"] for call in calls) <= len(rows)
+
+
+def test_sample_vs_source_reports_missing_bins_and_status_warning(spark_session, monkeypatch):
+    rows = _rows_with_missing()
+
+    def sample_without_missing(self, spark_df, *, population_size):
+        from pyspark.sql import functions as F
+
+        plan = self._resolve_sampling_plan(population_size=population_size)
+        sample = spark_df.filter(F.col("score").isNotNull() & ~F.isnan(F.col("score"))).limit(80)
+        plan["sample_size_effective"] = 80
+        plan["sample_fraction_effective"] = 80 / population_size
+        return sample, plan
+
+    monkeypatch.setattr(RiskBands, "_sample_pyspark_dataframe", sample_without_missing)
+    binner = RiskBands(
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        sample_size=80,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        missing_merge_fallback="separate_bin",
+    ).fit(_numeric_spark_frame(spark_session, rows), y="target", column="score", validate=True)
+
+    report = binner.fit_validation_report_
+    assert report["sample_representativeness"]["status"] == "warning"
+    assert report["sample_representativeness"]["bins_missing_in_sample"]
+    assert any(
+        "source_missing_not_seen_in_sample" in row["alert_flags"]
+        for row in report["missing_sampling_diagnostics"]
+    )
+
+
+def test_source_profile_guard_records_profile_too_large(spark_session, monkeypatch):
+    original_settings = RiskBands._default_validation_settings
+
+    def tiny_profile_limit(self):
+        settings = original_settings(self)
+        settings["max_profile_rows_to_collect"] = 0
+        return settings
+
+    monkeypatch.setattr(RiskBands, "_default_validation_settings", tiny_profile_limit)
+    binner = RiskBands(
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        sample_size=60,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    ).fit(_numeric_spark_frame(spark_session, _rows_with_missing(120)), y="target", column="score", validate=True)
+
+    report = binner.fit_validation_report_
+    assert binner.source_profile_ is None
+    assert report["summary"]["source_profile_status"] == "skipped_profile_too_large"
+    assert any("profile_too_large" in alert["alert_flags"] for alert in report["alerts"])

--- a/tests/test_missing_merge_pyspark_g3_static_guards.py
+++ b/tests/test_missing_merge_pyspark_g3_static_guards.py
@@ -1,0 +1,70 @@
+import inspect
+
+from riskbands.binning_engine import Binner
+
+
+def test_source_profile_uses_guarded_aggregate_collection_only():
+    source = inspect.getsource(Binner._build_bin_profile_pyspark)
+
+    assert ".groupBy(" in source
+    assert "_collect_pyspark_profile_aggregate(" in source
+    assert ".toPandas(" not in source
+    assert ".collect(" not in source
+
+
+def test_profile_aggregate_helper_checks_row_guard_before_to_pandas():
+    source = inspect.getsource(Binner._collect_pyspark_profile_aggregate)
+
+    assert "limit(remaining_rows + 1).count()" in source
+    assert "profile_sdf.toPandas()" in source
+    assert source.index("limit(remaining_rows + 1).count()") < source.index("profile_sdf.toPandas()")
+    assert ".collect(" not in source
+
+
+def test_spark_fit_to_pandas_is_confined_to_sampled_fit_boundary():
+    source = inspect.getsource(Binner._fit_pyspark)
+
+    assert "sampled_spark.toPandas()" in source
+    assert "selected_spark.limit(1).toPandas()" in source
+    assert "X.toPandas(" not in source
+    assert "selected_spark.toPandas(" not in source
+    assert ".collect(" not in source
+
+
+def test_transform_validation_path_has_no_full_collect_or_udf():
+    methods = [
+        "_validate_transform_pyspark",
+        "_build_transform_validation_report",
+        "_transform_pyspark",
+        "_spark_transform_expression",
+        "_numeric_supervised_spark_expression",
+        "_numeric_unsupervised_spark_expression",
+        "_categorical_spark_expression",
+    ]
+
+    for method_name in methods:
+        source = inspect.getsource(getattr(Binner, method_name))
+        assert ".toPandas(" not in source
+        assert ".collect(" not in source
+        assert "udf(" not in source
+        assert "pandas_udf" not in source
+        assert "UserDefinedFunction" not in source
+
+
+def test_collect_and_to_pandas_remain_limited_to_named_helpers_or_sampling():
+    allowed_to_pandas = {
+        "_fit_pyspark",
+        "_collect_pyspark_profile_aggregate",
+    }
+    allowed_collect = {
+        "_pyspark_missing_counts",
+    }
+    violations = []
+    for method_name, method in inspect.getmembers(Binner, predicate=inspect.isfunction):
+        source = inspect.getsource(method)
+        if ".toPandas(" in source and method_name not in allowed_to_pandas:
+            violations.append((method_name, ".toPandas("))
+        if ".collect(" in source and method_name not in allowed_collect:
+            violations.append((method_name, ".collect("))
+
+    assert violations == []

--- a/tests/test_missing_merge_pyspark_g3_transform_validation.py
+++ b/tests/test_missing_merge_pyspark_g3_transform_validation.py
@@ -1,0 +1,139 @@
+from collections import Counter
+
+import pytest
+
+from riskbands import RiskBands
+
+pytestmark = pytest.mark.spark
+pytest_plugins = ["tests.test_missing_values_pyspark_current_behavior"]
+
+
+def _numeric_spark_frame(spark_session, rows, *, include_target=True):
+    from pyspark.sql import types as T
+
+    fields = [T.StructField("score", T.DoubleType(), True)]
+    if include_target:
+        fields.append(T.StructField("target", T.IntegerType(), True))
+    return spark_session.createDataFrame(rows, schema=T.StructType(fields))
+
+
+def _fit_rows(n_rows=180):
+    rows = []
+    for idx in range(n_rows):
+        if idx % 10 == 0:
+            score = None
+        elif idx % 10 == 1:
+            score = float("nan")
+        else:
+            score = float((idx % 12) - 6)
+        rows.append((score, int(score is None or (score == score and score >= 1.0))))
+    return rows
+
+
+def test_transform_validate_true_builds_application_profile_and_final_merge_bins(spark_session):
+    fit_rows = _fit_rows()
+    binner = RiskBands(
+        max_bins=5,
+        min_n_bins=3,
+        min_event_rate_diff=0.0,
+        sample_size=len(fit_rows),
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    ).fit(_numeric_spark_frame(spark_session, fit_rows), y="target", column="score", validate=True)
+    learned_label = binner.missing_merge_map_["score"]
+
+    app_rows = [(None, 1), (float("nan"), 0), (4.0, 1), (-5.0, 0), (3.0, 1), (-4.0, 0)]
+    transformed = binner.transform(
+        _numeric_spark_frame(spark_session, app_rows),
+        column="score",
+        validate=True,
+    )
+    observed = Counter(row["score"] for row in transformed.select("score").collect())
+    report = binner.transform_validation_report_
+
+    assert observed[learned_label] >= 2
+    assert binner.application_profile_ is not None
+    assert not binner.application_profile_["is_missing_bin"].fillna(False).any()
+    assert binner.missing_merge_map_ == {"score": learned_label}
+    assert report is binner.validation_report_
+    assert report["backend"] == "pyspark"
+    assert report["status"] in {"ok", "warning", "critical"}
+    assert report["summary"]["target_available"] is True
+    assert report["summary"]["n_application_rows"] == len(app_rows)
+    assert report["profile_comparison"]
+
+
+def test_transform_validate_true_without_target_is_skipped_clear(spark_session):
+    fit_rows = _fit_rows()
+    binner = RiskBands(
+        max_bins=4,
+        min_n_bins=3,
+        min_event_rate_diff=0.0,
+        sample_size=len(fit_rows),
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    ).fit(_numeric_spark_frame(spark_session, fit_rows), y="target", column="score", validate=True)
+
+    binner.transform(
+        _numeric_spark_frame(spark_session, [(1.0,), (None,)], include_target=False),
+        column="score",
+        validate=True,
+    )
+
+    report = binner.transform_validation_report_
+    assert binner.application_profile_ is None
+    assert report["status"] == "skipped"
+    assert report["reason"] == "target_not_available"
+    assert report["summary"]["target_available"] is False
+
+
+def test_transform_validation_warns_on_application_share_shift(spark_session):
+    fit_rows = _fit_rows()
+    binner = RiskBands(
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        sample_size=len(fit_rows),
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+    ).fit(_numeric_spark_frame(spark_session, fit_rows), y="target", column="score", validate=True)
+    binner.reference_profile_ = binner.reference_profile_.copy()
+    binner.reference_profile_["share"] = 0.2
+
+    app_rows = [(5.0, 1) for _ in range(80)]
+    binner.transform(_numeric_spark_frame(spark_session, app_rows), column="score", validate=True)
+    report = binner.transform_validation_report_
+
+    assert report["status"] in {"warning", "critical"}
+    assert any("application_share_shift" in alert["alert_flags"] for alert in report["alerts"])
+
+
+def test_transform_validation_does_not_learn_missing_merge_when_fit_sample_had_no_missing(
+    spark_session, monkeypatch
+):
+    def sample_without_missing(self, spark_df, *, population_size):
+        from pyspark.sql import functions as F
+
+        plan = self._resolve_sampling_plan(population_size=population_size)
+        sample = spark_df.filter(F.col("score").isNotNull() & ~F.isnan(F.col("score"))).limit(60)
+        plan["sample_size_effective"] = 60
+        plan["sample_fraction_effective"] = 60 / population_size
+        return sample, plan
+
+    monkeypatch.setattr(RiskBands, "_sample_pyspark_dataframe", sample_without_missing)
+    binner = RiskBands(
+        max_bins=4,
+        min_event_rate_diff=0.0,
+        sample_size=60,
+        missing_policy="merge",
+        missing_merge_criterion="nearest_event_rate",
+        missing_merge_fallback="separate_bin",
+    ).fit(_numeric_spark_frame(spark_session, _fit_rows()), y="target", column="score", validate=True)
+
+    binner.transform(
+        _numeric_spark_frame(spark_session, [(None, 1), (float("nan"), 0), (2.0, 1)]),
+        column="score",
+        validate=True,
+    )
+
+    assert binner.missing_merge_map_ == {}
+    assert binner.application_profile_["is_missing_bin"].fillna(False).any()


### PR DESCRIPTION
Adds validation, source profile, sample-vs-source diagnostics, missing sampling diagnostics, bundle/reporting metadata, audit report caveats, and static guards for the PySpark sampled-to-pandas missing merge flow. This does not implement Spark-native full fit, Spark return_woe=True, new merge criteria, or a version bump.