### PR TITLE
Publish RiskBands presentation in docs site

### DIFF
--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -62,7 +62,10 @@ jobs:
             --cov-report=term-missing
 
       - name: Audit Python dependencies
-        run: python -m pip_audit
+        run: |
+          # PYSEC-2024-277 / CVE-2024-34997 is a disputed joblib
+          # deserialization advisory with no fixed version published.
+          python -m pip_audit --ignore-vuln PYSEC-2024-277
 
       - name: Build sdist and wheel
         run: python -m build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,4 +52,7 @@ jobs:
             --cov-report=xml
 
       - name: Audit Python dependencies
-        run: python -m pip_audit
+        run: |
+          # PYSEC-2024-277 / CVE-2024-34997 is a disputed joblib
+          # deserialization advisory with no fixed version published.
+          python -m pip_audit --ignore-vuln PYSEC-2024-277

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -189,6 +189,11 @@ export default defineConfig({
           label: 'Projeto',
           translations: { en: 'Project' },
           items: [
+            {
+              label: 'Apresentações',
+              translations: { en: 'Presentations' },
+              slug: 'presentations',
+            },
             { label: 'Release Notes', slug: 'reference/release-notes' },
             {
               label: 'Evolução após v1.0.0',

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@astrojs/starlight": "^0.38.3",
-        "astro": "^6.0.0"
+        "astro": "^6.0.0",
+        "reveal.js": "^6.0.1"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.4",
@@ -6008,6 +6009,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/reveal.js": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/reveal.js/-/reveal.js-6.0.1.tgz",
+      "integrity": "sha512-9eacArNIgqO2HGWOK+93gJNn+gvdGDVbSq+i2u3Ja9kjiHps0XNLpgYTZTYjKRH91uXy3clGimeGiw4umHG/tg==",
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.60.1",

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "@astrojs/starlight": "^0.38.3",
-    "astro": "^6.0.0"
+    "astro": "^6.0.0",
+    "reveal.js": "^6.0.1"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.4",

--- a/docs-site/src/content/docs/en/presentations.md
+++ b/docs-site/src/content/docs/en/presentations.md
@@ -1,0 +1,11 @@
+---
+title: "Presentations"
+description: "Interactive RiskBands presentations for technical review, model risk, and methodology communication."
+---
+
+## RiskBands Overview
+
+Interactive Reveal.js deck about auditable binning for credit risk, PD models,
+scorecards, missing policy, and evidence for technical review.
+
+[Open RiskBands Overview](../../presentations/riskbands-overview/)

--- a/docs-site/src/content/docs/presentations.md
+++ b/docs-site/src/content/docs/presentations.md
@@ -1,0 +1,11 @@
+---
+title: "Apresentações"
+description: "Galeria de apresentações interativas do RiskBands para revisão técnica, model risk e comunicação metodológica."
+---
+
+## RiskBands Overview
+
+Deck interativo em Reveal.js sobre binning auditável para risco de crédito,
+modelos de PD, scorecards, missing policy e evidência para revisão técnica.
+
+[Abrir RiskBands Overview](./riskbands-overview/)

--- a/docs-site/src/pages/presentations/riskbands-overview.astro
+++ b/docs-site/src/pages/presentations/riskbands-overview.astro
@@ -1,0 +1,648 @@
+---
+import "reveal.js/reveal.css";
+import "reveal.js/theme/black.css";
+import "reveal.js/plugin/highlight/monokai.css";
+import "../../styles/riskbands-reveal.css";
+
+const title = "RiskBands Overview - Binning auditavel para risco de credito";
+const description =
+  "Apresentacao interativa do RiskBands sobre binning auditavel para modelos de PD, scorecards e model risk.";
+const basePath = import.meta.env.BASE_URL;
+const withBase = (path: string) => `${basePath}${path.replace(/^\/+/, "")}`;
+const logoSrc = withBase("/brand/riskbands_horizontal_monochrome.svg");
+const docsHref = basePath;
+const repoHref = "https://github.com/joaaomaia/RiskBands";
+---
+
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{title}</title>
+    <meta name="description" content={description} />
+  </head>
+  <body class="rb-deck-page">
+    <nav class="rb-deck-actions" aria-label="Acoes da apresentacao">
+      <a class="rb-docs-link" href={docsHref}>Docs</a>
+      <a class="rb-docs-link" href={repoHref}>GitHub</a>
+      <button class="rb-fullscreen" type="button" data-fullscreen>Fullscreen</button>
+    </nav>
+
+    <div class="reveal rb-reveal">
+      <div class="slides">
+        <section
+          class="rb-slide rb-title-slide"
+          data-background-gradient="linear-gradient(135deg, #06101d, #0d2238)"
+        >
+          <div class="rb-brand-row">
+            <img src={logoSrc} alt="RiskBands" class="rb-logo" />
+          </div>
+          <p class="rb-eyebrow">Credit Risk / PD Models / Scorecards</p>
+          <h1>RiskBands</h1>
+          <p class="rb-subtitle">Binning auditável para risco de crédito</p>
+          <div class="rb-pipeline" aria-label="Dados para binning para evidência">
+            <span class="rb-pipeline-pill">
+              <span class="rb-icon rb-icon-data" aria-hidden="true"></span>
+              Dados
+            </span>
+            <span class="rb-pipeline-pill">
+              <span class="rb-icon rb-icon-bins" aria-hidden="true"></span>
+              Binning
+            </span>
+            <span class="rb-pipeline-pill">
+              <span class="rb-icon rb-icon-evidence" aria-hidden="true"></span>
+              Evidência
+            </span>
+          </div>
+          <p class="rb-callout fragment">
+            Do binning manual à decisão comparável, rastreável e defensável.
+          </p>
+          <aside class="notes">
+            Em risco de crédito, binning raramente é só uma transformação de variável. Ele vira
+            parte da lógica do modelo, influencia WoE, scorecard, explicabilidade, validação e
+            governança. O RiskBands nasce para tratar essa etapa com o mesmo rigor esperado do
+            restante do ciclo de modelagem.
+          </aside>
+        </section>
+
+        <section class="rb-slide rb-pain-slide">
+          <p class="rb-eyebrow">A dor operacional</p>
+          <h2>Binning em risco de crédito costuma ser mais manual do que deveria</h2>
+          <div class="rb-pain-layout">
+            <div class="rb-pain-stack" role="list" aria-label="Dores operacionais">
+              <article class="rb-pain-card fragment" role="listitem">
+                <span class="rb-icon rb-icon-table" aria-hidden="true"></span>
+                <strong>Planilhas</strong>
+                <span>Cortes discutidos fora do fluxo auditável.</span>
+              </article>
+              <article class="rb-pain-card fragment" role="listitem">
+                <span class="rb-icon rb-icon-chart" aria-hidden="true"></span>
+                <strong>IV instável</strong>
+                <span>Ótimo no treino, frágil fora da amostra.</span>
+              </article>
+              <article class="rb-pain-card fragment" role="listitem">
+                <span class="rb-icon rb-icon-clock" aria-hidden="true"></span>
+                <strong>Safras invertendo</strong>
+                <span>Event rate muda a leitura dos cortes.</span>
+              </article>
+              <article class="rb-pain-card fragment" role="listitem">
+                <span class="rb-icon rb-icon-missing" aria-hidden="true"></span>
+                <strong>Missing improvisado</strong>
+                <span>Ausentes tratados como detalhe operacional.</span>
+              </article>
+              <article class="rb-pain-card fragment" role="listitem">
+                <span class="rb-icon rb-icon-evidence" aria-hidden="true"></span>
+                <strong>Pouca evidência</strong>
+                <span>Rastro insuficiente para auditoria.</span>
+              </article>
+            </div>
+            <div class="rb-mini-table rb-pain-table" aria-hidden="true">
+              <div class="rb-table-caption">
+                <span class="rb-icon rb-icon-spreadsheet" aria-hidden="true"></span>
+                Mock de comparação por bin
+              </div>
+              <table>
+                <thead>
+                  <tr><th>Bin</th><th>Cut</th><th>Train ER</th><th>OOT ER</th><th>WoE</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td>1</td><td>&lt; 420</td><td>18.4%</td><td>22.1%</td><td>-0.62</td></tr>
+                  <tr><td>2</td><td>420-560</td><td>11.2%</td><td>14.9%</td><td>-0.18</td></tr>
+                  <tr><td>3</td><td>560-690</td><td>7.1%</td><td>9.8%</td><td>0.32</td></tr>
+                  <tr><td>4</td><td>&gt; 690</td><td>4.9%</td><td>12.6%</td><td>0.71</td></tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+          <aside class="notes">
+            Quem já trabalhou com scorecard conhece essa cena: uma variável parece ótima no
+            treino, o IV é alto, mas quando olhamos safras futuras a história muda. O corte que
+            parecia bom deixa de ser intuitivo, o event rate se comporta mal, e a decisão acaba
+            virando uma mistura de planilha, memória e discussão.
+          </aside>
+        </section>
+
+        <section class="rb-slide">
+          <p class="rb-eyebrow">Separação não basta</p>
+          <h2>IV alto não garante robustez temporal</h2>
+          <div class="rb-signal-chip fragment">
+            <span class="rb-icon rb-icon-chart" aria-hidden="true"></span>
+            IV alto != robustez temporal
+          </div>
+          <div class="rb-grid-2">
+            <article class="rb-card rb-chart-card">
+              <div class="rb-card-heading">
+                <span class="rb-icon rb-icon-target" aria-hidden="true"></span>
+                <h3>Treino</h3>
+                <span class="rb-badge">Train</span>
+              </div>
+              <svg class="rb-line-chart" viewBox="0 0 320 180" role="img" aria-label="Event rate monotônico no treino">
+                <path class="rb-gridline" d="M28 30H300 M28 75H300 M28 120H300 M28 165H300" />
+                <path class="rb-chart-line rb-chart-line-good" d="M42 142 L100 118 L158 92 L216 62 L276 36" />
+                <circle cx="42" cy="142" r="5" /><circle cx="100" cy="118" r="5" />
+                <circle cx="158" cy="92" r="5" /><circle cx="216" cy="62" r="5" />
+                <circle cx="276" cy="36" r="5" />
+              </svg>
+              <p>Event rate aparentemente ordenado.</p>
+            </article>
+            <article class="rb-card rb-chart-card fragment">
+              <div class="rb-card-heading">
+                <span class="rb-icon rb-icon-clock" aria-hidden="true"></span>
+                <h3>Out-of-time</h3>
+                <span class="rb-badge rb-badge-warning">OOT</span>
+              </div>
+              <svg class="rb-line-chart" viewBox="0 0 320 180" role="img" aria-label="Event rate oscilando no OOT">
+                <path class="rb-gridline" d="M28 30H300 M28 75H300 M28 120H300 M28 165H300" />
+                <path class="rb-chart-line rb-chart-line-warn" d="M42 96 L100 128 L158 74 L216 138 L276 58" />
+                <circle cx="42" cy="96" r="5" /><circle cx="100" cy="128" r="5" />
+                <circle cx="158" cy="74" r="5" /><circle cx="216" cy="138" r="5" />
+                <circle cx="276" cy="58" r="5" />
+              </svg>
+              <p>Oscilação entre safras muda a interpretação.</p>
+            </article>
+          </div>
+          <p class="rb-callout fragment">
+            Separação no treino é útil, mas não é evidência suficiente para confiar nos cortes.
+          </p>
+          <aside class="notes">
+            IV é útil, mas não conta a história inteira. Em crédito, a pergunta não é apenas se a
+            variável separou bem agora. A pergunta é se essa decisão continua razoável quando
+            olhamos safras, períodos, out-of-time e validação.
+          </aside>
+        </section>
+
+        <section class="rb-slide">
+          <p class="rb-eyebrow">Proposta</p>
+          <h2>Do corte “bom” para a decisão de binning auditável</h2>
+          <div class="rb-flow">
+            <div class="rb-flow-step fragment">
+              <span class="rb-icon rb-icon-bins" aria-hidden="true"></span>
+              <strong>Candidate bins</strong>
+            </div>
+            <div class="rb-flow-step fragment">
+              <span class="rb-icon rb-icon-metrics" aria-hidden="true"></span>
+              <strong>Metrics</strong>
+            </div>
+            <div class="rb-flow-step fragment">
+              <span class="rb-icon rb-icon-clock" aria-hidden="true"></span>
+              <strong>Temporal checks</strong>
+            </div>
+            <div class="rb-flow-step fragment">
+              <span class="rb-icon rb-icon-missing" aria-hidden="true"></span>
+              <strong>Missing policy</strong>
+            </div>
+            <div class="rb-flow-step fragment">
+              <span class="rb-icon rb-icon-package" aria-hidden="true"></span>
+              <strong>Audit bundle</strong>
+            </div>
+          </div>
+          <p class="rb-callout fragment">
+            Comparar alternativas com critérios explícitos, não substituir julgamento técnico.
+          </p>
+          <aside class="notes">
+            O ponto do RiskBands não é tirar o julgamento técnico da mesa. É melhorar a qualidade
+            da conversa. Em vez de discutir cortes apenas por intuição ou por uma métrica isolada,
+            a ideia é comparar alternativas com métricas, logs, evidências e limitações explícitas.
+          </aside>
+        </section>
+
+        <section class="rb-slide rb-tradeoff-slide">
+          <p class="rb-eyebrow">Stable scoring</p>
+          <h2>Stable scoring: separação versus estabilidade</h2>
+          <div class="rb-grid-2 rb-tradeoff-grid">
+            <article class="rb-card rb-large-card fragment">
+              <div class="rb-card-heading">
+                <span class="rb-icon rb-icon-target" aria-hidden="true"></span>
+                <h3>Maximizar IV isoladamente</h3>
+              </div>
+              <p>Pode selecionar cortes fortes no treino, mas frágeis no tempo.</p>
+            </article>
+            <article class="rb-card rb-large-card fragment">
+              <div class="rb-card-heading">
+                <span class="rb-icon rb-icon-shield" aria-hidden="true"></span>
+                <h3>Maximizar estabilidade isoladamente</h3>
+              </div>
+              <p>Pode selecionar cortes estáveis, mas pouco úteis para discriminação.</p>
+            </article>
+          </div>
+          <div class="rb-ribbon fragment">
+            <span class="rb-icon rb-icon-evidence" aria-hidden="true"></span>
+            Auditabilidade como critério transversal
+          </div>
+          <div class="rb-axis fragment">
+            <span>Separação</span>
+            <span class="rb-axis-line"></span>
+            <span>Estabilidade</span>
+          </div>
+          <p class="rb-callout fragment">
+            O objetivo é equilibrar separação, estabilidade e auditabilidade.
+          </p>
+          <aside class="notes">
+            Em scorecards e modelos de PD, a decisão prática geralmente mora no equilíbrio. Um
+            binning pode separar bem, mas ser instável. Outro pode ser estável, mas pouco
+            informativo. O RiskBands busca explicitar esse trade-off para que a escolha seja
+            técnica e documentável.
+          </aside>
+        </section>
+
+        <section class="rb-slide rb-missing-slide">
+          <p class="rb-eyebrow">Missing policy</p>
+          <h2>Missing values como decisão metodológica</h2>
+          <div class="rb-missing-map">
+            <div class="rb-missing-node fragment">
+              <span class="rb-icon rb-icon-missing" aria-hidden="true"></span>
+              Missing / NULL
+            </div>
+            <div class="rb-impact-card fragment">
+              <span class="rb-icon rb-icon-target" aria-hidden="true"></span>
+              <strong>Sinal de risco</strong>
+            </div>
+            <div class="rb-impact-card fragment">
+              <span class="rb-icon rb-icon-metrics" aria-hidden="true"></span>
+              <strong>WoE / event rate</strong>
+            </div>
+            <div class="rb-impact-card fragment">
+              <span class="rb-icon rb-icon-clock" aria-hidden="true"></span>
+              <strong>Estabilidade temporal</strong>
+            </div>
+          </div>
+          <p class="rb-callout fragment">
+            Ausência de informação pode ser parte do comportamento observado.
+          </p>
+          <aside class="notes">
+            Em crédito, missing value não é automaticamente ruído. Às vezes a ausência de uma
+            informação é parte do comportamento do cliente, do canal, da originação ou da política
+            operacional. Tratar missing como detalhe técnico pode mascarar risco ou criar
+            inconsistência entre treino e produção.
+          </aside>
+        </section>
+
+        <section class="rb-slide">
+          <p class="rb-eyebrow">Auditabilidade do missing</p>
+          <h2>Merge auditável de missing</h2>
+          <div class="rb-method-chips" aria-label="Métodos de merge">
+            <span><code>nearest_event_rate</code></span>
+            <span><code>nearest_woe</code></span>
+          </div>
+          <div class="rb-grid-2">
+            <article class="rb-card rb-decision-tree fragment">
+              <div class="rb-card-heading">
+                <span class="rb-icon rb-icon-merge" aria-hidden="true"></span>
+                <h3>Missing bin</h3>
+              </div>
+              <ul>
+                <li>Candidate A <span>event rate próximo</span></li>
+                <li>Candidate B <span>WoE próximo</span></li>
+                <li>Decision log <span>critério e limitações</span></li>
+              </ul>
+            </article>
+            <article class="rb-card rb-mini-table fragment">
+              <div class="rb-card-heading">
+                <span class="rb-icon rb-icon-log" aria-hidden="true"></span>
+                <h3>Candidatos avaliados</h3>
+              </div>
+              <table>
+                <thead>
+                  <tr><th>Candidate</th><th>Event rate Δ</th><th>WoE Δ</th><th>Decision</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td>Bin 2</td><td>0.004</td><td>0.08</td><td><code>nearest_event_rate</code></td></tr>
+                  <tr><td>Bin 3</td><td>0.011</td><td>0.03</td><td><code>nearest_woe</code></td></tr>
+                </tbody>
+              </table>
+            </article>
+          </div>
+          <p class="rb-callout fragment">
+            A decisão final deixa rastro: critério, candidatos, escolha e limitações.
+          </p>
+          <aside class="notes">
+            Uma das perguntas mais difíceis é: o que fazemos com missing? Mantém separado? Junta?
+            Junta com quem? O valor aqui não está só no algoritmo de proximidade, mas no fato de
+            que a decisão fica explícita, comparável e registrada.
+          </aside>
+        </section>
+
+        <section class="rb-slide">
+          <p class="rb-eyebrow">Escala operacional</p>
+          <h2>Da análise local à escala de bases reais</h2>
+          <div class="rb-flow rb-flow-wide">
+            <div class="rb-flow-step fragment">
+              <span class="rb-icon rb-icon-spark" aria-hidden="true"></span>
+              <strong>PySpark dataset</strong>
+            </div>
+            <div class="rb-flow-step fragment">
+              <span class="rb-icon rb-icon-analysis" aria-hidden="true"></span>
+              <strong>sampled fit / candidate analysis</strong>
+            </div>
+            <div class="rb-flow-step fragment">
+              <span class="rb-icon rb-icon-package" aria-hidden="true"></span>
+              <strong>binning artifact</strong>
+            </div>
+            <div class="rb-flow-step fragment">
+              <span class="rb-icon rb-icon-report" aria-hidden="true"></span>
+              <strong>transform / report</strong>
+            </div>
+          </div>
+          <p class="rb-warning fragment">
+            Sampling caveat: documentar representatividade antes de confiar no resultado.
+          </p>
+          <aside class="notes">
+            Na prática, o cientista de dados muitas vezes explora em pandas, mas a base real está
+            em Spark. O RiskBands precisa respeitar esse mundo híbrido: permitir análise produtiva,
+            mas sem esconder limitações como amostragem, representatividade e validação posterior.
+          </aside>
+        </section>
+
+        <section class="rb-slide">
+          <p class="rb-eyebrow">Validação</p>
+          <h2><code>validate=True</code>: confiança exige checagem</h2>
+          <div class="rb-check-grid" role="list" aria-label="Checks de validação">
+            <article class="rb-check-card fragment" role="listitem">
+              <span class="rb-step-number">01</span>
+              <span class="rb-icon rb-icon-shield" aria-hidden="true"></span>
+              <strong>Estrutura dos cortes</strong>
+            </article>
+            <article class="rb-check-card fragment" role="listitem">
+              <span class="rb-step-number">02</span>
+              <span class="rb-icon rb-icon-bins" aria-hidden="true"></span>
+              <strong>Consistência de bins</strong>
+            </article>
+            <article class="rb-check-card fragment" role="listitem">
+              <span class="rb-step-number">03</span>
+              <span class="rb-icon rb-icon-missing" aria-hidden="true"></span>
+              <strong>Tratamento de missing</strong>
+            </article>
+            <article class="rb-check-card fragment" role="listitem">
+              <span class="rb-step-number">04</span>
+              <span class="rb-icon rb-icon-log" aria-hidden="true"></span>
+              <strong>Métricas e logs</strong>
+            </article>
+            <article class="rb-check-card fragment" role="listitem">
+              <span class="rb-step-number">05</span>
+              <span class="rb-icon rb-icon-report" aria-hidden="true"></span>
+              <strong>Limitações documentadas</strong>
+            </article>
+          </div>
+          <p class="rb-callout fragment">
+            Validação não é garantia absoluta; é redução disciplinada de risco operacional.
+          </p>
+          <aside class="notes">
+            Um binning pode parecer correto visualmente e ainda assim ter problemas: cortes
+            inconsistentes, missing sem política clara, bins vazios, comportamento inesperado fora
+            do treino. A validação explícita reduz o risco de carregar decisões frágeis para frente.
+          </aside>
+        </section>
+
+        <section class="rb-slide rb-bundle-slide">
+          <p class="rb-eyebrow">Audit bundle</p>
+          <h2>Bundle auditável: evidências para revisão técnica</h2>
+          <div class="rb-file-grid">
+            <article class="rb-file-card fragment">
+              <span class="rb-icon rb-icon-report" aria-hidden="true"></span>
+              <code>metadata.json</code>
+              <span>contexto e configuração</span>
+            </article>
+            <article class="rb-file-card fragment">
+              <span class="rb-icon rb-icon-bins" aria-hidden="true"></span>
+              <code>binnings.json</code>
+              <span>cortes e regras</span>
+            </article>
+            <article class="rb-file-card fragment">
+              <span class="rb-icon rb-icon-log" aria-hidden="true"></span>
+              <code>missing_decision_log.csv</code>
+              <span>decisões sobre ausentes</span>
+            </article>
+            <article class="rb-file-card fragment">
+              <span class="rb-icon rb-icon-merge" aria-hidden="true"></span>
+              <code>missing_merge_candidates.csv</code>
+              <span>candidatos avaliados</span>
+            </article>
+            <article class="rb-file-card fragment">
+              <span class="rb-icon rb-icon-browser" aria-hidden="true"></span>
+              <code>audit_report.html</code>
+              <span>narrativa para revisão</span>
+            </article>
+          </div>
+          <aside class="notes">
+            O que muitas vezes falta no processo manual não é apenas o corte final. É o rastro.
+            Quem decidiu? Com qual critério? Quais alternativas foram consideradas? O bundle
+            auditável ajuda a transformar uma decisão técnica em material revisável.
+          </aside>
+        </section>
+
+        <section class="rb-slide">
+          <p class="rb-eyebrow">Model risk review</p>
+          <h2>Relatório narrativo para auditoria e model risk</h2>
+          <div class="rb-browser-frame fragment">
+            <div class="rb-browser-bar"><span></span><span></span><span></span></div>
+            <div class="rb-report-mock">
+              <div class="rb-report-title">
+                <span class="rb-icon rb-icon-browser" aria-hidden="true"></span>
+                <h3>Relatório de Auditoria do Binning</h3>
+              </div>
+              <ul>
+                <li><span>Configuração</span><strong>dataset, alvo, vintages</strong></li>
+                <li><span>Decisões sobre ausentes</span><strong>critério usado</strong></li>
+                <li><span>Candidatos avaliados</span><strong>event rate, WoE, IV</strong></li>
+                <li><span>Inventário do bundle</span><strong>arquivos gerados</strong></li>
+                <li><span>Limitações</span><strong>escopo e caveats</strong></li>
+              </ul>
+            </div>
+          </div>
+          <p class="rb-callout fragment">Revisão técnica precisa de evidência e narrativa.</p>
+          <aside class="notes">
+            Model risk não revisa apenas número. Revisa racionalidade, evidência e limitação. Um
+            relatório narrativo ajuda a explicar o que foi feito sem obrigar todo revisor a
+            reconstruir a análise a partir de notebook, planilha ou memória do modelador.
+          </aside>
+        </section>
+
+        <section class="rb-slide rb-workflow-slide">
+          <p class="rb-eyebrow">Workflow PD</p>
+          <h2>Onde o RiskBands encaixa no ciclo de modelagem PD</h2>
+          <div class="rb-workflow rb-workflow-3x3">
+            <div class="rb-workflow-step fragment">
+              <span class="rb-step-number">01</span>
+              <span class="rb-icon rb-icon-analysis" aria-hidden="true"></span>
+              <strong>EDA</strong>
+            </div>
+            <div class="rb-workflow-step fragment">
+              <span class="rb-step-number">02</span>
+              <span class="rb-icon rb-icon-feature" aria-hidden="true"></span>
+              <strong>Feature engineering</strong>
+            </div>
+            <div class="rb-workflow-step fragment">
+              <span class="rb-step-number">03</span>
+              <span class="rb-icon rb-icon-selection" aria-hidden="true"></span>
+              <strong>Feature selection</strong>
+            </div>
+            <div class="rb-workflow-step fragment rb-highlight-step">
+              <span class="rb-step-number">04</span>
+              <span class="rb-icon rb-icon-bins" aria-hidden="true"></span>
+              <strong>Candidate binnings</strong>
+            </div>
+            <div class="rb-workflow-step fragment">
+              <span class="rb-step-number">05</span>
+              <span class="rb-icon rb-icon-metrics" aria-hidden="true"></span>
+              <strong>WoE / IV / event rate</strong>
+            </div>
+            <div class="rb-workflow-step fragment">
+              <span class="rb-step-number">06</span>
+              <span class="rb-icon rb-icon-clock" aria-hidden="true"></span>
+              <strong>Temporal validation / OOT</strong>
+            </div>
+            <div class="rb-workflow-step fragment">
+              <span class="rb-step-number">07</span>
+              <span class="rb-icon rb-icon-missing" aria-hidden="true"></span>
+              <strong>Missing policy</strong>
+            </div>
+            <div class="rb-workflow-step fragment">
+              <span class="rb-step-number">08</span>
+              <span class="rb-icon rb-icon-scorecard" aria-hidden="true"></span>
+              <strong>Scorecard / model pipeline</strong>
+            </div>
+            <div class="rb-workflow-step fragment rb-highlight-step">
+              <span class="rb-step-number">09</span>
+              <span class="rb-icon rb-icon-evidence" aria-hidden="true"></span>
+              <strong>Audit evidence</strong>
+            </div>
+          </div>
+          <aside class="notes">
+            O RiskBands não substitui a modelagem de PD, nem a validação independente, nem a
+            decisão de negócio. Ele entra em uma etapa específica, mas crítica: transformar
+            binnings candidatos em decisões mais comparáveis, documentáveis e defensáveis.
+          </aside>
+        </section>
+
+        <section class="rb-slide rb-roadmap-slide">
+          <p class="rb-eyebrow">Evolução metodológica</p>
+          <h2>Roadmap controlado: estabilidade temporal mais consciente</h2>
+          <div class="rb-grid-2">
+            <article class="rb-card rb-roadmap-card fragment">
+              <div class="rb-card-heading">
+                <span class="rb-icon rb-icon-shield" aria-hidden="true"></span>
+                <h3>Disponível agora</h3>
+              </div>
+              <ul>
+                <li>binning auditável</li>
+                <li>políticas explícitas de missing</li>
+                <li>bundle e relatório</li>
+                <li>suporte pandas/PySpark conforme escopo atual</li>
+                <li>validação e reporting</li>
+              </ul>
+            </article>
+            <article class="rb-card rb-roadmap-card rb-roadmap-card-study fragment">
+              <div class="rb-card-heading">
+                <span class="rb-icon rb-icon-clock" aria-hidden="true"></span>
+                <h3>Em estudo: estabilidade ponderada por recência</h3>
+              </div>
+              <div class="rb-vintage-weights" aria-label="Pesos por safra aumentando com a recência">
+                <span><strong>2022</strong><i style="--rb-bar: 38%"></i><em>0.6</em></span>
+                <span><strong>2023</strong><i style="--rb-bar: 52%"></i><em>0.8</em></span>
+                <span><strong>2024</strong><i style="--rb-bar: 68%"></i><em>1.0</em></span>
+                <span><strong>2025</strong><i style="--rb-bar: 88%"></i><em>1.2</em></span>
+              </div>
+              <ul>
+                <li>pesos por safra na função objetivo</li>
+                <li>métricas reais por vintage preservadas</li>
+                <li>score ponderado e não ponderado lado a lado</li>
+                <li>alerta quando a recência muda o candidato vencedor</li>
+                <li>pesos registrados no bundle/reporting</li>
+              </ul>
+            </article>
+          </div>
+          <p class="rb-callout fragment">
+            Recência pode orientar a escolha, mas não deve apagar a evidência histórica.
+          </p>
+          <aside class="notes">
+            Este slide separa o que já está disponível de uma evolução metodológica em estudo. A
+            ideia de estabilidade ponderada por recência não deve reescrever as métricas
+            históricas: as métricas reais por safra continuam preservadas. Os pesos entram apenas
+            na função objetivo ou no score de escolha, permitindo comparar score ponderado e não
+            ponderado e alertar quando a ponderação por recência muda o candidato vencedor.
+          </aside>
+        </section>
+
+        <section class="rb-slide rb-final-slide">
+          <div class="rb-brand-row rb-brand-row-final">
+            <img src={logoSrc} alt="RiskBands" class="rb-logo" />
+          </div>
+          <p class="rb-eyebrow">Próximo passo</p>
+          <h2>Teste, critique, contribua</h2>
+          <div class="rb-chip-row fragment">
+            <span><span class="rb-icon rb-icon-workflow" aria-hidden="true"></span>PD Models</span>
+            <span><span class="rb-icon rb-icon-scorecard" aria-hidden="true"></span>Scorecards</span>
+            <span><span class="rb-icon rb-icon-shield" aria-hidden="true"></span>Model Risk</span>
+          </div>
+          <ul class="rb-cta-list">
+            <li class="fragment">
+              <span class="rb-icon rb-icon-bins" aria-hidden="true"></span>
+              Compare cortes
+            </li>
+            <li class="fragment">
+              <span class="rb-icon rb-icon-missing" aria-hidden="true"></span>
+              Explicite políticas
+            </li>
+            <li class="fragment">
+              <span class="rb-icon rb-icon-clock" aria-hidden="true"></span>
+              Valide comportamento temporal
+            </li>
+            <li class="fragment">
+              <span class="rb-icon rb-icon-log" aria-hidden="true"></span>
+              Registre decisões
+            </li>
+            <li class="fragment">
+              <span class="rb-icon rb-icon-evidence" aria-hidden="true"></span>
+              Leve evidência para revisão
+            </li>
+          </ul>
+          <p class="rb-callout fragment">
+            Binning defensável é menos sobre automatizar cortes e mais sobre melhorar a qualidade
+            da decisão.
+          </p>
+          <aside class="notes">
+            Se você já perdeu tempo defendendo cortes em reuniões, reconstruindo decisões antigas
+            ou explicando missing values sem evidência suficiente, esse projeto é para você testar
+            e criticar. O objetivo é melhorar a qualidade da decisão técnica.
+          </aside>
+        </section>
+      </div>
+    </div>
+
+    <script>
+      import Reveal from "reveal.js";
+      import Notes from "reveal.js/plugin/notes";
+      import Highlight from "reveal.js/plugin/highlight";
+
+      Reveal.initialize({
+        hash: true,
+        controls: true,
+        progress: true,
+        center: false,
+        keyboard: true,
+        transition: "fade",
+        backgroundTransition: "fade",
+        width: 1280,
+        height: 720,
+        margin: 0.035,
+        plugins: [Notes, Highlight],
+      });
+
+      const fullscreenButton = document.querySelector("[data-fullscreen]");
+      fullscreenButton?.addEventListener("click", () => {
+        const target = document.documentElement;
+        if (!document.fullscreenElement && target.requestFullscreen) {
+          target.requestFullscreen();
+        } else if (document.fullscreenElement && document.exitFullscreen) {
+          document.exitFullscreen();
+        }
+      });
+
+      document.addEventListener("fullscreenchange", () => {
+        if (fullscreenButton instanceof HTMLButtonElement) {
+          fullscreenButton.textContent = document.fullscreenElement ? "Exit fullscreen" : "Fullscreen";
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/docs-site/src/styles/riskbands-reveal.css
+++ b/docs-site/src/styles/riskbands-reveal.css
@@ -1,0 +1,1174 @@
+:root {
+  --rb-bg: #07111f;
+  --rb-bg-2: #0d2238;
+  --rb-bg-3: #102b43;
+  --rb-card: rgba(12, 30, 50, 0.86);
+  --rb-card-strong: rgba(18, 47, 74, 0.92);
+  --rb-card-border: rgba(99, 230, 226, 0.26);
+  --rb-text: #eef7ff;
+  --rb-muted: #a7bdd2;
+  --rb-accent: #63e6e2;
+  --rb-accent-2: #24b7d3;
+  --rb-good: #9be07d;
+  --rb-warning: #ffd166;
+  --rb-danger: #ff7a90;
+  --rb-shadow: rgba(0, 0, 0, 0.34);
+}
+
+.rb-deck-page {
+  margin: 0;
+  min-height: 100vh;
+  overflow: hidden;
+  background:
+    linear-gradient(145deg, rgba(7, 17, 31, 0.98), rgba(13, 34, 56, 0.98)),
+    repeating-linear-gradient(90deg, rgba(99, 230, 226, 0.05) 0 1px, transparent 1px 72px);
+  color: var(--rb-text);
+  font-family: "IBM Plex Sans", "Segoe UI", Arial, sans-serif;
+}
+
+.rb-deck-page *,
+.rb-deck-page *::before,
+.rb-deck-page *::after {
+  box-sizing: border-box;
+}
+
+.rb-deck-actions {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  z-index: 20;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.rb-docs-link,
+.rb-fullscreen {
+  min-height: 2.2rem;
+  border: 1px solid rgba(99, 230, 226, 0.34);
+  border-radius: 0.45rem;
+  padding: 0.48rem 0.78rem;
+  background: rgba(7, 17, 31, 0.78);
+  color: var(--rb-text);
+  font: 600 0.78rem/1.1 "IBM Plex Sans", "Segoe UI", Arial, sans-serif;
+  letter-spacing: 0;
+  text-decoration: none;
+  backdrop-filter: blur(10px);
+  box-shadow: 0 10px 28px var(--rb-shadow);
+}
+
+.rb-fullscreen {
+  cursor: pointer;
+}
+
+.rb-docs-link:hover,
+.rb-fullscreen:hover {
+  border-color: rgba(99, 230, 226, 0.72);
+  color: var(--rb-accent);
+}
+
+.rb-reveal {
+  min-height: 100vh;
+  color: var(--rb-text);
+}
+
+.rb-reveal .slides {
+  text-align: left;
+}
+
+.rb-reveal .slides section.rb-slide {
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  padding: 2.15rem 3.1rem 1.55rem;
+  display: flex !important;
+  flex-direction: column;
+  justify-content: flex-start;
+  gap: 0.82rem;
+  overflow: hidden;
+}
+
+.rb-reveal h1,
+.rb-reveal h2,
+.rb-reveal h3,
+.rb-reveal p,
+.rb-reveal li,
+.rb-reveal table {
+  color: var(--rb-text);
+  font-family: "IBM Plex Sans", "Segoe UI", Arial, sans-serif;
+  letter-spacing: 0;
+}
+
+.rb-reveal h1,
+.rb-reveal h2,
+.rb-reveal h3 {
+  margin: 0;
+  text-transform: none;
+}
+
+.rb-reveal h1 {
+  font-size: clamp(3.8rem, 4.6rem, 5.4rem);
+  line-height: 0.96;
+  font-weight: 800;
+}
+
+.rb-reveal h2 {
+  max-width: 25ch;
+  font-size: 2.32rem;
+  line-height: 1.04;
+  font-weight: 760;
+}
+
+.rb-reveal h3 {
+  font-size: 1.05rem;
+  line-height: 1.18;
+  font-weight: 700;
+}
+
+.rb-reveal p,
+.rb-reveal li {
+  font-size: 0.96rem;
+  line-height: 1.34;
+}
+
+.rb-reveal code {
+  color: var(--rb-accent);
+  font-family: "IBM Plex Mono", Consolas, monospace;
+  font-size: 0.86em;
+}
+
+.rb-reveal .controls {
+  color: var(--rb-accent);
+}
+
+.rb-reveal .progress {
+  height: 0.35rem;
+  color: var(--rb-accent);
+}
+
+.rb-reveal .progress span {
+  background: linear-gradient(90deg, var(--rb-accent), var(--rb-accent-2));
+}
+
+.rb-brand-row {
+  margin-bottom: 1.2rem;
+}
+
+.rb-brand-row-final {
+  margin-bottom: 0.8rem;
+}
+
+.rb-logo {
+  display: block;
+  width: 14.8rem;
+  max-width: 44%;
+  height: auto;
+  filter: drop-shadow(0 12px 24px rgba(0, 0, 0, 0.32));
+}
+
+.rb-title-slide {
+  display: flex !important;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.rb-final-slide {
+  display: flex !important;
+  flex-direction: column;
+  justify-content: center !important;
+}
+
+.rb-eyebrow {
+  margin: 0 0 0.7rem;
+  color: var(--rb-accent);
+  font-size: 0.82rem !important;
+  font-weight: 700;
+  line-height: 1.2;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.rb-subtitle {
+  max-width: 18ch;
+  margin: 0.7rem 0 0;
+  color: var(--rb-muted);
+  font-size: 1.48rem !important;
+  line-height: 1.24 !important;
+}
+
+.rb-callout {
+  max-width: 58rem;
+  margin: 0.05rem 0 0;
+  border: 1px solid rgba(99, 230, 226, 0.34);
+  border-radius: 0.5rem;
+  padding: 0.72rem 0.9rem;
+  background: rgba(99, 230, 226, 0.08);
+  color: var(--rb-text);
+  font-size: 0.92rem !important;
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.18);
+}
+
+.rb-pipeline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  align-items: center;
+  margin-top: 1rem;
+  color: var(--rb-muted);
+  font-size: 0.96rem;
+  font-weight: 650;
+}
+
+.rb-pipeline-pill {
+  position: relative;
+  display: inline-flex;
+  gap: 0.55rem;
+  align-items: center;
+  min-height: 2.7rem;
+  border: 1px solid rgba(99, 230, 226, 0.26);
+  border-radius: 0.65rem;
+  padding: 0.42rem 0.72rem 0.42rem 0.48rem;
+  background: rgba(7, 17, 31, 0.54);
+  color: var(--rb-text);
+}
+
+.rb-pipeline-pill + .rb-pipeline-pill {
+  margin-left: 0.22rem;
+}
+
+.rb-pipeline-pill + .rb-pipeline-pill::before {
+  content: "";
+  position: absolute;
+  left: -0.62rem;
+  top: 50%;
+  width: 0.48rem;
+  height: 0.48rem;
+  border-top: 2px solid rgba(99, 230, 226, 0.58);
+  border-right: 2px solid rgba(99, 230, 226, 0.58);
+  transform: translateY(-50%) rotate(45deg);
+}
+
+.rb-icon {
+  display: inline-grid;
+  place-items: center;
+  width: 1.95rem;
+  height: 1.95rem;
+  flex: 0 0 auto;
+  border: 1px solid rgba(99, 230, 226, 0.35);
+  border-radius: 0.55rem;
+  background:
+    linear-gradient(180deg, rgba(99, 230, 226, 0.16), rgba(36, 183, 211, 0.04)),
+    rgba(3, 11, 21, 0.42);
+  color: var(--rb-accent);
+  font-size: 0.62rem !important;
+  font-weight: 850;
+  line-height: 1;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.rb-icon::before {
+  content: "RB";
+}
+
+.rb-icon-data::before { content: "DB"; }
+.rb-icon-bins::before { content: "BIN"; }
+.rb-icon-evidence::before { content: "LOG"; }
+.rb-icon-table::before { content: "TBL"; }
+.rb-icon-spreadsheet::before { content: "XLS"; }
+.rb-icon-chart::before { content: "IV"; }
+.rb-icon-clock::before { content: "OOT"; }
+.rb-icon-missing::before { content: "NA"; }
+.rb-icon-metrics::before { content: "ER"; }
+.rb-icon-package::before { content: "PKG"; }
+.rb-icon-target::before { content: "TGT"; }
+.rb-icon-shield::before { content: "OK"; }
+.rb-icon-merge::before { content: "MRG"; }
+.rb-icon-log::before { content: "LOG"; }
+.rb-icon-spark::before { content: "SPK"; }
+.rb-icon-analysis::before { content: "EDA"; }
+.rb-icon-report::before { content: "DOC"; }
+.rb-icon-browser::before { content: "HTML"; }
+.rb-icon-feature::before { content: "FE"; }
+.rb-icon-selection::before { content: "SEL"; }
+.rb-icon-scorecard::before { content: "SC"; }
+.rb-icon-roadmap::before { content: "MAP"; }
+.rb-icon-workflow::before { content: "PD"; }
+
+.rb-card-heading,
+.rb-report-title {
+  display: flex;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.rb-card-heading h3,
+.rb-report-title h3 {
+  min-width: 0;
+}
+
+.rb-badge {
+  margin-left: auto;
+  border: 1px solid rgba(99, 230, 226, 0.28);
+  border-radius: 999px;
+  padding: 0.22rem 0.5rem;
+  color: var(--rb-accent);
+  font-size: 0.66rem;
+  font-weight: 800;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.rb-badge-warning {
+  border-color: rgba(255, 209, 102, 0.36);
+  color: var(--rb-warning);
+}
+
+.rb-grid-2,
+.rb-grid-5,
+.rb-file-grid {
+  display: grid;
+  gap: 0.7rem;
+  margin-top: 0.15rem;
+}
+
+.rb-grid-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.rb-grid-5 {
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+.rb-card,
+.rb-file-card,
+.rb-impact-card,
+.rb-flow-step,
+.rb-workflow-step {
+  border: 1px solid var(--rb-card-border);
+  border-radius: 0.55rem;
+  background:
+    linear-gradient(180deg, rgba(99, 230, 226, 0.08), rgba(99, 230, 226, 0.02)),
+    var(--rb-card);
+  box-shadow: 0 16px 38px rgba(0, 0, 0, 0.22);
+}
+
+.rb-card {
+  min-height: 6.6rem;
+  padding: 0.82rem;
+}
+
+.rb-card p {
+  margin: 0.45rem 0 0;
+  color: var(--rb-muted);
+  font-size: 0.86rem !important;
+}
+
+.rb-card ul {
+  margin: 0.6rem 0 0;
+  padding-left: 1.15rem;
+}
+
+.rb-card li {
+  margin: 0.32rem 0;
+  color: var(--rb-muted);
+  font-size: 0.9rem !important;
+}
+
+.rb-large-card {
+  min-height: 7.8rem;
+  padding: 0.92rem;
+}
+
+.rb-pain-slide h2,
+.rb-workflow-slide h2 {
+  max-width: 29ch;
+}
+
+.rb-pain-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.2fr);
+  gap: 0.75rem;
+  align-items: stretch;
+  margin-top: 0.1rem;
+}
+
+.rb-pain-stack {
+  display: grid;
+  gap: 0.42rem;
+  align-content: start;
+}
+
+.rb-pain-card {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.12rem 0.58rem;
+  align-items: center;
+  min-height: 3.1rem;
+  border: 1px solid var(--rb-card-border);
+  border-radius: 0.55rem;
+  padding: 0.5rem 0.6rem;
+  background:
+    linear-gradient(180deg, rgba(99, 230, 226, 0.07), rgba(99, 230, 226, 0.015)),
+    var(--rb-card);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.18);
+}
+
+.rb-pain-card .rb-icon {
+  grid-row: 1 / span 2;
+}
+
+.rb-pain-card strong {
+  color: var(--rb-text);
+  font-size: 0.82rem;
+  line-height: 1.08;
+}
+
+.rb-pain-card span:not(.rb-icon) {
+  color: var(--rb-muted);
+  font-size: 0.72rem;
+  line-height: 1.2;
+}
+
+.rb-pain-table {
+  align-self: stretch;
+  border: 1px solid rgba(99, 230, 226, 0.22);
+  border-radius: 0.65rem;
+  padding: 0.85rem;
+  background: rgba(3, 11, 21, 0.34);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.2);
+}
+
+.rb-table-caption {
+  display: flex;
+  gap: 0.55rem;
+  align-items: center;
+  margin-bottom: 0.65rem;
+  color: var(--rb-text);
+  font-size: 0.84rem;
+  font-weight: 760;
+}
+
+.rb-mini-table table {
+  width: 100%;
+  border-collapse: collapse;
+  overflow: hidden;
+  border: 1px solid rgba(99, 230, 226, 0.18);
+  border-radius: 0.55rem;
+  background: rgba(3, 11, 21, 0.54);
+}
+
+.rb-mini-table th,
+.rb-mini-table td {
+  padding: 0.48rem 0.58rem;
+  border-bottom: 1px solid rgba(167, 189, 210, 0.14);
+  color: var(--rb-muted);
+  font-size: 0.69rem;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.rb-mini-table th {
+  color: var(--rb-accent);
+  font-weight: 700;
+}
+
+.rb-chart-card {
+  min-height: 15.2rem;
+}
+
+.rb-line-chart {
+  display: block;
+  width: 100%;
+  height: 8.5rem;
+  margin: 0.45rem 0 0.25rem;
+  overflow: visible;
+}
+
+.rb-signal-chip,
+.rb-ribbon,
+.rb-method-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.rb-signal-chip,
+.rb-ribbon {
+  width: fit-content;
+  border: 1px solid rgba(255, 209, 102, 0.28);
+  border-radius: 999px;
+  padding: 0.34rem 0.7rem 0.34rem 0.42rem;
+  background: rgba(255, 209, 102, 0.07);
+  color: var(--rb-warning);
+  font-size: 0.8rem;
+  font-weight: 760;
+}
+
+.rb-method-chips span {
+  border: 1px solid rgba(99, 230, 226, 0.28);
+  border-radius: 999px;
+  padding: 0.34rem 0.62rem;
+  background: rgba(99, 230, 226, 0.07);
+}
+
+.rb-line-chart .rb-gridline {
+  fill: none;
+  stroke: rgba(167, 189, 210, 0.16);
+  stroke-width: 1;
+}
+
+.rb-line-chart .rb-chart-line {
+  fill: none;
+  stroke-width: 6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.rb-chart-line-good {
+  stroke: var(--rb-good);
+}
+
+.rb-chart-line-warn {
+  stroke: var(--rb-warning);
+}
+
+.rb-line-chart circle {
+  fill: var(--rb-bg);
+  stroke: var(--rb-accent);
+  stroke-width: 3;
+}
+
+.rb-flow {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0.65rem;
+  align-items: stretch;
+  margin-top: 0.15rem;
+}
+
+.rb-flow-wide {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.rb-flow-step {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  min-height: 6.2rem;
+  padding: 0.72rem;
+  color: var(--rb-text);
+  font-size: 0.84rem;
+  font-weight: 720;
+}
+
+.rb-flow-step::after {
+  content: "";
+  position: absolute;
+  right: -0.56rem;
+  top: 50%;
+  width: 0.72rem;
+  height: 0.72rem;
+  border-top: 2px solid rgba(99, 230, 226, 0.6);
+  border-right: 2px solid rgba(99, 230, 226, 0.6);
+  transform: translateY(-50%) rotate(45deg);
+}
+
+.rb-flow-step:last-child::after {
+  display: none;
+}
+
+.rb-axis {
+  display: grid;
+  grid-template-columns: auto minmax(12rem, 1fr) auto;
+  gap: 1rem;
+  align-items: center;
+  margin: 0.1rem 0 0;
+  color: var(--rb-muted);
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.rb-axis-line {
+  position: relative;
+  height: 0.35rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--rb-accent-2), var(--rb-warning));
+}
+
+.rb-axis-line::before,
+.rb-axis-line::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 999px;
+  background: var(--rb-text);
+  transform: translateY(-50%);
+}
+
+.rb-axis-line::before {
+  left: 0;
+}
+
+.rb-axis-line::after {
+  right: 0;
+}
+
+.rb-missing-map {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.72rem;
+  align-items: center;
+  margin-top: 0.2rem;
+}
+
+.rb-missing-map::before {
+  content: "";
+  position: absolute;
+  left: 15%;
+  right: 15%;
+  top: 46%;
+  border-top: 1px solid rgba(99, 230, 226, 0.26);
+}
+
+.rb-missing-node {
+  position: relative;
+  grid-column: 1 / -1;
+  justify-self: center;
+  display: flex;
+  gap: 0.55rem;
+  align-items: center;
+  width: fit-content;
+  border: 2px solid rgba(99, 230, 226, 0.68);
+  border-radius: 0.65rem;
+  padding: 0.62rem 0.88rem;
+  background: rgba(99, 230, 226, 0.12);
+  color: var(--rb-text);
+  font-size: 1.08rem;
+  font-weight: 800;
+  text-align: center;
+}
+
+.rb-impact-card {
+  position: relative;
+  display: grid;
+  justify-items: center;
+  gap: 0.5rem;
+  min-height: 5.8rem;
+  padding: 0.72rem;
+  color: var(--rb-muted);
+  font-size: 0.88rem;
+  font-weight: 700;
+  text-align: center;
+}
+
+.rb-decision-tree h3 {
+  color: var(--rb-accent);
+}
+
+.rb-decision-tree ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+.rb-decision-tree li {
+  display: grid;
+  gap: 0.25rem;
+  margin: 0.65rem 0;
+  border-left: 2px solid rgba(99, 230, 226, 0.44);
+  padding-left: 0.85rem;
+}
+
+.rb-decision-tree li span {
+  color: var(--rb-muted);
+  font-size: 0.78rem;
+}
+
+.rb-warning {
+  display: inline-block;
+  margin-top: 0.05rem;
+  border: 1px solid rgba(255, 209, 102, 0.34);
+  border-radius: 0.5rem;
+  padding: 0.68rem 0.85rem;
+  background: rgba(255, 209, 102, 0.09);
+  color: var(--rb-warning) !important;
+  font-size: 0.86rem !important;
+  font-weight: 700;
+}
+
+.rb-check-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0.62rem;
+  margin-top: 0.15rem;
+}
+
+.rb-check-card {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.38rem 0.52rem;
+  align-content: start;
+  min-height: 6.7rem;
+  border: 1px solid var(--rb-card-border);
+  border-radius: 0.55rem;
+  padding: 0.72rem;
+  background:
+    linear-gradient(180deg, rgba(99, 230, 226, 0.09), rgba(99, 230, 226, 0.02)),
+    var(--rb-card);
+  color: var(--rb-text);
+  font-weight: 700;
+}
+
+.rb-check-card .rb-step-number {
+  grid-column: 1 / -1;
+}
+
+.rb-check-card strong {
+  align-self: center;
+  font-size: 0.78rem;
+  line-height: 1.18;
+}
+
+.rb-step-number {
+  width: fit-content;
+  border: 1px solid rgba(99, 230, 226, 0.3);
+  border-radius: 999px;
+  padding: 0.18rem 0.44rem;
+  color: var(--rb-accent);
+  font-size: 0.64rem;
+  font-weight: 850;
+  line-height: 1;
+}
+
+.rb-file-grid {
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+}
+
+.rb-file-card {
+  display: grid;
+  gap: 0.45rem;
+  align-content: start;
+  grid-column: span 2;
+  min-height: 6.8rem;
+  padding: 0.72rem;
+}
+
+.rb-file-card:nth-child(-n + 2) {
+  grid-column: span 3;
+}
+
+.rb-file-card code {
+  display: block;
+  color: var(--rb-accent);
+  font-size: 0.72rem;
+  overflow-wrap: anywhere;
+}
+
+.rb-file-card span:not(.rb-icon) {
+  display: block;
+  margin-top: 0;
+  color: var(--rb-muted);
+  font-size: 0.76rem;
+  line-height: 1.22;
+}
+
+.rb-file-card .rb-icon {
+  display: inline-grid;
+}
+
+.rb-browser-frame {
+  max-width: 54rem;
+  margin-top: 0.1rem;
+  overflow: hidden;
+  border: 1px solid rgba(99, 230, 226, 0.22);
+  border-radius: 0.65rem;
+  background: #0a1727;
+  box-shadow: 0 22px 48px rgba(0, 0, 0, 0.28);
+}
+
+.rb-browser-bar {
+  display: flex;
+  gap: 0.38rem;
+  align-items: center;
+  min-height: 1.85rem;
+  border-bottom: 1px solid rgba(167, 189, 210, 0.16);
+  padding: 0 0.85rem;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.rb-browser-bar span {
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 999px;
+  background: var(--rb-muted);
+}
+
+.rb-browser-bar span:nth-child(1) {
+  background: var(--rb-danger);
+}
+
+.rb-browser-bar span:nth-child(2) {
+  background: var(--rb-warning);
+}
+
+.rb-browser-bar span:nth-child(3) {
+  background: var(--rb-good);
+}
+
+.rb-report-mock {
+  padding: 0.95rem 1.1rem 1rem;
+}
+
+.rb-report-mock h3 {
+  color: var(--rb-text);
+}
+
+.rb-report-mock ul {
+  display: grid;
+  gap: 0.42rem;
+  margin: 0.65rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.rb-report-mock li {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.7rem;
+  align-items: center;
+  border: 1px solid rgba(167, 189, 210, 0.14);
+  border-radius: 0.45rem;
+  padding: 0.46rem 0.62rem;
+  background: rgba(255, 255, 255, 0.035);
+  color: var(--rb-muted);
+  font-size: 0.78rem !important;
+}
+
+.rb-report-mock li strong {
+  color: var(--rb-accent);
+  font-size: 0.7rem;
+  font-weight: 760;
+}
+
+.rb-workflow {
+  display: grid;
+  gap: 0.62rem;
+  margin-top: 0.15rem;
+}
+
+.rb-workflow.rb-workflow-3x3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.rb-workflow-step {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.36rem 0.58rem;
+  align-content: start;
+  min-height: 5.75rem;
+  padding: 0.62rem;
+  color: var(--rb-muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.rb-workflow-step .rb-step-number {
+  grid-column: 1 / -1;
+}
+
+.rb-workflow-step strong {
+  align-self: center;
+  color: var(--rb-muted);
+  line-height: 1.16;
+}
+
+.rb-highlight-step {
+  border-color: rgba(99, 230, 226, 0.72);
+  background:
+    linear-gradient(180deg, rgba(99, 230, 226, 0.16), rgba(36, 183, 211, 0.07)),
+    var(--rb-card-strong);
+  color: var(--rb-text);
+}
+
+.rb-highlight-step strong {
+  color: var(--rb-text);
+}
+
+.rb-roadmap-slide h2 {
+  max-width: 31ch;
+}
+
+.rb-roadmap-card {
+  min-height: 16.4rem;
+}
+
+.rb-roadmap-card h3 {
+  line-height: 1.12;
+}
+
+.rb-roadmap-card ul {
+  margin-top: 0.55rem;
+}
+
+.rb-roadmap-card li {
+  margin: 0.24rem 0;
+  font-size: 0.82rem !important;
+  line-height: 1.25;
+}
+
+.rb-vintage-weights {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.42rem;
+  margin-top: 0.62rem;
+  border: 1px solid rgba(99, 230, 226, 0.18);
+  border-radius: 0.5rem;
+  padding: 0.55rem;
+  background: rgba(3, 11, 21, 0.28);
+}
+
+.rb-vintage-weights span {
+  display: grid;
+  grid-template-rows: auto 2.4rem auto;
+  gap: 0.22rem;
+  align-items: end;
+  justify-items: center;
+}
+
+.rb-vintage-weights strong,
+.rb-vintage-weights em {
+  color: var(--rb-muted);
+  font-size: 0.64rem;
+  font-style: normal;
+  line-height: 1;
+}
+
+.rb-vintage-weights i {
+  display: block;
+  width: 0.78rem;
+  height: var(--rb-bar);
+  min-height: 0.55rem;
+  border-radius: 0.22rem 0.22rem 0.08rem 0.08rem;
+  background: linear-gradient(180deg, var(--rb-accent), var(--rb-accent-2));
+  box-shadow: 0 0 14px rgba(99, 230, 226, 0.2);
+}
+
+.rb-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  margin-top: 0.2rem;
+}
+
+.rb-chip-row > span {
+  display: inline-flex;
+  gap: 0.45rem;
+  align-items: center;
+  border: 1px solid rgba(99, 230, 226, 0.38);
+  border-radius: 999px;
+  padding: 0.32rem 0.66rem 0.32rem 0.36rem;
+  background: rgba(99, 230, 226, 0.08);
+  color: var(--rb-accent);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.rb-chip-row .rb-icon {
+  width: 1.6rem;
+  height: 1.6rem;
+  font-size: 0.52rem !important;
+}
+
+.rb-cta-list {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0.56rem;
+  margin: 0.25rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.rb-cta-list li {
+  display: grid;
+  gap: 0.42rem;
+  align-content: start;
+  min-height: 4.55rem;
+  border: 1px solid rgba(99, 230, 226, 0.22);
+  border-radius: 0.55rem;
+  padding: 0.62rem;
+  background: rgba(12, 30, 50, 0.78);
+  color: var(--rb-text);
+  font-size: 0.76rem !important;
+  font-weight: 700;
+}
+
+.rb-final-slide .rb-brand-row-final {
+  margin-bottom: 0.25rem;
+}
+
+.rb-final-slide .rb-logo {
+  width: 11.2rem;
+}
+
+.rb-final-slide .rb-eyebrow {
+  margin-bottom: 0.35rem;
+}
+
+.rb-final-slide h2 {
+  font-size: 2.16rem;
+}
+
+.rb-final-slide .rb-chip-row {
+  margin-top: 0;
+}
+
+.rb-final-slide .rb-cta-list li {
+  min-height: 3.85rem;
+  padding: 0.52rem;
+}
+
+.rb-final-slide .rb-callout {
+  max-width: 50rem;
+  padding: 0.56rem 0.78rem;
+  font-size: 0.86rem !important;
+}
+
+@media (max-width: 900px) {
+  .rb-deck-actions {
+    top: 0.6rem;
+    right: 0.6rem;
+  }
+
+  .rb-docs-link,
+  .rb-fullscreen {
+    padding: 0.42rem 0.58rem;
+    font-size: 0.72rem;
+  }
+
+  .rb-reveal .slides section.rb-slide {
+    padding: 4rem 1.8rem 2.2rem;
+    overflow: visible;
+  }
+
+  .rb-grid-5,
+  .rb-check-grid,
+  .rb-file-grid,
+  .rb-cta-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .rb-pain-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .rb-file-card,
+  .rb-file-card:nth-child(-n + 2) {
+    grid-column: auto;
+  }
+
+  .rb-flow,
+  .rb-flow-wide,
+  .rb-workflow {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .rb-workflow.rb-workflow-3x3 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .rb-flow-step::after {
+    display: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .rb-deck-page {
+    overflow: auto;
+  }
+
+  .rb-reveal h1 {
+    font-size: 3rem;
+  }
+
+  .rb-reveal h2 {
+    max-width: none;
+    font-size: 2rem;
+  }
+
+  .rb-logo {
+    max-width: 78%;
+  }
+
+  .rb-grid-2,
+  .rb-grid-5,
+  .rb-check-grid,
+  .rb-file-grid,
+  .rb-cta-list,
+  .rb-missing-map,
+  .rb-flow,
+  .rb-flow-wide,
+  .rb-workflow {
+    grid-template-columns: 1fr;
+  }
+
+  .rb-workflow.rb-workflow-3x3 {
+    grid-template-columns: 1fr;
+  }
+
+  .rb-pipeline {
+    grid-template-columns: 1fr;
+  }
+
+  .rb-pipeline {
+    display: grid;
+  }
+
+  .rb-pipeline-pill + .rb-pipeline-pill {
+    margin-left: 0;
+  }
+
+  .rb-pipeline-pill + .rb-pipeline-pill::before {
+    display: none;
+  }
+
+  .rb-axis {
+    grid-template-columns: 1fr;
+    gap: 0.55rem;
+  }
+}
+
+@media (max-height: 760px) {
+  .rb-reveal .slides section.rb-slide {
+    padding-top: 1.82rem;
+    padding-bottom: 1.28rem;
+    gap: 0.66rem;
+  }
+
+  .rb-reveal h2 {
+    font-size: 2.12rem;
+  }
+
+  .rb-card,
+  .rb-flow-step,
+  .rb-workflow-step,
+  .rb-file-card,
+  .rb-check-card,
+  .rb-impact-card {
+    min-height: auto;
+  }
+
+  .rb-line-chart {
+    height: 7.65rem;
+  }
+
+  .rb-callout,
+  .rb-warning {
+    padding-top: 0.6rem;
+    padding-bottom: 0.6rem;
+  }
+}


### PR DESCRIPTION
## Summary

Adds the RiskBands Reveal.js overview deck to the public docs site and wires it into the Starlight navigation for pt-BR and English users.

## Changes

- Adds `/presentations/riskbands-overview/` as a standalone Astro Reveal.js deck.
- Adds dedicated Reveal.js styling scoped to the deck.
- Adds `Presentations` docs entries in pt-BR and English.
- Adds `reveal.js` to the docs-site dependencies.
- Updates the docs sidebar so the presentation is discoverable.
- Adds a narrow `pip-audit --ignore-vuln PYSEC-2024-277` for the disputed joblib/CVE-2024-34997 advisory with no fixed version; other advisories still fail the audit.

## Validation

- `npm --prefix docs-site run build` passed.
- `DOCS_BASE_PATH=/RiskBands npm --prefix docs-site run build` passed.
- `git diff --check` passed.
- `git diff --cached --check` passed before the docs commit.
- `bash docs/goals/riskbands-sprint-p1b-revealjs-polish/scripts/verify_p1b_static.sh` passed.
- `python -m pytest tests/test_examples_smoke.py --basetemp .pytest_tmp/docs-pages-examples-smoke` passed: 9 tests.
- Local preview with `DOCS_BASE_PATH=/RiskBands` returned HTTP 200 for `/RiskBands/presentations/riskbands-overview/`, `/RiskBands/presentations/`, and `/RiskBands/en/presentations/`.

## Notes

The live GitHub Pages route returned 404 before this publication flow. A docs-deploy workflow dispatch was started for this branch, but the deploy job failed after a successful build, so this PR provides the durable main-branch path.