### PR TITLE
Prepare RiskBands v2.4.0 release

### DIFF
--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -65,6 +65,8 @@ jobs:
         run: |
           # PYSEC-2024-277 / CVE-2024-34997 is a disputed joblib
           # deserialization advisory with no fixed version published.
+          # Exception rationale: docs/security/pip_audit_exceptions.md
+          # Do not ignore or suppress any other advisory.
           python -m pip_audit --ignore-vuln PYSEC-2024-277
 
       - name: Build sdist and wheel

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,4 +55,6 @@ jobs:
         run: |
           # PYSEC-2024-277 / CVE-2024-34997 is a disputed joblib
           # deserialization advisory with no fixed version published.
+          # Exception rationale: docs/security/pip_audit_exceptions.md
+          # Do not ignore or suppress any other advisory.
           python -m pip_audit --ignore-vuln PYSEC-2024-277

--- a/README.md
+++ b/README.md
@@ -257,33 +257,36 @@ Exemplos executaveis:
 - `python examples/missing_policy/missing_policy_pandas_demo.py`
 - `python examples/missing_policy/missing_policy_pyspark_demo.py`
 
-## Destaques da versao 2.3.0
+## Destaques da versao 2.4.0
 
-A versao 2.3.0 prepara a release de merge auditavel de missing values:
+A versao 2.4.0 prepara a release de Spark missing merge, audit bundle narrativo,
+docs publicas e exemplos:
 
 - `missing_policy="standard"` permanece como default compativel.
-- `missing_policy="separate_bin"` cria bin explicito `Missing` quando essa escolha
-  for intencional.
-- `missing_policy="forbid"` falha quando missing values devem ser tratados antes
-  do binning.
-- `missing_policy="merge"` permite unir o grupo missing a um bin regular usando
-  `nearest_event_rate` ou `nearest_woe`.
-- `missing_merge_fallback` controla o comportamento quando missing aparece no
-  transform sem uma decisao aprendida no fit.
-- `missing_profile_`, `missing_decision_log_`, `missing_merge_candidates_` e
-  `missing_merge_map_` preservam a auditoria do merge.
-- `return_woe=True` em pandas usa o WoE do bin de destino aprendido.
-- bundles e reporting persistem criterio, fallback, candidatos e mapa de merge.
+- `missing_policy="merge"` continua auditavel em pandas com
+  `nearest_event_rate` e `nearest_woe`.
+- Spark transform aplica decisoes de missing merge aprendidas usando expressoes
+  Spark nativas e `return_woe=False`.
+- Spark fit com missing merge usa caminho controlado sampled-to-pandas, registra
+  a caveat de amostragem e nao afirma aprendizado Spark-native no dataset
+  completo.
+- `fit(validate=True)` em Spark pode gerar `source_profile_`,
+  diagnosticos sample-vs-source e `missing_sampling_diagnostics`.
+- `audit_report.html` gera um relatorio narrativo standalone e print-friendly
+  com configuracao, missing policies, merge, validacao, inventario do bundle e
+  limitacoes.
+- `export_bundle(...)` inclui `audit_report.html` por padrao, alem de metadata,
+  CSVs, tabelas por feature e trilhas de missing merge quando disponiveis.
+- A galeria Reveal.js do docs-site inclui uma apresentacao RiskBands Overview.
 - `standard` e o nome canonico do score historico; `legacy` segue como alias
   compativel.
 - pandas e PySpark seguem suportados, com PySpark opcional via
-  `riskbands[spark]` e restrito a `pyspark>=3.5,<4`.
-- bundles antigos seguem carregando como `standard` quando nao possuem os novos
-  campos de missing policy ou missing merge.
+  `riskbands[spark]` e restrito a `pyspark>=3.5.2,<4`.
 
-Fora do escopo desta versao: `temporal_stable`, `monotonic_neighbor`, PySpark
-merge completo, criterios adicionais de merge, imputacao inteligente opaca e um
-backend Spark distribuido completo para fitting.
+Fora do escopo desta versao: Spark-native full fit para missing merge, Spark
+`return_woe=True`, `temporal_stable`, `monotonic_neighbor`, criterios adicionais
+de merge, imputacao inteligente opaca, PDF nativo do audit report e garantia de
+conformidade regulatoria.
 
 ## Export auditavel e supply chain
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,82 +4,118 @@
 
 - Project: `RiskBands`
 - Distribution: `riskbands`
-- Repository version: `2.3.0`
-- Planned release tag: `v2.3.0`
+- Repository version: `2.4.0`
+- Planned release tag: `v2.4.0`
 - Default branch: `main`
-- Preparation branch: `release/v2.3.0-prep`
-- Status: prepared for v2.3.0 publication review after local validation.
+- Preparation branch: `release/v2.4.0-prep`
+- Status: prepared for v2.4.0 publication review after local validation.
 
-No PyPI upload, TestPyPI upload, tag creation, or push is performed by Sprint E3.
+No PyPI upload, TestPyPI upload, tag creation, workflow dispatch, or push is
+performed by Sprint I.
 
-## 2.3.0 Release Notes
+## 2.4.0 Release Notes
 
 Type: compatible minor release preparation.
 
-Positioning: RiskBands v2.3.0 - auditable missing merge policies.
+Positioning: RiskBands v2.4.0 - Spark missing merge, audit bundle narrative
+reporting, public docs, examples, and Reveal.js documentation gallery.
 
 ### Added
 
-- `missing_policy="merge"` for pandas flows that need to route a missing group into a learned regular bin while preserving audit evidence.
-- `missing_merge_criterion="nearest_event_rate"` to select the regular candidate bin with the closest fit-time event rate.
-- `missing_merge_criterion="nearest_woe"` to select the regular candidate bin with the closest fit-time WoE.
-- `missing_merge_fallback="separate_bin"` and `missing_merge_fallback="raise"` for transform-time missing values when no fit-time merge decision was learned.
-- `missing_merge_candidates_`, `missing_merge_map_`, and richer `missing_decision_log_` fields for reviewable merge decisions.
-- Bundle and report persistence for merge criterion, fallback, candidates, selected destination, distances, and merge map.
-
-### Changed
-
-- Release documentation now describes merge as an opt-in policy alongside `standard`, `separate_bin`, and `forbid`.
-- README, technical docs, and docs-site pages explain when to use `nearest_event_rate` versus `nearest_woe`.
-- pandas examples include `separate_bin`, merge with both criteria, fallback behavior, audit fields, and bundle roundtrip.
+- Spark transform support for `missing_policy="merge"` with learned merge
+  decisions applied through native Spark expressions and `return_woe=False`.
+- Spark sampled-to-pandas fit for missing merge, recording that the merge
+  decision was learned on a controlled sample rather than a Spark-native full
+  fit.
+- Spark validation/reporting diagnostics for sampled missing merge, including
+  `source_profile_`, sample-vs-source comparisons, and
+  `missing_sampling_diagnostics`.
+- Sampling caveats in metadata, bundle outputs, and `audit_report.html`.
+- Narrative `audit_report.html` with embedded CSS, print-friendly layout,
+  missing policy explanations, merge decisions, validation alerts, bundle
+  inventory, and known limitations.
+- Bundle integration for the narrative audit report through
+  `export_bundle(..., include_audit_report=True)`.
+- Docs-site Reveal.js gallery and RiskBands overview presentation.
+- Public pt-BR/en docs and runnable examples for missing policy, audit report,
+  bundle/reporting, and Spark missing merge.
 
 ### Compatibility
 
 - `missing_policy="standard"` remains the default.
-- `missing_policy="separate_bin"` and `missing_policy="forbid"` remain supported.
-- `score_strategy="standard"` remains canonical; `score_strategy="legacy"` remains a compatibility alias.
+- `missing_policy="separate_bin"`, `missing_policy="forbid"`, and pandas
+  `missing_policy="merge"` remain supported.
+- `missing_merge_criterion="nearest_event_rate"` and
+  `missing_merge_criterion="nearest_woe"` remain the only merge criteria.
+- `missing_merge_fallback="separate_bin"` and
+  `missing_merge_fallback="raise"` remain supported.
+- `score_strategy="standard"` remains canonical; `score_strategy="legacy"`
+  remains a compatibility alias.
 - Existing `from riskbands import Binner` and `Binner(...)` usage is preserved.
 - `RiskBands` remains the preferred public estimator name and aliases `Binner`.
-- Bundles created before missing-merge metadata existed continue to load with missing-merge fields as `None`.
-- The base installation does not install PySpark.
-- PySpark support remains optional through `riskbands[spark]`.
-- The Spark extra remains constrained to `pyspark>=3.5,<4`.
+- Base installation does not install PySpark.
+- PySpark remains optional through `riskbands[spark]` with `pyspark>=3.5.2,<4`.
+
+### Security Audit Exception
+
+- The standard `python -m pip_audit` command reports
+  `joblib/PYSEC-2024-277`, a disputed deserialization advisory with no fixed
+  version available.
+- RiskBands does not load untrusted `joblib`/pickle artifacts as part of the
+  public workflow; bundle outputs use auditable formats such as JSON, CSV, and
+  HTML where applicable.
+- Release-prep keeps `pip-audit` enabled and ignores only this advisory through
+  `python -m pip_audit --ignore-vuln PYSEC-2024-277`.
+- The rationale and future review requirement are documented in
+  `docs/security/pip_audit_exceptions.md`.
 
 ### Explicitly Out Of Scope
 
-- No `temporal_stable` missing-merge criterion is included.
-- No `monotonic_neighbor` missing-merge criterion is included.
-- No additional merge criteria beyond `nearest_event_rate` and `nearest_woe` are included.
+- No Spark-native full-data fitting backend for missing merge is added.
+- No Spark `return_woe=True` support is added.
+- No `temporal_stable` or `monotonic_neighbor` merge criterion is added.
+- No additional merge criteria beyond `nearest_event_rate` and `nearest_woe`
+  are added.
 - No opaque intelligent imputation is added.
-- No full PySpark implementation for `missing_policy="merge"` is added.
-- No PySpark 4.x support is promised.
+- No native PDF export for the audit report is added.
 - No regulatory compliance guarantee is made.
 
 ## Workflows In Use
 
 - `tests.yml`: regular CI test suite.
-- `release-validation.yml`: package build, `twine check`, wheel smoke, and sdist smoke for PRs, `main`, manual dispatch, and tags.
-- `docs-deploy.yml`: Astro/Starlight build plus GitHub Pages deploy on pushes to `main` and manual dispatch.
-- `publish-testpypi.yml`: optional TestPyPI publication via Trusted Publishing. Run manually only after review.
-- `publish-pypi.yml`: PyPI publication via Trusted Publishing. Run manually only after review.
+- `release-validation.yml`: package build, `twine check`, wheel smoke, and
+  sdist smoke for PRs, `main`, manual dispatch, and tags.
+- `docs-deploy.yml`: Astro/Starlight build plus GitHub Pages deploy on pushes
+  to `main` and manual dispatch.
+- `publish-testpypi.yml`: optional TestPyPI publication via Trusted Publishing.
+  Run manually only after review.
+- `publish-pypi.yml`: PyPI publication via Trusted Publishing. Run manually only
+  after review.
 
 ## Release Sequence
 
-1. Prepare versioned files and release notes for `2.3.0`.
+1. Prepare versioned files and release notes for `2.4.0`.
 2. Run the complete local validation suite.
-3. Confirm docs-site build.
-4. Confirm package build, `twine check`, smoke base install, and smoke `[spark]` install.
-5. Confirm no tag, push, PyPI upload, or TestPyPI upload was performed during Sprint E3.
-6. Commit the final release-prep changes after review.
-7. Open a PR from `release/v2.3.0-prep` to `main`.
-8. Create the annotated git tag `v2.3.0` manually only after review approval and merge.
-9. Push `main` and the tag manually.
-10. Confirm `release-validation.yml` is green for the pushed tag.
-11. Optionally run `publish-testpypi.yml` on the reviewed tag.
-12. Run `publish-pypi.yml` on the same stable tag only after release validation and optional TestPyPI smoke checks are green.
-13. Confirm `docs-deploy.yml` is green after the push to `main`.
+3. Confirm Spark tests with the configured local Java/PySpark environment.
+4. Confirm docs-site build and Reveal.js route build.
+5. Confirm package build, `twine check`, smoke base install, and smoke `[spark]`
+   install.
+6. Confirm no tag, push, workflow dispatch, PyPI upload, or TestPyPI upload was
+   performed during Sprint I.
+7. Commit the final release-prep changes only after review.
+8. Open a PR from `release/v2.4.0-prep` to `main`.
+9. Create the annotated git tag `v2.4.0` manually only after review approval and
+   merge.
+10. Push `main` and the tag manually.
+11. Confirm `release-validation.yml` is green for the pushed tag.
+12. Optionally run `publish-testpypi.yml` on the reviewed tag.
+13. Run `publish-pypi.yml` on the same stable tag only after release validation
+   and optional TestPyPI smoke checks are green.
+14. Confirm `docs-deploy.yml` is green after the push to `main`.
 
-Do not replace an artifact that already exists on a package index. If a defect is found after PyPI publication, yank the affected version and prepare a new version.
+Do not replace an artifact that already exists on a package index. If a defect
+is found after PyPI publication, yank the affected version and prepare a new
+version.
 
 ## Local Validation
 
@@ -91,11 +127,11 @@ Recommended command sequence:
 .\.venv-v210-spark\Scripts\python.exe -m pip check
 .\.venv-v210-spark\Scripts\python.exe -m ruff check riskbands tests
 .\.venv-v210-spark\Scripts\python.exe -m bandit -q -r riskbands
-.\.venv-v210-spark\Scripts\python.exe -m pytest --basetemp .pytest_tmp\v230-full-core
-.\.venv-v210-spark\Scripts\python.exe -m pytest -m spark --basetemp .pytest_tmp\v230-full-spark
-.\.venv-v210-spark\Scripts\python.exe -m pip_audit
+.\.venv-v210-spark\Scripts\python.exe -m pytest --basetemp .pytest_tmp\v240-full-core
+.\.venv-v210-spark\Scripts\python.exe -m pytest -m spark --basetemp .pytest_tmp\v240-full-spark
+.\.venv-v210-spark\Scripts\python.exe -m pip_audit --ignore-vuln PYSEC-2024-277
 npm --prefix docs-site run build
-Remove-Item -Recurse -Force dist, build, *.egg-info -ErrorAction SilentlyContinue
+Remove-Item -Recurse -Force dist, build, riskbands.egg-info -ErrorAction SilentlyContinue
 .\.venv-v210-spark\Scripts\python.exe -m build
 .\.venv-v210-spark\Scripts\python.exe -m twine check dist/*
 ```
@@ -103,23 +139,21 @@ Remove-Item -Recurse -Force dist, build, *.egg-info -ErrorAction SilentlyContinu
 Wheel smoke test, base install:
 
 ```powershell
-python -m venv .pytest_tmp\v230-smoke-base
-.\.pytest_tmp\v230-smoke-base\Scripts\python.exe -m pip install --upgrade pip
-.\.pytest_tmp\v230-smoke-base\Scripts\python.exe -m pip install dist/riskbands-2.3.0-py3-none-any.whl
-.\.pytest_tmp\v230-smoke-base\Scripts\python.exe .\scripts\smoke_test_installed_package.py --expected-version 2.3.0 --expect-no-pyspark
-.\.pytest_tmp\v230-smoke-base\Scripts\python.exe -c "import importlib.util, riskbands; from riskbands import RiskBands, Binner; print('version:', riskbands.__version__); print('RiskBands is Binner:', RiskBands is Binner); print('pyspark_installed:', importlib.util.find_spec('pyspark') is not None); assert riskbands.__version__ == '2.3.0'; assert RiskBands is Binner; assert importlib.util.find_spec('pyspark') is None"
-.\.pytest_tmp\v230-smoke-base\Scripts\python.exe -m pip check
+python -m venv .pytest_tmp\v240-smoke-base
+.\.pytest_tmp\v240-smoke-base\Scripts\python.exe -m pip install --upgrade pip
+.\.pytest_tmp\v240-smoke-base\Scripts\python.exe -m pip install dist/riskbands-2.4.0-py3-none-any.whl
+.\.pytest_tmp\v240-smoke-base\Scripts\python.exe .\scripts\smoke_test_installed_package.py --expected-version 2.4.0 --expect-no-pyspark
+.\.pytest_tmp\v240-smoke-base\Scripts\python.exe -m pip check
 ```
 
 Wheel smoke test with the `spark` extra:
 
 ```powershell
-python -m venv .pytest_tmp\v230-smoke-spark
-.\.pytest_tmp\v230-smoke-spark\Scripts\python.exe -m pip install --upgrade pip
-.\.pytest_tmp\v230-smoke-spark\Scripts\python.exe -m pip install "dist/riskbands-2.3.0-py3-none-any.whl[spark]"
-.\.pytest_tmp\v230-smoke-spark\Scripts\python.exe .\scripts\smoke_test_installed_package.py --expected-version 2.3.0 --check-spark --expect-pyspark-major 3
-.\.pytest_tmp\v230-smoke-spark\Scripts\python.exe -c "import pyspark; print('pyspark:', pyspark.__version__); assert int(pyspark.__version__.split('.')[0]) == 3"
-.\.pytest_tmp\v230-smoke-spark\Scripts\python.exe -m pip check
+python -m venv .pytest_tmp\v240-smoke-spark
+.\.pytest_tmp\v240-smoke-spark\Scripts\python.exe -m pip install --upgrade pip
+.\.pytest_tmp\v240-smoke-spark\Scripts\python.exe -m pip install "dist/riskbands-2.4.0-py3-none-any.whl[spark]"
+.\.pytest_tmp\v240-smoke-spark\Scripts\python.exe .\scripts\smoke_test_installed_package.py --expected-version 2.4.0 --check-spark --expect-pyspark-major 3
+.\.pytest_tmp\v240-smoke-spark\Scripts\python.exe -m pip check
 ```
 
 Docs-site validation:
@@ -135,28 +169,30 @@ Both publication workflows require:
 
 - the workflow to run against a git tag, not a branch;
 - the tag name to match `v<pyproject version>`;
-- the package version to be stable, such as `2.3.0`.
+- the package version to be stable, such as `2.4.0`.
 
-For this target, the planned tag is `v2.3.0`. Do not create the tag during Sprint E3.
+For this target, the planned tag is `v2.4.0`. Do not create the tag during
+Sprint I.
 
 ## TestPyPI
 
-`publish-testpypi.yml` is optional but recommended when release preparation changes packaging, metadata, dependencies, or installation behavior.
+`publish-testpypi.yml` is optional but recommended when release preparation
+changes packaging, metadata, dependencies, or installation behavior.
 
 After a successful TestPyPI upload, smoke test with:
 
 ```powershell
-python -m venv .pytest_tmp\v230-testpypi
-.\.pytest_tmp\v230-testpypi\Scripts\python.exe -m pip install --upgrade pip
-.\.pytest_tmp\v230-testpypi\Scripts\python.exe -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ riskbands==2.3.0
-.\.pytest_tmp\v230-testpypi\Scripts\python.exe .\scripts\smoke_test_installed_package.py --expected-version 2.3.0 --expect-no-pyspark
-.\.pytest_tmp\v230-testpypi\Scripts\python.exe -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ "riskbands[spark]==2.3.0"
-.\.pytest_tmp\v230-testpypi\Scripts\python.exe .\scripts\smoke_test_installed_package.py --expected-version 2.3.0 --check-spark --expect-pyspark-major 3
+python -m venv .pytest_tmp\v240-testpypi
+.\.pytest_tmp\v240-testpypi\Scripts\python.exe -m pip install --upgrade pip
+.\.pytest_tmp\v240-testpypi\Scripts\python.exe -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ riskbands==2.4.0
+.\.pytest_tmp\v240-testpypi\Scripts\python.exe .\scripts\smoke_test_installed_package.py --expected-version 2.4.0 --expect-no-pyspark
+.\.pytest_tmp\v240-testpypi\Scripts\python.exe -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ "riskbands[spark]==2.4.0"
+.\.pytest_tmp\v240-testpypi\Scripts\python.exe .\scripts\smoke_test_installed_package.py --expected-version 2.4.0 --check-spark --expect-pyspark-major 3
 ```
 
 ## PyPI
 
-Run `publish-pypi.yml` manually on `v2.3.0` only after:
+Run `publish-pypi.yml` manually on `v2.4.0` only after:
 
 - local validation is complete and green;
 - `release-validation.yml` is green on the pushed tag;
@@ -167,7 +203,8 @@ Run `publish-pypi.yml` manually on `v2.3.0` only after:
 
 ## Docs Site
 
-`docs-deploy.yml` builds the site from `docs-site/` and deploys automatically on pushes to `main`.
+`docs-deploy.yml` builds the site from `docs-site/` and deploys automatically on
+pushes to `main`.
 
 To validate locally:
 
@@ -178,6 +215,9 @@ npm --prefix docs-site run build
 
 ## Failure Handling
 
-- If validation or packaging fails before publication, fix forward on the branch and tag only when the final version is ready.
-- If TestPyPI succeeds but smoke tests fail, do not publish to PyPI; prepare the next version instead.
-- If PyPI succeeds and a defect is found afterwards, yank the affected version and prepare a new stable version rather than replacing artifacts.
+- If validation or packaging fails before publication, fix forward on the branch
+  and tag only when the final version is ready.
+- If TestPyPI succeeds but smoke tests fail, do not publish to PyPI; prepare the
+  next version instead.
+- If PyPI succeeds and a defect is found afterwards, yank the affected version
+  and prepare a new stable version rather than replacing artifacts.

--- a/docs-site/src/content/docs/en/reference/release-notes.md
+++ b/docs-site/src/content/docs/en/reference/release-notes.md
@@ -3,6 +3,30 @@ title: "Release Notes"
 description: "High-level release milestones for the public package and the official documentation."
 ---
 
+## v2.4.0
+
+Type: compatible minor release preparation.
+
+Main points:
+
+- Spark transform supports `missing_policy="merge"` when a merge decision was learned, using native Spark expressions and `return_woe=False`
+- Spark fit with missing merge uses a controlled sampled-to-pandas path and records that the merge decision was learned on the sample
+- Spark validation/reporting adds `source_profile_`, sample-vs-source diagnostics, and `missing_sampling_diagnostics`
+- metadata, bundle outputs, and `audit_report.html` carry sampling caveats for Spark sampled fit
+- `audit_report.html` is a narrative standalone HTML report with embedded CSS, print-friendly layout, missing policy explanations, bundle inventory, validation alerts, and limitations
+- `export_bundle(...)` includes `audit_report.html` by default
+- docs-site includes a Reveal.js presentation gallery and RiskBands overview deck
+- pt-BR/en docs and examples cover missing policy, audit bundle/reporting, and Spark missing merge behavior
+
+Notes:
+
+- `missing_policy="standard"` remains the default
+- Spark-native full fit is not part of this release target
+- Spark `return_woe=True` is still not supported
+- no `temporal_stable`, `monotonic_neighbor`, custom merge criteria, opaque imputation, or PySpark 4.x support is added
+- the audit report supports review, but it does not replace independent formal validation or guarantee regulatory compliance
+- `joblib/PYSEC-2024-277` is handled as a documented `pip-audit` exception with no fixed version available; only that advisory is ignored, and the decision is recorded in `docs/security/pip_audit_exceptions.md`
+
 ## v2.3.0
 
 Type: compatible minor release.

--- a/docs-site/src/content/docs/en/technical/api-overview.md
+++ b/docs-site/src/content/docs/en/technical/api-overview.md
@@ -80,7 +80,7 @@ The API exposes two explicit strategies:
 - `standard`: compatible default with the current behavior
 - `separate_bin`: opt-in explicit `Missing` bin
 - `forbid`: error during `fit` or `transform` if selected features contain missing values
-- `merge`: opt-in pandas routing from the missing group to the closest regular bin learned during `fit`
+- `merge`: opt-in routing from the missing group to the closest regular bin learned during `fit`
 
 `merge` requires `missing_merge_criterion="nearest_event_rate"` or
 `missing_merge_criterion="nearest_woe"`. The first uses absolute event-rate
@@ -91,6 +91,11 @@ accepts `separate_bin` or `raise` for missing values that appear during
 These policies do not perform opaque imputation. In merge mode, `transform(...)`
 uses only the decision learned during `fit` and does not learn a new rule from
 application data.
+
+In Spark, `merge` uses the controlled sampled-to-pandas path for `fit` and
+applies the learned decision during `transform` with native Spark expressions
+and `return_woe=False`. Review sampling metadata, `source_profile_`, and
+`missing_sampling_diagnostics_` when `fit(validate=True)` is used.
 
 After `fit`, inspect `missing_profile_`, `missing_decision_log_`,
 `missing_merge_candidates_`, and `missing_merge_map_` to review volume, share,

--- a/docs-site/src/content/docs/en/technical/examples.md
+++ b/docs-site/src/content/docs/en/technical/examples.md
@@ -52,6 +52,8 @@ They show:
 - `missing_merge_candidates_`
 - bundle fields for missing policy and missing merge
 - optional guard for PySpark
+- Spark sampled-to-pandas for missing merge when the Spark extra is available
+- sampling caveats in validation, bundle, and audit report
 - comparison across `standard`, `separate_bin`, `forbid`, `merge + nearest_event_rate`, and `merge + nearest_woe`
 - synthetic credit-risk data without real or sensitive records
 

--- a/docs-site/src/content/docs/en/technical/installation.md
+++ b/docs-site/src/content/docs/en/technical/installation.md
@@ -24,7 +24,7 @@ pip install "riskbands[spark]"
 ```
 
 The base package does not install PySpark. The `spark` extra uses
-`pyspark>=3.5,<4`.
+`pyspark>=3.5.2,<4`.
 
 ## Development environment
 

--- a/docs-site/src/content/docs/en/technical/missing-policy.md
+++ b/docs-site/src/content/docs/en/technical/missing-policy.md
@@ -60,6 +60,12 @@ and the learned routing map is stored in `missing_merge_map_`. `transform(...)`
 uses only the fit-time decision; it does not learn a new rule from application
 data.
 
+In Spark, v2.4.0 supports the controlled sampled-to-pandas `fit` path and
+applies the learned decision during `transform` with native Spark expressions
+and `return_woe=False`. This is not Spark-native full fit: review the sampling
+metadata, `source_profile_`, and `missing_sampling_diagnostics_` when using
+`fit(validate=True)`.
+
 Compare merge against `separate_bin` before accepting the decision. The
 [`missing_policy_comparison_demo.py`](https://github.com/joaaomaia/RiskBands/blob/main/examples/missing_policy/missing_policy_comparison_demo.py)
 script builds a table with IV, number of bins, missing event rate, action,
@@ -125,9 +131,11 @@ It uses:
 - `spark.sql.shuffle.partitions=2`;
 - a small synthetic dataset;
 - `missing_policy="separate_bin"`;
+- the Spark sampled-to-pandas path for `missing_policy="merge"` when the Spark
+  extra is available;
 - `transform(validate=True)`;
 - `missing_policy="forbid"` producing a clear error;
-- an explicit boundary for `missing_policy="merge"` in PySpark;
+- sampling caveats for Spark missing merge;
 - no UDF.
 
 ```bash
@@ -147,6 +155,8 @@ After `fit(...)`, look at:
 - `missing_decision_log_`
 - `fit_profile_`, `reference_profile_`, and `application_profile_` when
   validation is enabled.
+- `source_profile_` and `missing_sampling_diagnostics_` when Spark fit with
+  missing merge uses sampled-to-pandas.
 
 `missing_profile_` shows volume, share, events, event rate, backend, context,
 and whether the row represents a missing bin. `missing_decision_log_` records
@@ -164,6 +174,8 @@ the action taken per variable.
 - `missing_merge_fallback`
 - `missing_merge_candidates`
 - `missing_merge_map`
+- `missing_sampling_diagnostics` when Spark sampled-to-pandas creates sampling
+  diagnostics
 
 ```python
 from riskbands.reporting import load_bundle
@@ -184,7 +196,8 @@ This page documents the current contract. There are not yet:
 - `temporal_stable` as a merge criterion;
 - `monotonic_neighbor` as a merge criterion;
 - merge criteria beyond `nearest_event_rate` and `nearest_woe`;
-- complete PySpark merge support;
+- Spark-native full fit for missing merge;
+- Spark `return_woe=True`;
 - intelligent imputation inside RiskBands;
 - fully distributed statistical fitting in Spark.
 

--- a/docs-site/src/content/docs/en/technical/outputs.md
+++ b/docs-site/src/content/docs/en/technical/outputs.md
@@ -80,7 +80,8 @@ bundle must omit the narrative HTML.
 Bundles also persist the missing-values trail when available:
 `missing_policy`, `effective_missing_policy`, `missing_profile`,
 `missing_decision_log`, `missing_merge_criterion`, `missing_merge_fallback`,
-`missing_merge_candidates`, and `missing_merge_map`.
+`missing_merge_candidates`, `missing_merge_map`, and, for Spark
+sampled-to-pandas fit, `missing_sampling_diagnostics`.
 
 These fields record the missing-values treatment decision. They do not
 represent opaque imputation.
@@ -91,6 +92,11 @@ variable. Use `missing_decision_log_` to see whether the action was to preserve
 route missing values with `merge`. For merge, use `missing_merge_candidates_`
 to review candidates and distances and `missing_merge_map_` to see the learned
 destination.
+
+For Spark sampled-to-pandas fit, also review `source_profile_`,
+`reference_profile_`, `fit_validation_report_["sample_representativeness"]`,
+and `missing_sampling_diagnostics_` to understand the gap between the fit sample
+and the Spark source.
 
 Dedicated guide: [Missing policy](../missing-policy/).
 

--- a/docs-site/src/content/docs/reference/release-notes.md
+++ b/docs-site/src/content/docs/reference/release-notes.md
@@ -3,6 +3,30 @@ title: "Release Notes"
 description: "Marcos de release em alto nível para o pacote público e para a documentação oficial."
 ---
 
+## v2.4.0
+
+Type: compatible minor release preparation.
+
+Main points:
+
+- Spark transform supports `missing_policy="merge"` when a merge decision was learned, using native Spark expressions and `return_woe=False`
+- Spark fit with missing merge uses a controlled sampled-to-pandas path and records that the merge decision was learned on the sample
+- Spark validation/reporting adds `source_profile_`, sample-vs-source diagnostics, and `missing_sampling_diagnostics`
+- metadata, bundle outputs, and `audit_report.html` carry sampling caveats for Spark sampled fit
+- `audit_report.html` is a narrative standalone HTML report with embedded CSS, print-friendly layout, missing policy explanations, bundle inventory, validation alerts, and limitations
+- `export_bundle(...)` includes `audit_report.html` by default
+- docs-site includes a Reveal.js presentation gallery and RiskBands overview deck
+- pt-BR/en docs and examples cover missing policy, audit bundle/reporting, and Spark missing merge behavior
+
+Notes:
+
+- `missing_policy="standard"` remains the default
+- Spark-native full fit is not part of this release target
+- Spark `return_woe=True` is still not supported
+- no `temporal_stable`, `monotonic_neighbor`, custom merge criteria, opaque imputation, or PySpark 4.x support is added
+- the audit report supports review, but it does not replace independent formal validation or guarantee regulatory compliance
+- `joblib/PYSEC-2024-277` is handled as a documented `pip-audit` exception with no fixed version available; only that advisory is ignored, and the decision is recorded in `docs/security/pip_audit_exceptions.md`
+
 ## v2.3.0
 
 Type: compatible minor release.

--- a/docs-site/src/content/docs/technical/api-overview.md
+++ b/docs-site/src/content/docs/technical/api-overview.md
@@ -80,7 +80,7 @@ A API expõe duas estratégias explícitas:
 - `standard`: default compatível com o comportamento atual
 - `separate_bin`: opt-in para bin explícito `Missing`
 - `forbid`: erro em `fit` ou `transform` quando ha missing nas features selecionadas
-- `merge`: opt-in pandas para rotear missing ao bin regular mais próximo aprendido no `fit`
+- `merge`: opt-in para rotear missing ao bin regular mais próximo aprendido no `fit`
 
 `merge` exige `missing_merge_criterion="nearest_event_rate"` ou
 `missing_merge_criterion="nearest_woe"`. O primeiro usa distância absoluta de
@@ -91,6 +91,11 @@ decisão aprendida no `fit`.
 Essas políticas não fazem imputação opaca. Em merge, `transform(...)` usa
 somente a decisão aprendida no `fit` e não aprende regra nova com a base de
 aplicação.
+
+Em Spark, `merge` usa o caminho controlado sampled-to-pandas para `fit` e
+aplica a decisão aprendida no `transform` com expressões Spark nativas e
+`return_woe=False`. Revise metadados de amostragem, `source_profile_` e
+`missing_sampling_diagnostics_` quando `fit(validate=True)` for usado.
 
 Depois do `fit`, inspecione `missing_profile_`, `missing_decision_log_`,
 `missing_merge_candidates_` e `missing_merge_map_` para revisar volume, share,

--- a/docs-site/src/content/docs/technical/examples.md
+++ b/docs-site/src/content/docs/technical/examples.md
@@ -52,6 +52,8 @@ Eles mostram:
 - `missing_merge_candidates_`
 - bundle com campos de missing policy e missing merge
 - guarda opcional para PySpark
+- Spark sampled-to-pandas para missing merge quando o extra Spark esta disponivel
+- caveats de amostragem em validacao, bundle e audit report
 - comparação entre `standard`, `separate_bin`, `forbid`, `merge + nearest_event_rate` e `merge + nearest_woe`
 - exemplo sintético de risco de crédito sem dados reais
 

--- a/docs-site/src/content/docs/technical/installation.md
+++ b/docs-site/src/content/docs/technical/installation.md
@@ -23,7 +23,7 @@ Para usar os caminhos opcionais de fit/transform com PySpark:
 pip install "riskbands[spark]"
 ```
 
-O pacote base nao instala PySpark. O extra `spark` usa `pyspark>=3.5,<4`.
+O pacote base não instala PySpark. O extra `spark` usa `pyspark>=3.5.2,<4`.
 
 ## Ambiente de desenvolvimento
 

--- a/docs-site/src/content/docs/technical/missing-policy.md
+++ b/docs-site/src/content/docs/technical/missing-policy.md
@@ -59,6 +59,12 @@ candidatos ficam em `missing_merge_candidates_`, e o mapa aprendido fica em
 `missing_merge_map_`. O `transform(...)` usa apenas essa decisao aprendida no
 fit; ele nao aprende regra nova com a base de aplicacao.
 
+Em Spark, a v2.4.0 suporta o caminho controlado sampled-to-pandas para `fit` e
+aplica a decisao aprendida no `transform` com expressoes Spark nativas e
+`return_woe=False`. Isso nao e Spark-native full fit: revise os metadados de
+amostragem, `source_profile_` e `missing_sampling_diagnostics_` quando usar
+`fit(validate=True)`.
+
 Compare merge contra `separate_bin` antes de aceitar a decisao. O script
 [`missing_policy_comparison_demo.py`](https://github.com/joaaomaia/RiskBands/blob/main/examples/missing_policy/missing_policy_comparison_demo.py)
 gera uma tabela com IV, numero de bins, evento do missing, acao tomada, bin
@@ -125,9 +131,11 @@ Ele usa:
 - `spark.sql.shuffle.partitions=2`;
 - dataset sintetico pequeno;
 - `missing_policy="separate_bin"`;
+- caminho Spark sampled-to-pandas para `missing_policy="merge"` quando o extra
+  Spark esta disponivel;
 - `transform(validate=True)`;
 - `missing_policy="forbid"` gerando erro claro;
-- boundary explicito para `missing_policy="merge"` em PySpark;
+- caveats de amostragem para missing merge em Spark;
 - nenhum UDF.
 
 ```bash
@@ -147,6 +155,8 @@ Apos `fit(...)`, olhe:
 - `missing_decision_log_`
 - `fit_profile_`, `reference_profile_` e `application_profile_` quando houver
   validacao.
+- `source_profile_` e `missing_sampling_diagnostics_` quando Spark fit com
+  missing merge usa sampled-to-pandas.
 
 `missing_profile_` mostra volume, share, eventos, event rate, backend, contexto
 e se a linha representa bin missing. `missing_decision_log_` registra a acao
@@ -164,6 +174,8 @@ tomada por variavel.
 - `missing_merge_fallback`
 - `missing_merge_candidates`
 - `missing_merge_map`
+- `missing_sampling_diagnostics` quando Spark sampled-to-pandas gera
+  diagnosticos de amostragem
 
 ```python
 from riskbands.reporting import load_bundle
@@ -184,7 +196,8 @@ Esta pagina documenta o contrato atual. Ainda nao existem:
 - `temporal_stable` como criterio de merge;
 - `monotonic_neighbor` como criterio de merge;
 - criterios de merge alem de `nearest_event_rate` e `nearest_woe`;
-- PySpark merge completo;
+- Spark-native full fit para missing merge;
+- Spark `return_woe=True`;
 - imputacao inteligente dentro do RiskBands;
 - fitting estatistico totalmente distribuido em Spark.
 

--- a/docs-site/src/content/docs/technical/outputs.md
+++ b/docs-site/src/content/docs/technical/outputs.md
@@ -80,7 +80,8 @@ manter o bundle sem o HTML narrativo.
 Bundles também persistem a trilha de missing values quando disponível:
 `missing_policy`, `effective_missing_policy`, `missing_profile`,
 `missing_decision_log`, `missing_merge_criterion`, `missing_merge_fallback`,
-`missing_merge_candidates` e `missing_merge_map`.
+`missing_merge_candidates`, `missing_merge_map` e, em Spark sampled-to-pandas,
+`missing_sampling_diagnostics`.
 
 Esses campos registram a decisão de tratamento de missing values. Eles não
 representam imputação opaca.
@@ -91,6 +92,11 @@ variável. Use `missing_decision_log_` para ver se a ação foi preservar
 rotear missing com `merge`. Para merge, use `missing_merge_candidates_` para
 revisar candidatos e distâncias e `missing_merge_map_` para ver o destino
 aprendido.
+
+Em Spark sampled-to-pandas, revise também `source_profile_`,
+`reference_profile_`, `fit_validation_report_["sample_representativeness"]` e
+`missing_sampling_diagnostics_` para entender a distância entre a amostra usada
+no fit e a fonte Spark.
 
 Guia dedicado: [Missing policy](../missing-policy/).
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -15,7 +15,7 @@ from riskbands import (
 
 Current version:
 
-- `2.3.0`
+- `2.4.0`
 
 ## `RiskBands` / `Binner`
 
@@ -92,7 +92,7 @@ Missing policy semantics:
 - `standard`: preserves the current missing-value behavior and is the default.
 - `separate_bin`: creates an explicit, auditable `Missing` bin.
 - `forbid`: raises a clear error in `fit` or `transform` when selected features contain missing values.
-- `merge`: learns a fit-time destination for the missing group and routes missing values to the selected regular bin during pandas transform.
+- `merge`: learns a fit-time destination for the missing group and routes missing values to the selected regular bin during pandas transform or supported Spark transform.
 
 For `merge`, use one supported criterion:
 
@@ -101,7 +101,13 @@ For `merge`, use one supported criterion:
 
 The decision is learned only during `fit(...)`; `transform(...)` does not use application target values, application event rates, application WoE, or out-of-time distributions to retarget missing values.
 
-No opaque missing-value imputation is added. The v2.3.0 merge contract does not include `temporal_stable`, `monotonic_neighbor`, custom criteria, or full PySpark merge routing.
+Spark support for `merge` is deliberately narrow. Spark fit uses a controlled
+sampled-to-pandas path and records that the merge decision was learned on the
+sample, not on a Spark-native full-data fit. Spark transform applies learned
+merge decisions with native Spark expressions and currently supports
+`return_woe=False` only. No opaque missing-value imputation is added. The
+v2.4.0 merge contract does not include `temporal_stable`, `monotonic_neighbor`,
+custom criteria, Spark-native full fit, or Spark `return_woe=True`.
 
 For user guidance and runnable examples, see
 [`docs/missing_policy_user_guide.md`](missing_policy_user_guide.md) and:
@@ -142,6 +148,7 @@ Main attributes after `fit`:
 - `transform_validation_report_` when `transform(validate=True)` was requested
 - `validation_report_` as the latest validation report compatibility alias
 - `fit_profile_`, `source_profile_`, and `reference_profile_` when available
+- `missing_sampling_diagnostics_` when Spark sampled-to-pandas fit creates sampling diagnostics
 - `missing_policy_`, `effective_missing_policy_`, `missing_profile_`, and `missing_decision_log_`
 - `missing_merge_criterion_`, `missing_merge_fallback_`, `missing_merge_candidates_`, and `missing_merge_map_` when merge is enabled
 - `iv_`
@@ -210,11 +217,17 @@ Main attributes after `fit`:
 - `audit_report.html` by default, unless `include_audit_report=False`
 - per-feature tables under `feature_tables/`
 - parquet artifacts when the environment has parquet support available
+- sampling metadata and `missing_sampling_diagnostics` when Spark sampled-to-pandas fit is used
 
 `export_audit_report(path, title=None, dataset_name=None)` creates a standalone
 HTML narrative report with embedded CSS and no external assets. It explains the
 model configuration, variables, missing policies, missing merge decisions,
 merge candidates, validation alerts, bundle inventory, and known limitations.
+
+When Spark sampled-to-pandas fit is used for missing merge, the report and
+bundle metadata carry the sampling caveat, source/sample row counts when
+available, and diagnostics that help reviewers see whether source missing values
+were represented in the sample.
 
 The report is print-friendly and can be exported to PDF by the browser. Native
 PDF export is not part of the public API in this release. The report organizes

--- a/docs/audit_bundle_narrative_report.md
+++ b/docs/audit_bundle_narrative_report.md
@@ -61,6 +61,11 @@ the selected destination bin, the criterion (`nearest_event_rate` or
 the learned decision instead of recalculating event rate or WoE on application
 data.
 
+For Spark sampled-to-pandas fit, the report also surfaces the sampling caveat,
+source/sample row counts when available, source profile status, and
+`missing_sampling_diagnostics`. These fields help reviewers distinguish a merge
+decision learned on the sample from evidence observed on the full Spark source.
+
 ## Bundle Inventory
 
 The report explains common bundle files, including:
@@ -75,6 +80,7 @@ The report explains common bundle files, including:
 - `missing_profile.csv`;
 - `missing_decision_log.csv`;
 - `missing_merge_candidates.csv`;
+- sampling diagnostics when Spark sampled-to-pandas fit produced them;
 - `feature_tables/`;
 - `audit_report.html`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,12 +27,20 @@ Entry point for the project documentation.
   Methodological guidance for choosing missing policies and reviewing merge decisions.
 - [docs/audit_bundle_narrative_report.md](audit_bundle_narrative_report.md)
   Guide for the standalone narrative audit report generated as `audit_report.html`.
+- [docs/releases/2.4.0.md](releases/2.4.0.md)
+  v2.4.0 release-prep notes for Spark missing merge, audit bundle reporting, public docs, examples, and the Reveal.js gallery.
 - [docs/releases/2.3.0.md](releases/2.3.0.md)
   v2.3.0 release-prep notes for auditable missing merge policies.
 - [docs/missing_merge_nearest_event_rate_design.md](missing_merge_nearest_event_rate_design.md)
   Internal design note for `missing_merge_criterion="nearest_event_rate"`.
 - [docs/missing_merge_nearest_woe_design.md](missing_merge_nearest_woe_design.md)
   Internal design note for `missing_merge_criterion="nearest_woe"`.
+- [docs/pyspark_missing_merge_transform_design.md](pyspark_missing_merge_transform_design.md)
+  Design note for Spark transform with learned missing merge decisions.
+- [docs/pyspark_missing_merge_sampled_fit_design.md](pyspark_missing_merge_sampled_fit_design.md)
+  Design note for Spark sampled-to-pandas fit with missing merge.
+- [docs/pyspark_missing_merge_validation_reporting_design.md](pyspark_missing_merge_validation_reporting_design.md)
+  Design note for Spark sampled-fit validation, reporting, and caveats.
 - [docs/migration.md](migration.md)
   Breaking migration guide for users coming from `NASABinning`.
 - [examples/README.md](../examples/README.md)

--- a/docs/missing_merge_nearest_event_rate_design.md
+++ b/docs/missing_merge_nearest_event_rate_design.md
@@ -93,15 +93,13 @@ Bundle export and JSON/Excel report paths persist the merge audit fields.
 
 ## PySpark Boundary
 
-v2.3.0 does not implement PySpark merge routing. PySpark fit or transform with
-`missing_policy="merge"` raises:
+v2.4.0 supports Spark missing merge through the narrow sampled-to-pandas fit and
+native Spark transform path documented in the PySpark design notes. It does not
+implement Spark-native full-data merge learning or Spark `return_woe=True`.
 
-```text
-missing_policy="merge" with PySpark is not implemented in this release. Use pandas fit/transform or missing_policy="separate_bin"/"forbid".
-```
-
-Existing Spark behavior for `standard`, `separate_bin`, and `forbid` remains in
-scope and is covered by Spark regression tests.
+Existing Spark behavior for `standard`, `separate_bin`, `forbid`, sampled
+missing merge fit, native missing merge transform, and validation/reporting
+diagnostics is covered by Spark regression tests.
 
 ## Relationship To Nearest WOE
 
@@ -120,7 +118,7 @@ The detailed E2 design is documented in
 - No `monotonic_neighbor` criterion.
 - No custom criterion.
 - No threshold tuning beyond exact nearest event-rate distance.
-- No full PySpark implementation.
+- No Spark-native full-data fit or Spark `return_woe=True`.
 - No use of transform/OOT target data to choose a merge destination.
 
 ## Future Work

--- a/docs/missing_merge_nearest_woe_design.md
+++ b/docs/missing_merge_nearest_woe_design.md
@@ -98,10 +98,13 @@ distance metric, event-rate distance, and WOE distance.
 
 ## PySpark Boundary
 
-PySpark merge remains intentionally unsupported in v2.3.0. Fit or transform with
-`missing_policy="merge"` raises a clear `NotImplementedError` for both
-`nearest_event_rate` and `nearest_woe`. Existing PySpark behavior for
-`separate_bin` and `forbid` remains covered by regression tests.
+v2.4.0 supports Spark missing merge through the narrow sampled-to-pandas fit and
+native Spark transform path documented in the PySpark design notes. This applies
+to both `nearest_event_rate` and `nearest_woe`, with sampling caveats captured in
+metadata, bundle, validation reports, and `audit_report.html`.
+
+Spark-native full-data merge learning and Spark `return_woe=True` remain outside
+the current public contract.
 
 ## Out Of Scope
 
@@ -111,5 +114,6 @@ E2 does not implement:
 - `monotonic_neighbor`
 - custom criteria
 - advanced thresholds
-- full PySpark merge routing
+- Spark-native full-data merge learning
+- Spark `return_woe=True`
 - publication, tags, or automatic pushes

--- a/docs/missing_policy_methodological_guide.md
+++ b/docs/missing_policy_methodological_guide.md
@@ -1,7 +1,7 @@
 # Missing policy methodological guide
 
 This guide helps reviewers choose among the RiskBands missing-value policies in
-v2.3.0. It is methodological guidance, not a regulatory certification. Every
+v2.4.0. It is methodological guidance, not a regulatory certification. Every
 choice should still be reviewed against the project data, controls, sampling
 design, and model-governance process.
 
@@ -85,11 +85,17 @@ production contract, not convenience.
 
 ## PySpark boundary
 
-In v2.3.0, full PySpark merge is intentionally not implemented. PySpark fit or
-transform with `missing_policy="merge"` raises an explicit
-`NotImplementedError`. PySpark remains available for supported policies such as
-`standard`, `separate_bin`, and `forbid`, including validation paths covered by
-the test suite.
+In v2.4.0, PySpark missing merge is supported only through the narrow audited
+path documented in the Spark design notes. Spark fit uses controlled
+sampled-to-pandas fitting and records that the merge decision was learned on
+the sample, not through Spark-native full-data learning. Spark transform applies
+learned merge decisions with native Spark expressions and `return_woe=False`.
+
+Review `source_profile_`, `fit_validation_report_["sample_representativeness"]`,
+`missing_sampling_diagnostics_`, bundle metadata, and `audit_report.html`
+sampling caveats before accepting a sampled Spark merge decision. Warnings such
+as source missing values not seen in the sample are review signals, not
+automatic approvals or failures.
 
 ## Not implemented in this release
 
@@ -98,8 +104,8 @@ available behavior:
 
 - `temporal_stable`;
 - `monotonic_neighbor`;
-- full PySpark missing merge.
+- Spark-native full-data missing merge fit.
 
 Use the current audit artifacts to compare policies today. Do not infer that
 future criteria already exist, and do not create local policy names outside the
-public v2.3.0 contract.
+public v2.4.0 contract.

--- a/docs/missing_policy_user_guide.md
+++ b/docs/missing_policy_user_guide.md
@@ -2,7 +2,7 @@
 
 Este guia explica como usar `missing_policy` no RiskBands em fluxos pandas e
 PySpark, com foco em risco de credito, auditabilidade e revisao defensavel do
-binning. Ele reflete a preparacao da v2.3.0 para merge auditavel de missing
+binning. Ele reflete a preparacao da v2.4.0 para merge auditavel de missing
 values, sem afirmar publicacao.
 
 ## Por que missing values importam
@@ -90,9 +90,11 @@ Essa politica nao faz imputacao opaca. Ela separa missing como bin observavel.
 
 ## `merge`
 
-`merge` e uma politica opt-in para pandas. Ela primeiro trata missing como grupo
+`merge` e uma politica opt-in. Em pandas, ela primeiro trata missing como grupo
 observavel no `fit`, depois escolhe um bin regular de destino com criterio
-explicito e auditavel.
+explicito e auditavel. Em Spark, a v2.4.0 suporta o caminho controlado
+sampled-to-pandas para `fit` e aplica a decisao aprendida no `transform` com
+expressoes Spark nativas e `return_woe=False`.
 
 ```python
 binner = RiskBands(
@@ -222,7 +224,9 @@ spark_binned = binner.transform(
 ```
 
 O exemplo usa `SparkSession` local pequena, `spark.sql.shuffle.partitions=2`,
-nao usa UDF e coleta apenas uma amostra pequena para demonstracao.
+nao usa UDF e coleta apenas uma amostra pequena para demonstracao. Quando
+`missing_policy="merge"` e usado em Spark, a decisao de merge e aprendida na
+amostra pandas controlada, nao em um fit Spark-native completo.
 
 ## Como inspecionar a trilha
 
@@ -235,6 +239,8 @@ Apos `fit(...)`, os principais campos sao:
 - `missing_decision_log_`: decisao por variavel, acao tomada e observacoes.
 - `fit_profile_`, `source_profile_`, `reference_profile_` e
   `application_profile_`: perfis usados em validacao e monitoramento.
+- `missing_sampling_diagnostics_`: diagnosticos de amostragem quando Spark fit
+  usa sampled-to-pandas para missing merge.
 
 Exemplo:
 
@@ -255,6 +261,8 @@ decisions = binner.missing_decision_log_
 - `missing_merge_fallback`
 - `missing_merge_candidates`
 - `missing_merge_map`
+- `missing_sampling_diagnostics` quando o fit Spark sampled-to-pandas gera
+  diagnosticos de amostragem
 
 ```python
 from riskbands.reporting import load_bundle
@@ -271,12 +279,14 @@ compatibilidade.
 
 ## O que ainda nao existe
 
-Na preparacao v2.3.0, o escopo e propositalmente estreito. Ainda nao existem:
+Na preparacao v2.4.0, o escopo segue propositalmente estreito. Ainda nao
+existem:
 
 - `temporal_stable` como criterio de merge;
 - `monotonic_neighbor` como criterio de merge;
 - criterios de merge alem de `nearest_event_rate` e `nearest_woe`;
-- PySpark merge completo;
+- Spark-native full fit para missing merge;
+- Spark `return_woe=True`;
 - imputacao inteligente dentro do RiskBands;
 - backend Spark distribuido completo para o fitting estatistico.
 

--- a/docs/pyspark_missing_merge_sampled_fit_design.md
+++ b/docs/pyspark_missing_merge_sampled_fit_design.md
@@ -95,9 +95,9 @@ allowed only for:
 - the one-row empty-sample fallback;
 - aggregate missing-count/profile helpers with row guards.
 
-## G3 candidates
+## Release boundary
 
-- Decide whether Spark-native missing merge fit is needed.
-- Decide whether bundle loading should reconstruct a callable estimator.
-- Consider stratified or representativeness-aware sampling controls without
-  changing the G2 merge criteria.
+The v2.4.0 release-prep documents this sampled-to-pandas path as the supported
+Spark fit boundary for missing merge. Spark-native full fit, callable estimator
+reconstruction from `load_bundle(...)`, and additional sampling controls remain
+future work unless explicitly scoped in a later release.

--- a/docs/pyspark_missing_merge_transform_design.md
+++ b/docs/pyspark_missing_merge_transform_design.md
@@ -101,7 +101,9 @@ G1B adds tests that inspect the direct Spark transform methods and block acciden
 
 Collection remains allowed only in named aggregate/profile helpers, such as missing-count aggregation for fallback `raise` and bounded validation profile collection.
 
-## Next steps
+## Release boundary
 
-- G3: decide whether Spark-native missing merge fit or reconstructed callable estimators from bundle are required.
-- G4: update public docs and release notes only after functional gates are accepted.
+The v2.4.0 release-prep documents this as supported Spark missing merge
+behavior with the limits above. Spark-native full fit, Spark `return_woe=True`,
+and callable estimator reconstruction from `load_bundle(...)` remain outside
+the current public contract.

--- a/docs/releases/2.4.0.md
+++ b/docs/releases/2.4.0.md
@@ -1,0 +1,95 @@
+# RiskBands 2.4.0
+
+Type: compatible minor release preparation.
+
+## Positioning
+
+RiskBands v2.4.0 prepares the Spark, audit bundle, and public documentation
+surface accumulated after v2.3.0. This release preparation does not publish to
+PyPI, create a tag, or push automatically.
+
+## Added
+
+- Spark transform support for `missing_policy="merge"` after a learned merge
+  decision, using native Spark expressions and `return_woe=False`.
+- Spark sampled-to-pandas fit for `missing_policy="merge"`, preserving the
+  existing pandas merge engine while recording that the merge decision was
+  learned on a controlled sample.
+- Spark validation/reporting diagnostics for sampled missing merge, including
+  `source_profile_`, sample-vs-source comparisons, and
+  `missing_sampling_diagnostics`.
+- Sampling caveats in metadata, bundle outputs, and `audit_report.html`.
+- Narrative `audit_report.html` with embedded CSS, print-friendly layout,
+  bundle inventory, missing policy explanations, merge decisions, validation
+  alerts, and limitations.
+- Bundle integration for the narrative audit report through
+  `export_bundle(..., include_audit_report=True)`.
+- Docs-site presentation gallery with a Reveal.js RiskBands overview deck.
+- Public pt-BR/en documentation and runnable examples for missing policy,
+  audit bundle/reporting, and Spark missing merge behavior.
+
+## Compatibility
+
+- `missing_policy="standard"` remains the default.
+- `missing_policy="separate_bin"`, `missing_policy="forbid"`, and pandas
+  `missing_policy="merge"` remain compatible.
+- `missing_merge_criterion="nearest_event_rate"` and
+  `missing_merge_criterion="nearest_woe"` remain the only merge criteria.
+- `missing_merge_fallback="separate_bin"` and
+  `missing_merge_fallback="raise"` remain supported.
+- `score_strategy="standard"` remains canonical; `legacy` remains a
+  compatibility alias.
+- `RiskBands is Binner` remains true.
+- Base installation does not install PySpark.
+- The Spark extra remains constrained to `pyspark>=3.5.2,<4`.
+
+## Spark Contract
+
+Spark missing merge uses a narrow, auditable boundary:
+
+```text
+Spark DataFrame -> controlled sample -> pandas core fit -> Spark transform
+```
+
+The merge decision is learned by the pandas core on sampled fit rows, not by a
+Spark-native full-data fitting backend. Spark transform applies the learned
+decision with native expressions. `transform(validate=True)` may build bounded
+aggregate profiles and compare application/source profiles without learning a
+new merge destination from application data.
+
+## Known Limits
+
+- Spark-native full fit is not part of this release target.
+- Spark `return_woe=True` is still not supported.
+- No new merge criteria are added.
+- `temporal_stable` and `monotonic_neighbor` are not implemented as merge
+  criteria.
+- Native PDF export for `audit_report.html` is not part of the public API; use
+  browser print/export when a PDF is needed.
+- The narrative report organizes evidence for review, but it does not replace
+  independent formal validation or constitute regulatory certification.
+
+## Security Audit Exception
+
+The standard `python -m pip_audit` command reports `joblib/PYSEC-2024-277`
+with no fixed version available. The advisory is a disputed deserialization
+risk around loading untrusted `joblib`/pickle artifacts.
+
+RiskBands does not load untrusted `joblib`/pickle artifacts as part of the
+public workflow, and release-prep keeps `pip-audit` active with a documented
+single-advisory exception:
+
+```bash
+python -m pip_audit --ignore-vuln PYSEC-2024-277
+```
+
+The rationale and review requirement are recorded in
+`docs/security/pip_audit_exceptions.md`. This exception must be revisited in a
+future release and removed when an actionable upstream fix or corrected advisory
+metadata is available.
+
+## Documentation
+
+The release-prep updates README, `docs/`, docs-site pt-BR/en pages, examples,
+release notes, checklist, and release-prep report. It does not create a tag,
+publish to PyPI/TestPyPI, run `twine upload`, or push automatically.

--- a/docs/releases/2.4.0_publication_checklist.md
+++ b/docs/releases/2.4.0_publication_checklist.md
@@ -1,0 +1,105 @@
+# RiskBands 2.4.0 Publication Checklist
+
+## Scope
+
+- [x] Version target: `2.4.0`
+- [x] Branch: `release/v2.4.0-prep`
+- [x] Planned tag after review: `v2.4.0`
+- [x] No local `v2.4.0` tag observed during preflight
+- [x] No remote `v2.4.0` tag observed during preflight
+- [x] No tag created during Sprint I
+- [x] No PyPI/TestPyPI upload
+- [x] No `twine upload`
+- [x] No `publish-pypi.yml` dispatch
+- [x] No automatic push
+- [x] `.agents/` and `.codex/` kept out of edits and release artifacts
+- [x] `PYSEC-2024-277` security exception documented and scoped to joblib only
+
+## Release Surface
+
+- [x] Spark transform for `missing_policy="merge"`
+- [x] Spark transform hardening for missing, fallback, unknown categories, and `return_woe=False`
+- [x] Spark sampled-to-pandas fit for missing merge
+- [x] Spark validation/reporting with source profile and sample-vs-source diagnostics
+- [x] Sampling caveats in metadata, bundle, and audit report
+- [x] Narrative standalone `audit_report.html`
+- [x] Audit report included in bundle by default
+- [x] Public docs pt-BR/en updated
+- [x] Reveal.js presentation gallery validated in docs-site build
+- [x] Examples smoke validated
+
+## Validation Matrix
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| Version import | PASS | `2.4.0 True` |
+| Public API tests | PASS | `20 passed` |
+| Examples smoke | PASS | `9 passed` |
+| Bundle/audit report tests | PASS | `39 passed` |
+| Spark missing merge targeted | PASS | `61 passed` |
+| Spark full | PASS | `98 passed, 334 deselected` after PySpark fix |
+| Full pytest | PASS | `432 passed` |
+| Ruff | PASS | `All checks passed!` |
+| Bandit | PASS | exit code 0 |
+| Docs-site build | PASS | `42 page(s) built` |
+| Build | PASS | `riskbands-2.4.0.tar.gz`, `riskbands-2.4.0-py3-none-any.whl` |
+| Twine check | PASS | both v2.4.0 artifacts passed |
+| Smoke base | PASS | version `2.4.0`, `RiskBands is Binner=True`, `pyspark_installed=False`, `pip check` OK |
+| Smoke spark | PASS | version `2.4.0`, `RiskBands is Binner=True`, `pyspark=3.5.8`, `pip check` OK |
+| Pip-audit exact | KNOWN FAIL | `joblib 1.5.3 PYSEC-2024-277`, no fix version |
+| Pip-audit with documented joblib exception | PASS | `No known vulnerabilities found`; `PYSEC-2024-277` ignored by command flag |
+
+## Security Exception
+
+`python -m pip_audit` still reports `joblib/PYSEC-2024-277`. The advisory has
+no `fix_versions` in pip-audit and is described as disputed by the supplier.
+The risk class is loading untrusted `joblib`/pickle artifacts, which can execute
+arbitrary code during deserialization.
+
+RiskBands does not load untrusted `joblib`/pickle artifacts as part of the
+public workflow. RiskBands bundles use auditable formats such as JSON, CSV, and
+HTML where applicable.
+
+Maintainer decision for v2.4.0 release-prep: keep `pip-audit` enabled and
+ignore only `PYSEC-2024-277`, documented in
+`docs/security/pip_audit_exceptions.md`.
+
+Approved command:
+
+```powershell
+python -m pip_audit --ignore-vuln PYSEC-2024-277
+```
+
+This decision must be revisited during the next release-prep cycle. The
+exception should be removed if a fixed joblib version or corrected advisory
+metadata becomes available. The actionable PySpark advisory was fixed by
+changing the Spark extra to `pyspark>=3.5.2,<4` and validating with
+`pyspark 3.5.8`.
+
+## Manual Post-Merge Plan
+
+Run only after review approval and merge:
+
+```powershell
+git switch main
+git pull --ff-only
+git tag -a v2.4.0 -m "Release v2.4.0"
+git push origin v2.4.0
+gh workflow run publish-pypi.yml --ref v2.4.0
+```
+
+After the PyPI workflow is green:
+
+```powershell
+python -m venv .pytest_tmp\v240-pypi-smoke-base
+.\.pytest_tmp\v240-pypi-smoke-base\Scripts\python.exe -m pip install --upgrade pip
+.\.pytest_tmp\v240-pypi-smoke-base\Scripts\python.exe -m pip install riskbands==2.4.0
+.\.pytest_tmp\v240-pypi-smoke-base\Scripts\python.exe .\scripts\smoke_test_installed_package.py --expected-version 2.4.0 --expect-no-pyspark
+
+python -m venv .pytest_tmp\v240-pypi-smoke-spark
+.\.pytest_tmp\v240-pypi-smoke-spark\Scripts\python.exe -m pip install --upgrade pip
+.\.pytest_tmp\v240-pypi-smoke-spark\Scripts\python.exe -m pip install "riskbands[spark]==2.4.0"
+.\.pytest_tmp\v240-pypi-smoke-spark\Scripts\python.exe .\scripts\smoke_test_installed_package.py --expected-version 2.4.0 --check-spark --expect-pyspark-major 3
+```
+
+Then create or verify the GitHub Release using `docs/releases/2.4.0.md` as the notes source.

--- a/docs/releases/2.4.0_release_prep_report.md
+++ b/docs/releases/2.4.0_release_prep_report.md
@@ -1,0 +1,98 @@
+# RiskBands 2.4.0 Release Prep Report
+
+Status: `V240_PIP_AUDIT_EXCEPTION_READY`
+
+Branch: `release/v2.4.0-prep`
+
+Target version: `2.4.0`
+
+## Summary
+
+Sprint I prepared RiskBands v2.4.0 without publishing, tagging, dispatching a
+publish workflow, or pushing automatically. The version bump, release notes,
+public docs, docs-site build, examples, Spark missing merge validation,
+bundle/audit report validation, package build, twine check, and smoke installs
+are complete.
+
+The standard `python -m pip_audit` gate reports `joblib/PYSEC-2024-277` with no
+fix version. The advisory is described by pip-audit as disputed by the supplier
+and covers the risk of executing arbitrary code when untrusted `joblib`/pickle
+artifacts are loaded.
+
+RiskBands does not load untrusted `joblib`/pickle artifacts as part of the
+public workflow. For v2.4.0 release-prep, maintainers accept a documented,
+single-advisory exception while keeping `pip-audit` active:
+`python -m pip_audit --ignore-vuln PYSEC-2024-277`. The exception is recorded
+in `docs/security/pip_audit_exceptions.md` and must be revisited in a future
+release. The actionable PySpark advisory was fixed by requiring
+`pyspark>=3.5.2,<4` and validating with `pyspark 3.5.8`.
+
+## Release Positioning
+
+RiskBands v2.4.0 - Spark missing merge, sampled-to-pandas fit caveats,
+narrative audit bundle reporting, public docs, examples, and Reveal.js
+documentation gallery.
+
+## Files Prepared
+
+- `pyproject.toml`
+- `README.md`
+- `RELEASE.md`
+- `docs/releases/2.4.0.md`
+- `docs/releases/2.4.0_publication_checklist.md`
+- `docs/releases/2.4.0_release_prep_report.md`
+- `docs/security/pip_audit_exceptions.md`
+- `docs/api_reference.md`
+- `docs/index.md`
+- `docs/audit_bundle_narrative_report.md`
+- `docs/missing_policy_methodological_guide.md`
+- `docs/missing_policy_user_guide.md`
+- `docs/missing_merge_nearest_event_rate_design.md`
+- `docs/missing_merge_nearest_woe_design.md`
+- `docs/pyspark_missing_merge_transform_design.md`
+- `docs/pyspark_missing_merge_sampled_fit_design.md`
+- docs-site pt-BR/en release notes, API, outputs, examples, installation, and missing-policy pages
+
+## Validation Evidence
+
+| Gate | Result |
+| --- | --- |
+| Version import | `2.4.0 True` |
+| Public API tests | `20 passed` |
+| Examples smoke | `9 passed` |
+| Bundle/audit report tests | `39 passed` |
+| Spark targeted G1/G1B/G2/G3 | `61 passed` |
+| Spark full after PySpark fix | `98 passed, 334 deselected` |
+| Full pytest | `432 passed` |
+| Ruff | `All checks passed!` |
+| Bandit | exit code 0 |
+| Docs-site build | `42 page(s) built`, includes `/presentations/riskbands-overview/index.html` |
+| Build | `riskbands-2.4.0.tar.gz`, `riskbands-2.4.0-py3-none-any.whl` |
+| Twine check | both v2.4.0 artifacts passed |
+| Smoke base | version `2.4.0`, no PySpark, `pip check` OK |
+| Smoke spark | version `2.4.0`, `pyspark=3.5.8`, `pip check` OK |
+| Pip-audit exact | known fail: `joblib/PYSEC-2024-277`, no fixed version |
+| Pip-audit with `--ignore-vuln PYSEC-2024-277` | PASS: `No known vulnerabilities found`; `PYSEC-2024-277` ignored by command flag |
+
+## Known Limits Preserved
+
+- `missing_policy="standard"` remains the default.
+- Spark-native full fit is not implemented.
+- Spark `return_woe=True` is not supported.
+- `temporal_stable` and `monotonic_neighbor` are not implemented as merge criteria.
+- No new merge criteria were added.
+- Native PDF export for `audit_report.html` is not part of the public API.
+- The report supports audit/model-risk review but does not replace independent formal validation or provide regulatory certification.
+
+## Security Exception Guardrail
+
+The `PYSEC-2024-277` exception is narrow and auditable. It does not disable
+`pip-audit`, does not ignore any other advisory, and does not remove `joblib`.
+Revisit `docs/security/pip_audit_exceptions.md` during future releases and drop
+the ignore if an actionable fix or corrected advisory metadata is available.
+
+## Manual Publication Plan
+
+After approval, merge to `main`, create annotated tag `v2.4.0`, push the tag,
+run `publish-pypi.yml` manually on `v2.4.0`, run PyPI base and `[spark]` smoke
+installs, and create or verify the GitHub Release from `docs/releases/2.4.0.md`.

--- a/docs/security/pip_audit_exceptions.md
+++ b/docs/security/pip_audit_exceptions.md
@@ -1,0 +1,29 @@
+# pip-audit Exceptions
+
+This file records explicit, reviewable exceptions used by release-prep and CI
+security gates. An exception here is not a blanket waiver: `pip-audit` must keep
+running, and only the listed advisory may be ignored.
+
+## PYSEC-2024-277
+
+- ID: `PYSEC-2024-277`
+- CVE: `CVE-2024-34997`
+- Package: `joblib`
+- Status: disputed/no fixed version available
+- Context: reported by `pip-audit` during RiskBands v2.4.0 release-prep.
+- Risk: `joblib`/pickle deserialization can execute arbitrary code if an
+  application loads untrusted serialized artifacts.
+- RiskBands mitigation: RiskBands does not load untrusted `joblib`/pickle
+  artifacts as part of the public workflow. RiskBands bundles use auditable
+  formats such as JSON, CSV, and HTML where applicable.
+- Decision: explicitly ignore `PYSEC-2024-277` in the `pip-audit` gate until a
+  fixed version is available or the advisory is reclassified.
+- Future review: re-evaluate this exception during each release-prep cycle and
+  remove it as soon as an actionable upstream fix or corrected advisory metadata
+  is available.
+
+Approved command:
+
+```bash
+python -m pip_audit --ignore-vuln PYSEC-2024-277
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "riskbands"
-version = "2.3.0"
+version = "2.4.0"
 description = "Interpretable binning with temporal stability diagnostics for credit risk, PD, and scorecard workflows."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -49,7 +49,7 @@ viz = [
   "plotly>=6.0"
 ]
 spark = [
-  "pyspark>=3.5,<4"
+  "pyspark>=3.5.2,<4"
 ]
 dev = [
   "build>=1.2",


### PR DESCRIPTION
Prepares RiskBands v2.4.0 release metadata, release notes, documentation, Spark missing merge validation/reporting, audit report bundle updates, Reveal.js presentation documentation, packaging checks, and a documented pip-audit exception for PYSEC-2024-277/joblib. This is release preparation only: no tag, no publish, and no PyPI upload.